### PR TITLE
style(reader): thin, dashed quote highlight underline

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1962,7 +1962,7 @@ void EpubReaderActivity::renderHighlights(const Page& page, const int fontId, co
 
   const int wordCount = static_cast<int>(wordList.size());
   const int textHeight = renderer.getTextHeight(fontId);
-  constexpr int thickness = 6;
+  constexpr int thickness = 2;
 
   // Clamp cursor indices to current word list size (guards against stale index after rebuild)
   if (highlightCursorIndex >= wordCount) {
@@ -1983,7 +1983,7 @@ void EpubReaderActivity::renderHighlights(const Page& page, const int fontId, co
     }
     // Draw thick underline beneath the word
     const int underY = cw.y + textHeight + 1;
-    renderer.fillRect(cw.x, underY, cw.width, thickness, true);
+    drawDashedHLine(renderer, cw.x, underY, cw.width, thickness);
   };
 
   if (highlightState == HighlightState::SELECT_START) {
@@ -2024,7 +2024,7 @@ void EpubReaderActivity::renderHighlights(const Page& page, const int fontId, co
         const auto& w = wordList[i];
         if (w.y != lineY) {
           // Flush previous line
-          renderer.fillRect(lineMinX, lineY + textHeight + 1, lineMaxX - lineMinX, thickness, true);
+          drawDashedHLine(renderer, lineMinX, lineY + textHeight + 1, lineMaxX - lineMinX, thickness);
           lineY = w.y;
           lineMinX = w.x;
           lineMaxX = w.x + w.width;
@@ -2033,7 +2033,7 @@ void EpubReaderActivity::renderHighlights(const Page& page, const int fontId, co
         }
       }
       // Flush last line
-      renderer.fillRect(lineMinX, lineY + textHeight + 1, lineMaxX - lineMinX, thickness, true);
+      drawDashedHLine(renderer, lineMinX, lineY + textHeight + 1, lineMaxX - lineMinX, thickness);
     }
   }
 }

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -161,6 +161,17 @@ uint32_t countBmpsInDir(const char* path) {
   return count;
 }
 
+void drawDashedHLine(const GfxRenderer& renderer, int x, int y, int w, int thickness) {
+  constexpr int dash = 8;
+  constexpr int gap = 4;
+  constexpr int step = dash + gap;
+  const int x2 = x + w - 1;
+  for (int px = x; px <= x2; px += step) {
+    const int segW = std::min(dash, x2 - px + 1);
+    renderer.fillRect(px, y, segW, thickness, true);
+  }
+}
+
 void drawDashedRect(const GfxRenderer& renderer, int x, int y, int w, int h) {
   constexpr int dash = 5;
   constexpr int gap = 3;

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -141,6 +141,8 @@ class BaseTheme {
   void drawReadingProgressBar(const GfxRenderer& renderer, const size_t bookProgress) const;
 };
 
+void drawDashedHLine(const GfxRenderer& renderer, int x, int y, int w, int thickness);
+
 // Global theme instance — used by all UI drawing code via the GUI macro.
 extern BaseTheme baseTheme;
 #define GUI baseTheme


### PR DESCRIPTION
Make the 3-second quote highlight underline (and the cursor underline it
shares thickness with) 2px tall and dashed (8px dash / 4px gap) so it
reads as a selection marker rather than a heavy block.