### PR TITLE
me put random book toggle in book menu

### DIFF
--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -4,6 +4,7 @@
 #include <HalStorage.h>
 #include <I18n.h>
 
+#include "CrossPointSettings.h"
 #include "CrossPointState.h"
 #include "MappedInputManager.h"
 #include "components/UITheme.h"
@@ -27,7 +28,7 @@ EpubReaderMenuActivity::EpubReaderMenuActivity(GfxRenderer& renderer, MappedInpu
 
 std::vector<EpubReaderMenuActivity::MenuItem> EpubReaderMenuActivity::buildMenuItems(bool hasFootnotes) {
   std::vector<MenuItem> items;
-  items.reserve(14);
+  items.reserve(15);
   items.push_back({MenuAction::SELECT_CHAPTER, StrId::STR_SELECT_CHAPTER});
   if (hasFootnotes) {
     items.push_back({MenuAction::FOOTNOTES, StrId::STR_FOOTNOTES});
@@ -53,6 +54,8 @@ std::vector<EpubReaderMenuActivity::MenuItem> EpubReaderMenuActivity::buildMenuI
     items.push_back({MenuAction::TRIAGE_MOVE_PAUSE, StrId::STR_MOVE_TO_SLEEP_PAUSE});
     items.push_back({MenuAction::TRIAGE_DELETE, StrId::STR_TRIAGE_DELETE});
   }
+
+  items.push_back({MenuAction::TOGGLE_RANDOM_BOOK_ON_BOOT, StrId::STR_RANDOM_BOOK_ON_BOOT});
 
   return items;
 }
@@ -94,6 +97,12 @@ void EpubReaderMenuActivity::loop() {
     if (selectedAction == MenuAction::ROTATE_SCREEN) {
       // Cycle orientation preview locally; actual rotation happens on menu exit.
       pendingOrientation = (pendingOrientation + 1) % orientationLabels.size();
+      requestUpdate();
+      return;
+    }
+    if (selectedAction == MenuAction::TOGGLE_RANDOM_BOOK_ON_BOOT) {
+      SETTINGS.randomBookOnBoot = !SETTINGS.randomBookOnBoot;
+      SETTINGS.saveToFile();
       requestUpdate();
       return;
     }
@@ -180,6 +189,10 @@ void EpubReaderMenuActivity::render(Activity::RenderLock&&) {
     if (item.action == MenuAction::ROTATE_SCREEN) {
       // Render current orientation value on the right edge of the content area.
       const char* value = I18N.get(orientationLabels[pendingOrientation]);
+      const auto width = renderer.getTextWidth(UI_10_FONT_ID, value);
+      renderer.drawText(UI_10_FONT_ID, contentX + contentWidth - 20 - width, displayY, value, !isSelected);
+    } else if (item.action == MenuAction::TOGGLE_RANDOM_BOOK_ON_BOOT) {
+      const char* value = SETTINGS.randomBookOnBoot ? I18N.get(StrId::STR_STATE_ON) : I18N.get(StrId::STR_STATE_OFF);
       const auto width = renderer.getTextWidth(UI_10_FONT_ID, value);
       renderer.drawText(UI_10_FONT_ID, contentX + contentWidth - 20 - width, displayY, value, !isSelected);
     }

--- a/src/activities/reader/EpubReaderMenuActivity.h
+++ b/src/activities/reader/EpubReaderMenuActivity.h
@@ -28,6 +28,7 @@ class EpubReaderMenuActivity final : public ActivityWithSubactivity {
     TRIAGE_PAUSE_ROTATION,
     TRIAGE_MOVE_PAUSE,
     TRIAGE_DELETE,
+    TOGGLE_RANDOM_BOOK_ON_BOOT,
   };
 
   explicit EpubReaderMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const std::string& title,


### PR DESCRIPTION
## what me do

- before, random book on boot toggle only live in settings cave. far away. many button press to get there
- now toggle also live in book menu. right below wallpaper triage. easy find
- me press button, it go ON. me press again, it go OFF. simple. even caveman understand
- it save right away. no need leave menu. no need go home. just toggle and keep read

## how me do it

- me add new action `TOGGLE_RANDOM_BOOK_ON_BOOT` to menu enum. strong name
- me put menu item at bottom of book menu, after wallpaper triage rocks
- me make it show ON or OFF on right side, like orientation thing do
- when press, it flip setting and save to file. no exit menu. stay right there

## me test by

- [ ] open book, open menu, scroll down, see "Random Book on Boot" with ON/OFF
- [ ] press it, watch value flip
- [ ] close book, go to settings, confirm value match what menu say
- [ ] reboot device, check if random book behavior match toggle

https://claude.ai/code/session_01X1B5TgVXGXxqW3zt9PxHrN