### PR TITLE
test(lifecycle): host-side tests for ActivityRouter (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,28 @@ macOS example:
 python3 scripts/debugging_monitor.py /dev/cu.usbmodem101
 ```
 
+### Host-side tests
+
+Pure-logic tests that run on your laptop (no ESP32 hardware needed) live
+under `test/test_*/` and use PlatformIO's Unity framework.
+
+```sh
+pio test -e test_host
+```
+
+The `test_host` environment uses `platform = native`. Currently covered:
+
+- `test/test_activity_router/` — `lifecycle::ActivityRouter` policy, pending
+  coalesce, deep-sleep sequencing, and make* synthesizers
+
+Sources compiled into this env are explicitly whitelisted in
+`platformio.ini` via `build_src_filter` — Arduino/FreeRTOS-dependent code
+is excluded. When adding a new module that needs host tests, either keep
+it free of Arduino includes or provide a `#ifdef UNIT_TEST_HOST` stub
+header (see `src/lifecycle/ActivityStubForHostTest.h`).
+
+CI integration (GitHub Actions) is not yet wired up — tracked as follow-up.
+
 ---
 
 ## Limitations and Scope Notes

--- a/platformio.ini
+++ b/platformio.ini
@@ -118,4 +118,39 @@ build_flags =
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-slim\"
   ; serial output is disabled in slim builds to save space
   -UENABLE_SERIAL_LOG
-  
+
+; Host-only test environment — runs on developer machine, no ESP32 toolchain.
+; Compiles a narrow slice of src/ (lifecycle/) plus stubs for activities.
+; Invoke:  pio test -e test_host
+[env:test_host]
+platform = native
+test_framework = unity
+test_build_src = true
+lib_compat_mode = strict
+lib_ignore =
+  BatteryMonitor
+  InputManager
+  EInkDisplay
+  SDCardManager
+  ArduinoJson
+  QRCode
+  PNGdec
+  WebSockets
+  JPEGDEC
+  NimBLE-Arduino
+  BookFingerprint
+  EpdFont
+  GfxRenderer
+  Logging
+  MappedInputManager
+  hal
+build_src_filter =
+  -<*>
+  +<lifecycle/ActivityRouter.cpp>
+build_flags =
+  -std=gnu++2a
+  -DUNIT_TEST_HOST=1
+  -Isrc
+build_unflags =
+  -std=gnu++11
+

--- a/src/lifecycle/ActivityRouter.cpp
+++ b/src/lifecycle/ActivityRouter.cpp
@@ -1,6 +1,10 @@
 #include "ActivityRouter.h"
 
+#ifdef UNIT_TEST_HOST
+#include "ActivityStubForHostTest.h"
+#else
 #include "../activities/Activity.h"
+#endif
 
 namespace lifecycle {
 
@@ -101,5 +105,15 @@ std::function<void()> ActivityRouter::makeGoToBrowser() const {
 void ActivityRouter::setDeps(Deps deps) { deps_ = std::move(deps); }
 
 void ActivityRouter::setDepsForTest(Deps deps) { instance().deps_ = std::move(deps); }
+
+#ifdef UNIT_TEST_HOST
+void ActivityRouter::resetForTest() {
+  auto& r = instance();
+  r.deps_ = Deps{};
+  for (size_t i = 0; i < kRouteCount; ++i) r.factories_[i] = Factory{};
+  r.pending_.reset();
+  r.busy_ = false;
+}
+#endif
 
 }  // namespace lifecycle

--- a/src/lifecycle/ActivityRouter.h
+++ b/src/lifecycle/ActivityRouter.h
@@ -63,6 +63,11 @@ class ActivityRouter {
   void setDeps(Deps deps);
   static void setDepsForTest(Deps deps);
 
+#ifdef UNIT_TEST_HOST
+  // Clears deps, factories, and pending nav on the singleton. Host tests only.
+  static void resetForTest();
+#endif
+
  private:
   ActivityRouter() = default;
   void dispatch(const Nav& nav);

--- a/src/lifecycle/ActivityStubForHostTest.h
+++ b/src/lifecycle/ActivityStubForHostTest.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// Minimal host-test stub for Activity. Only defines the surface the
+// lifecycle::ActivityRouter uses: virtual onExit() and a virtual destructor
+// (so `delete slot;` on an Activity* pointer calls the subclass destructor).
+//
+// Do NOT include this in any device-target translation unit. It is only
+// picked up when ActivityRouter.cpp is compiled with -DUNIT_TEST_HOST=1
+// under the [env:test_host] PlatformIO environment.
+
+class Activity {
+ public:
+  virtual ~Activity() = default;
+  virtual void onExit() {}
+};

--- a/test/test_activity_router/test_main.cpp
+++ b/test/test_activity_router/test_main.cpp
@@ -1,0 +1,315 @@
+// Host-side tests for lifecycle::ActivityRouter (issue #25).
+//
+// Runs under PlatformIO [env:test_host] — pure std::, no Arduino/ESP32.
+// Activity is stubbed via ActivityStubForHostTest.h (pulled in by
+// ActivityRouter.cpp when -DUNIT_TEST_HOST=1).
+//
+// Invoke:  pio test -e test_host
+
+#include <unity.h>
+
+#include <string>
+#include <vector>
+
+#include "lifecycle/ActivityRouter.h"
+#include "lifecycle/ActivityStubForHostTest.h"
+#include "lifecycle/Nav.h"
+
+using lifecycle::ActivityRouter;
+using lifecycle::Nav;
+using lifecycle::RouteId;
+using lifecycle::policyFor;
+
+namespace {
+
+// --- Recording globals. Router Deps take function pointers, so recorders must
+// be statics with free-function thunks. Cleared in setUp().
+std::vector<std::string> g_persistCalls;
+int g_trimCalls = 0;
+std::vector<bool> g_beforeSleep;
+int g_afterSleep = 0;
+int g_enterSleep = 0;
+std::vector<std::string> g_factoryCalls;  // "Route:payload"
+
+bool thunkPersist(const char* ctx) {
+  g_persistCalls.emplace_back(ctx ? ctx : "");
+  return true;
+}
+void thunkTrim() { g_trimCalls++; }
+void thunkBefore(bool fromReader) { g_beforeSleep.push_back(fromReader); }
+void thunkAfter() { g_afterSleep++; }
+
+const char* routeName(RouteId r) {
+  switch (r) {
+    case RouteId::Home: return "Home";
+    case RouteId::Reader: return "Reader";
+    case RouteId::MyLibrary: return "MyLibrary";
+    case RouteId::MyLibraryAt: return "MyLibraryAt";
+    case RouteId::RecentBooks: return "RecentBooks";
+    case RouteId::Settings: return "Settings";
+    case RouteId::FileTransfer: return "FileTransfer";
+    case RouteId::Browser: return "Browser";
+  }
+  return "?";
+}
+
+void registerRecordingFactories() {
+  auto& r = ActivityRouter::instance();
+  const RouteId all[] = {RouteId::Home, RouteId::Reader, RouteId::MyLibrary,
+                         RouteId::MyLibraryAt, RouteId::RecentBooks,
+                         RouteId::Settings, RouteId::FileTransfer,
+                         RouteId::Browser};
+  for (RouteId id : all) {
+    const char* name = routeName(id);
+    r.setRouteFactory(id, [name](const std::string& p) {
+      g_factoryCalls.push_back(std::string(name) + ":" + p);
+    });
+  }
+}
+
+}  // namespace
+
+void setUp() {
+  ActivityRouter::resetForTest();
+  g_persistCalls.clear();
+  g_trimCalls = 0;
+  g_beforeSleep.clear();
+  g_afterSleep = 0;
+  g_enterSleep = 0;
+  g_factoryCalls.clear();
+}
+
+void tearDown() {}
+
+// ---- Policy tests ----
+
+void test_policy_exhaustive_for_all_routes() {
+  // Exercises the switch in policyFor for every RouteId. If a new enum value
+  // is added without updating the switch, the compile warning + unreachable
+  // sentinel would be exposed here. Runtime check also confirms expected rows.
+  TEST_ASSERT_TRUE(policyFor(RouteId::Home).persistBefore);
+  TEST_ASSERT_TRUE(policyFor(RouteId::Home).trimSleepFolder);
+  TEST_ASSERT_EQUAL_STRING("go home", policyFor(RouteId::Home).persistCtx);
+
+  TEST_ASSERT_TRUE(policyFor(RouteId::MyLibrary).persistBefore);
+  TEST_ASSERT_TRUE(policyFor(RouteId::MyLibraryAt).persistBefore);
+  TEST_ASSERT_TRUE(policyFor(RouteId::RecentBooks).persistBefore);
+
+  TEST_ASSERT_FALSE(policyFor(RouteId::Reader).persistBefore);
+  TEST_ASSERT_FALSE(policyFor(RouteId::Settings).persistBefore);
+  TEST_ASSERT_FALSE(policyFor(RouteId::FileTransfer).persistBefore);
+  TEST_ASSERT_FALSE(policyFor(RouteId::Browser).persistBefore);
+}
+
+// ---- Router dispatch tests ----
+
+void test_request_home_persists_before_factory_runs() {
+  registerRecordingFactories();
+  ActivityRouter::Deps d{};
+  d.persistAppState = &thunkPersist;
+  d.trimSleepFolderIfDirty = &thunkTrim;
+  ActivityRouter::setDepsForTest(d);
+
+  ActivityRouter::instance().request({RouteId::Home, ""});
+  ActivityRouter::instance().applyIfPending();
+
+  TEST_ASSERT_EQUAL(1, g_trimCalls);
+  TEST_ASSERT_EQUAL_size_t(1, g_persistCalls.size());
+  TEST_ASSERT_EQUAL_STRING("go home", g_persistCalls[0].c_str());
+  TEST_ASSERT_EQUAL_size_t(1, g_factoryCalls.size());
+  TEST_ASSERT_EQUAL_STRING("Home:", g_factoryCalls[0].c_str());
+}
+
+void test_no_persist_routes_skip_persist() {
+  registerRecordingFactories();
+  ActivityRouter::Deps d{};
+  d.persistAppState = &thunkPersist;
+  d.trimSleepFolderIfDirty = &thunkTrim;
+  ActivityRouter::setDepsForTest(d);
+
+  const RouteId skipRoutes[] = {RouteId::Reader, RouteId::Settings,
+                                RouteId::FileTransfer, RouteId::Browser};
+  for (RouteId r : skipRoutes) {
+    ActivityRouter::instance().request({r, "x"});
+    ActivityRouter::instance().applyIfPending();
+  }
+
+  TEST_ASSERT_EQUAL_size_t(0, g_persistCalls.size());
+  TEST_ASSERT_EQUAL(0, g_trimCalls);
+  TEST_ASSERT_EQUAL_size_t(4, g_factoryCalls.size());
+}
+
+void test_pending_coalesce_keeps_last_request() {
+  registerRecordingFactories();
+  ActivityRouter::setDepsForTest(ActivityRouter::Deps{});
+
+  ActivityRouter::instance().request({RouteId::Settings, "first"});
+  ActivityRouter::instance().request({RouteId::Browser, "second"});
+  ActivityRouter::instance().applyIfPending();
+
+  TEST_ASSERT_EQUAL_size_t(1, g_factoryCalls.size());
+  TEST_ASSERT_EQUAL_STRING("Browser:second", g_factoryCalls[0].c_str());
+}
+
+void test_apply_if_pending_noop_without_pending() {
+  registerRecordingFactories();
+  ActivityRouter::setDepsForTest(ActivityRouter::Deps{});
+
+  ActivityRouter::instance().applyIfPending();
+  ActivityRouter::instance().applyIfPending();
+
+  TEST_ASSERT_EQUAL_size_t(0, g_factoryCalls.size());
+}
+
+void test_begin_dispatches_synchronously_with_payload() {
+  registerRecordingFactories();
+  ActivityRouter::Deps d{};
+  d.persistAppState = &thunkPersist;
+  ActivityRouter::setDepsForTest(d);
+
+  ActivityRouter::instance().begin({RouteId::Reader, "/books/foo.epub"});
+
+  // No persist for Reader.
+  TEST_ASSERT_EQUAL_size_t(0, g_persistCalls.size());
+  TEST_ASSERT_EQUAL_size_t(1, g_factoryCalls.size());
+  TEST_ASSERT_EQUAL_STRING("Reader:/books/foo.epub", g_factoryCalls[0].c_str());
+}
+
+void test_begin_home_applies_policy_before_factory() {
+  registerRecordingFactories();
+  ActivityRouter::Deps d{};
+  d.persistAppState = &thunkPersist;
+  d.trimSleepFolderIfDirty = &thunkTrim;
+  ActivityRouter::setDepsForTest(d);
+
+  ActivityRouter::instance().begin({RouteId::Home, ""});
+
+  TEST_ASSERT_EQUAL(1, g_trimCalls);
+  TEST_ASSERT_EQUAL_size_t(1, g_persistCalls.size());
+  TEST_ASSERT_EQUAL_STRING("go home", g_persistCalls[0].c_str());
+  TEST_ASSERT_EQUAL_size_t(1, g_factoryCalls.size());
+  TEST_ASSERT_EQUAL_STRING("Home:", g_factoryCalls[0].c_str());
+}
+
+void test_unmigrated_route_is_noop() {
+  // No factory registered → router silently does nothing (legacy caller path).
+  ActivityRouter::setDepsForTest(ActivityRouter::Deps{});
+  ActivityRouter::instance().request({RouteId::Home, ""});
+  ActivityRouter::instance().applyIfPending();
+  TEST_ASSERT_EQUAL_size_t(0, g_factoryCalls.size());
+}
+
+// ---- Deep-sleep sequencing ----
+
+// Ordering is captured by recording every hook into a single vector of tags.
+std::vector<std::string> g_sleepOrder;
+
+void orderBefore(bool fromReader) {
+  g_sleepOrder.push_back(fromReader ? "before:true" : "before:false");
+}
+bool orderPersist(const char* ctx) {
+  g_sleepOrder.push_back(std::string("persist:") + (ctx ? ctx : ""));
+  return true;
+}
+void orderAfter() { g_sleepOrder.push_back("after"); }
+
+class OrderExitActivity : public Activity {
+ public:
+  void onExit() override { g_sleepOrder.push_back("exit"); }
+};
+
+void setUpSleep() {
+  setUp();
+  g_sleepOrder.clear();
+}
+
+void test_enter_deep_sleep_sequence_from_reader() {
+  setUpSleep();
+  Activity* slot = new OrderExitActivity();
+
+  ActivityRouter::Deps d{};
+  d.currentActivitySlot = &slot;
+  d.persistAppState = &orderPersist;
+  d.onBeforeDeepSleep = &orderBefore;
+  d.onAfterDeepSleep = &orderAfter;
+  d.enterSleepActivity = [] { g_sleepOrder.push_back("sleepActivity"); };
+  ActivityRouter::setDepsForTest(d);
+
+  ActivityRouter::instance().enterDeepSleep(true);
+
+  TEST_ASSERT_NULL(slot);
+  TEST_ASSERT_EQUAL_size_t(5, g_sleepOrder.size());
+  TEST_ASSERT_EQUAL_STRING("before:true", g_sleepOrder[0].c_str());
+  TEST_ASSERT_EQUAL_STRING("persist:enter deep sleep", g_sleepOrder[1].c_str());
+  TEST_ASSERT_EQUAL_STRING("exit", g_sleepOrder[2].c_str());
+  TEST_ASSERT_EQUAL_STRING("sleepActivity", g_sleepOrder[3].c_str());
+  TEST_ASSERT_EQUAL_STRING("after", g_sleepOrder[4].c_str());
+}
+
+void test_enter_deep_sleep_sequence_not_from_reader() {
+  setUpSleep();
+  Activity* slot = nullptr;  // no active slot — exit hook must be skipped.
+
+  ActivityRouter::Deps d{};
+  d.currentActivitySlot = &slot;
+  d.persistAppState = &orderPersist;
+  d.onBeforeDeepSleep = &orderBefore;
+  d.onAfterDeepSleep = &orderAfter;
+  d.enterSleepActivity = [] { g_sleepOrder.push_back("sleepActivity"); };
+  ActivityRouter::setDepsForTest(d);
+
+  ActivityRouter::instance().enterDeepSleep(false);
+
+  // Exit tag absent because slot was null.
+  TEST_ASSERT_EQUAL_size_t(4, g_sleepOrder.size());
+  TEST_ASSERT_EQUAL_STRING("before:false", g_sleepOrder[0].c_str());
+  TEST_ASSERT_EQUAL_STRING("persist:enter deep sleep", g_sleepOrder[1].c_str());
+  TEST_ASSERT_EQUAL_STRING("sleepActivity", g_sleepOrder[2].c_str());
+  TEST_ASSERT_EQUAL_STRING("after", g_sleepOrder[3].c_str());
+}
+
+// ---- Make* synthesizer tests ----
+
+void test_make_go_to_reader_binds_payload() {
+  registerRecordingFactories();
+  ActivityRouter::setDepsForTest(ActivityRouter::Deps{});
+
+  auto go = ActivityRouter::instance().makeGoToReader();
+  go("/books/bar.epub");
+  ActivityRouter::instance().applyIfPending();
+
+  TEST_ASSERT_EQUAL_size_t(1, g_factoryCalls.size());
+  TEST_ASSERT_EQUAL_STRING("Reader:/books/bar.epub", g_factoryCalls[0].c_str());
+}
+
+void test_make_go_home_has_no_payload() {
+  registerRecordingFactories();
+  ActivityRouter::Deps d{};
+  d.persistAppState = &thunkPersist;
+  d.trimSleepFolderIfDirty = &thunkTrim;
+  ActivityRouter::setDepsForTest(d);
+
+  auto go = ActivityRouter::instance().makeGoHome();
+  go();
+  ActivityRouter::instance().applyIfPending();
+
+  TEST_ASSERT_EQUAL_size_t(1, g_factoryCalls.size());
+  TEST_ASSERT_EQUAL_STRING("Home:", g_factoryCalls[0].c_str());
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_policy_exhaustive_for_all_routes);
+  RUN_TEST(test_request_home_persists_before_factory_runs);
+  RUN_TEST(test_no_persist_routes_skip_persist);
+  RUN_TEST(test_pending_coalesce_keeps_last_request);
+  RUN_TEST(test_apply_if_pending_noop_without_pending);
+  RUN_TEST(test_begin_dispatches_synchronously_with_payload);
+  RUN_TEST(test_begin_home_applies_policy_before_factory);
+  RUN_TEST(test_unmigrated_route_is_noop);
+  RUN_TEST(test_enter_deep_sleep_sequence_from_reader);
+  RUN_TEST(test_enter_deep_sleep_sequence_not_from_reader);
+  RUN_TEST(test_make_go_to_reader_binds_payload);
+  RUN_TEST(test_make_go_home_has_no_payload);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary

- Bootstraps the first host-side test environment in the repo: `[env:test_host]` (PlatformIO native + Unity).
- Adds 12 pure-logic tests for `lifecycle::ActivityRouter`: policy rows, request/apply ordering, pending coalesce, begin() dispatch, deep-sleep sequencing, makeGoTo* synthesizers.
- Activity shim (`src/lifecycle/ActivityStubForHostTest.h`) is the only device-side touch — only active under `-DUNIT_TEST_HOST=1`.

Closes #25.

## Why now

RFCs #20, #22, #24 all specify host tests but assumed the harness already existed. #23 landed without its tests. Landing the harness against the simplest module (router is pure logic once deps are stubbed) unblocks the remaining RFCs.

## Test plan

- [x] `pio test -e test_host` — 12/12 PASSED
- [x] `pio run -e default` — SUCCESS (no change to firmware binary layout)
- [x] `pio run -e debug` — SUCCESS

## Out of scope / follow-ups

- CI hook (GitHub Actions) — deferred, documented in README
- Host tests for #20 / #22 / #24 — filed as sub-issues once each RFC lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)