### PR TITLE
fix: footnotes menu option disappearing after returning from menu

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1417,8 +1417,8 @@ void EpubReaderActivity::render(Activity::RenderLock&& lock) {
     pageLoadFailCount = 0;
     refreshPageCacheWindow(section->currentPage, p);
 
-    // Collect footnotes from the loaded page
-    currentPageFootnotes = std::move(p->footnotes);
+    // Collect footnotes from the loaded page (copy, not move, to preserve cached page data)
+    currentPageFootnotes = p->footnotes;
     const auto start = millis();
     renderContents(*p, orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft,
                    statusBarLayout);


### PR DESCRIPTION
## Summary

- **Fix**: The "Footnotes" button in the inbook menu disappeared after closing and reopening the menu on a page with footnotes.
- **Root cause**: `std::move(p->footnotes)` on line 1421 of `EpubReaderActivity::render()` was draining the footnotes vector from the cached `Page` object. On re-render (triggered by closing the menu), the same cached page was fetched but its footnotes were already empty, so `currentPageFootnotes` became empty and the menu no longer showed the Footnotes button.
- **Fix**: Changed to copy assignment (`currentPageFootnotes = p->footnotes`) so the cached page retains its data across renders. `FootnoteEntry` is 88 bytes with a max of 16 per page, so the copy cost is negligible.

## Test plan

- [ ] Open a book and navigate to a page with footnotes
- [ ] Open the inbook menu — verify "Footnotes" button is present
- [ ] Press back to return to the book
- [ ] Open the inbook menu again — verify "Footnotes" button is still present
- [ ] Repeat several times to confirm it persists
- [ ] Select the Footnotes option, navigate to a footnote, press back, then reopen the menu — verify the button is still present

https://claude.ai/code/session_01NRRoainjwLhdmyXWJWGYTA