### PR TITLE
go home fast. no scan rock twice.

### DIFF
--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -382,15 +382,25 @@ bool SleepActivity::randomizeSleepImagePlaylist() {
   return true;
 }
 
+static size_t s_cachedSleepFavoriteCount = 0;
+
+size_t SleepActivity::cachedSleepFavoriteCount() {
+  return s_cachedSleepFavoriteCount;
+}
+
 void SleepActivity::trimSleepFolderToLimit(GfxRenderer* popupRenderer) {
   const size_t kLimit = CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST;
   const size_t kScanCap = kLimit + 500; // Hard cap on scanning to avoid OOM
 
   // Count .bmp files in /sleep first to avoid allocating the vector if not needed.
+  // Also count favorites so callers can use cachedSleepFavoriteCount() without
+  // a separate directory scan.
   size_t count = 0;
+  size_t scannedFavorites = 0;
   auto dir = Storage.open("/sleep");
   if (!dir || !dir.isDirectory()) {
     if (dir) dir.close();
+    s_cachedSleepFavoriteCount = 0;
     return;
   }
   char name[256]; // Reduced from 500 to save stack
@@ -401,6 +411,9 @@ void SleepActivity::trimSleepFolderToLimit(GfxRenderer* popupRenderer) {
     if (!filename.empty() && filename[0] != '.' &&
         filename.size() >= 4 && filename.substr(filename.size() - 4) == ".bmp") {
       count++;
+      if (FavoriteBmp::isFavoritePath("/sleep/" + filename)) {
+        scannedFavorites++;
+      }
       if (count > kScanCap) break; // Optimization: we already know we're over limit
     }
     file.close();
@@ -408,6 +421,7 @@ void SleepActivity::trimSleepFolderToLimit(GfxRenderer* popupRenderer) {
   dir.rewindDirectory();
 
   if (count <= kLimit) {
+    s_cachedSleepFavoriteCount = scannedFavorites;
     dir.close();
     return; // Under limit — nothing to do.
   }
@@ -447,6 +461,7 @@ void SleepActivity::trimSleepFolderToLimit(GfxRenderer* popupRenderer) {
                     [](const std::string& filename) {
                       return FavoriteBmp::isFavoritePath("/sleep/" + filename);
                     });
+  s_cachedSleepFavoriteCount = favoriteCount;
   if (favoriteCount > kLimit) {
     LOG_ERR("SLP", "Trim: %zu favorites in /sleep exceed limit %zu", favoriteCount, kLimit);
     return;

--- a/src/activities/boot_sleep/SleepActivity.h
+++ b/src/activities/boot_sleep/SleepActivity.h
@@ -20,7 +20,10 @@ class SleepActivity final : public Activity {
   void onEnter() override;
   static bool randomizeSleepImagePlaylist();
   // Called once on boot: moves overflow images beyond the playlist limit to /sleep pause.
+  // Also caches the number of protected sleep favorites for fast access.
   static void trimSleepFolderToLimit(GfxRenderer* renderer = nullptr);
+  // Return the favorite count cached by the last trimSleepFolderToLimit() call.
+  static size_t cachedSleepFavoriteCount();
 
  private:
   void renderDefaultSleepScreen() const;

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -84,7 +84,9 @@ int HomeActivity::getRecentSlotCount() const {
 }
 
 void HomeActivity::refreshSleepFavoriteWarning() {
-  protectedSleepFavoriteCount = FavoriteBmp::countProtectedSleepFavorites();
+  // Use the count cached by trimSleepFolderToLimit() (called in onGoHome)
+  // instead of re-scanning the /sleep directory.
+  protectedSleepFavoriteCount = SleepActivity::cachedSleepFavoriteCount();
   sleepFavoritesFull =
       protectedSleepFavoriteCount >= CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST;
 }
@@ -151,8 +153,8 @@ void HomeActivity::loadRecentBooks(int maxBooks) {
 void HomeActivity::onEnter() {
   Activity::onEnter();
 
-  // Trim sleep folder once we reach home to avoid delays during boot/sleep entry
-  SleepActivity::trimSleepFolderToLimit(&renderer);
+  // Sleep folder trimming is handled by onGoHome() before this activity is
+  // created, so we only need to read the cached favorite count here.
   refreshSleepFavoriteWarning();
 
   // Check if OPDS browser URL is configured

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,6 +233,12 @@ void enterDeepSleep() {
 void onGoHome();
 void onGoToMyLibraryWithPath(const std::string& path);
 void onGoToRecentBooks();
+
+// When true the /sleep folder may have changed since the last trim, so
+// onGoHome() will re-scan.  Set to false after a successful trim and to true
+// before entering activities that can modify /sleep (e.g. file transfer).
+static bool sleepFolderDirty = true;
+
 void onGoToReader(const std::string& initialEpubPath) {
   const std::string bookPath = initialEpubPath;  // Copy before exitActivity() invalidates the reference
   TransitionFeedback::show(renderer, "Opening book...");
@@ -279,11 +285,6 @@ void onGoToBrowser() {
   exitActivity();
   enterNewActivity(new OpdsBookBrowserActivity(renderer, mappedInputManager, onGoHome));
 }
-
-// When true the /sleep folder may have changed since the last trim, so
-// onGoHome() will re-scan.  Set to false after a successful trim and to true
-// before entering activities that can modify /sleep (e.g. file transfer).
-static bool sleepFolderDirty = true;
 
 void onGoHome() {
   TransitionFeedback::show(renderer, "Loading home...");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -242,6 +242,7 @@ void onGoToReader(const std::string& initialEpubPath) {
 
 void onGoToFileTransfer() {
   TransitionFeedback::show(renderer, "Starting server...");
+  sleepFolderDirty = true;  // Files may be uploaded to /sleep during transfer
   exitActivity();
   enterNewActivity(new CrossPointWebServerActivity(renderer, mappedInputManager, onGoHome));
 }
@@ -279,19 +280,17 @@ void onGoToBrowser() {
   enterNewActivity(new OpdsBookBrowserActivity(renderer, mappedInputManager, onGoHome));
 }
 
-// Track whether home-screen data was loaded (deferred when booting to a book)
-static bool homeDataLoaded = false;
-
-void ensureHomeDataLoaded() {
-  if (!homeDataLoaded) {
-    SleepActivity::trimSleepFolderToLimit();
-    homeDataLoaded = true;
-  }
-}
+// When true the /sleep folder may have changed since the last trim, so
+// onGoHome() will re-scan.  Set to false after a successful trim and to true
+// before entering activities that can modify /sleep (e.g. file transfer).
+static bool sleepFolderDirty = true;
 
 void onGoHome() {
   TransitionFeedback::show(renderer, "Loading home...");
-  ensureHomeDataLoaded();
+  if (sleepFolderDirty) {
+    SleepActivity::trimSleepFolderToLimit();
+    sleepFolderDirty = false;
+  }
   persistAppState("go home");
   exitActivity();
   enterNewActivity(new HomeActivity(renderer, mappedInputManager, onGoToReader, onGoToMyLibrary, onGoToRecentBooks,
@@ -502,7 +501,7 @@ void setup() {
   if (goHome) {
     bootActivity->setProgress(60, "Refreshing sleep cache");
     SleepActivity::trimSleepFolderToLimit();
-    homeDataLoaded = true;
+    sleepFolderDirty = false;
   }
   bootActivity->setProgress(80, goHome ? "Preparing home" : "Resuming book");
 


### PR DESCRIPTION
## ugg smash slow home button

before: e-reader go home. scan /sleep cave 3 time. why scan 3 time? one time enough. SD card slow like mammoth in tar pit.

## what ugg do

- **stop scan same cave twice.** trimSleepFolderToLimit already look at all rock in /sleep. HomeActivity::onEnter look at same rock AGAIN. ugg remove second look. one look enough.
- **remember how many favorite rock.** old code count favorite wallpaper by scanning whole /sleep cave THIRD time. now ugg count favorite while already looking at rock first time. put number in brain (cache). no need look again.
- **only scan when cave change.** ugg add dirty flag. if no one put new rock in cave (file transfer), why look? skip scan entirely. go home FAST.

## before and after

| where ugg come from | before (scan) | after (scan) |
|---|---|---|
| reader → home (normal day) | 2 | **0** 🦴 |
| reader → home (first time) | 3 | **1** |
| file transfer → home | 2 | **1** |
| boot → home | 3 | **1** |

## file ugg touch with club

- `SleepActivity.cpp/h` — count favorite during trim, add `cachedSleepFavoriteCount()`
- `main.cpp` — replace `ensureHomeDataLoaded()` with `sleepFolderDirty` flag
- `HomeActivity.cpp` — remove duplicate trim, use cached count

## test plan

- [ ] boot to home. no crash. good.
- [ ] open book. press home. screen appear fast. no extra "Loading home..." wait.
- [ ] go file transfer. upload wallpaper to /sleep. go home. new wallpaper counted.
- [ ] move file to /sleep from library. go home. warning show if favorite full.
- [ ] have many wallpaper (>200). trim still move overflow to /sleep pause.

https://claude.ai/code/session_017EtpApUPrmKkKbv8KY3VYx