### PR TITLE
refactor(webserver): WsUploadSession + SettingsGateway (#24)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -93,6 +93,10 @@ build_flags =
   ; LIFECYCLE_V2 routes Home → Settings through lifecycle::ActivityRouter (#23).
   ; debug env only; default/release keep the legacy path until fully migrated.
   -DLIFECYCLE_V2=1
+  ; WEBSERVER_V2 routes WS upload + settings POST through the new modules
+  ; (WsUploadSession + SettingsGateway). See RFC #24.
+  ; Debug env only until soak-tested, then promote to default in a follow-up.
+  -DWEBSERVER_V2=1
 
 
 [env:gh_release]
@@ -127,12 +131,13 @@ platform = native
 test_framework = unity
 test_build_src = true
 lib_compat_mode = strict
+lib_deps =
+  bblanchon/ArduinoJson @ 7.4.2
 lib_ignore =
   BatteryMonitor
   InputManager
   EInkDisplay
   SDCardManager
-  ArduinoJson
   QRCode
   PNGdec
   WebSockets
@@ -147,6 +152,8 @@ lib_ignore =
 build_src_filter =
   -<*>
   +<lifecycle/ActivityRouter.cpp>
+  +<network/ws/WsUploadSession.cpp>
+  +<network/SettingsGateway.cpp>
 build_flags =
   -std=gnu++2a
   -DUNIT_TEST_HOST=1

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -30,6 +30,11 @@
 #include "html/js/jszip_minJs.generated.h"
 #include "util/StringUtils.h"
 
+#if WEBSERVER_V2
+#include "network/SettingsGateway.h"
+#include "network/ws/WsUploadSession.h"
+#endif
+
 namespace {
 // Folders/files to hide from the web interface file browser
 // Note: Items starting with "." are automatically hidden
@@ -61,6 +66,15 @@ uint8_t wsDownloadClientNum = 0;
 String wsLastCompleteName;
 size_t wsLastCompleteSize = 0;
 unsigned long wsLastCompleteAt = 0;
+
+#if WEBSERVER_V2
+// V2 globals (RFC #24). Session owns the WS upload state machine; gateway
+// owns the settings POST orchestration. Both created in begin(), destroyed
+// in stop(). Kept at file scope rather than class members so the V1 path
+// stays byte-identical when WEBSERVER_V2 is off.
+std::unique_ptr<crosspoint::ws::WsUploadSession> g_wsUploadSession;
+std::unique_ptr<crosspoint::network::SettingsGateway> g_settingsGateway;
+#endif
 
 // Compute the cache directory path for a book file (returns empty if not a book).
 // Uses content-based fingerprint so the path is stable across file moves.
@@ -267,6 +281,136 @@ void CrossPointWebServer::begin() {
   udpActive = udp.begin(LOCAL_UDP_PORT);
   LOG_DBG("WEB", "Discovery UDP %s on port %d", udpActive ? "enabled" : "failed", LOCAL_UDP_PORT);
 
+#if WEBSERVER_V2
+  // WsUploadSession deps bind the existing file-scope upload state so the V1
+  // ownership semantics (wsUploadFile, wsUploadFileName, wsUploadPath,
+  // wsUploadSize, wsLastCompleteName/Size/At) are preserved exactly. V1 code
+  // paths continue to read these for status endpoints.
+  crosspoint::ws::WsUploadDeps wsDeps;
+  wsDeps.beginWrite = [](const std::string& path, const std::string& name) {
+    wsUploadPath = path.c_str();
+    wsUploadFileName = name.c_str();
+    String filePath = wsUploadPath;
+    if (!filePath.endsWith("/")) filePath += "/";
+    filePath += wsUploadFileName;
+    esp_task_wdt_reset();
+    if (Storage.exists(filePath.c_str())) Storage.remove(filePath.c_str());
+    esp_task_wdt_reset();
+    if (!Storage.openFileForWrite("WS", filePath, wsUploadFile)) return false;
+    esp_task_wdt_reset();
+    wsUploadSize = 0;
+    wsUploadReceived = 0;
+    wsUploadLastProgressSent = 0;
+    wsUploadStartTime = millis();
+    wsUploadInProgress = true;
+    return true;
+  };
+  wsDeps.writeBytes = [](const uint8_t* data, size_t len) {
+    esp_task_wdt_reset();
+    const size_t written = wsUploadFile.write(data, len);
+    esp_task_wdt_reset();
+    return written == len;
+  };
+  wsDeps.closeAndDelete = [] {
+    wsUploadFile.close();
+    String filePath = wsUploadPath;
+    if (!filePath.endsWith("/")) filePath += "/";
+    filePath += wsUploadFileName;
+    Storage.remove(filePath.c_str());
+    wsUploadInProgress = false;
+    wsUploadClientNum = 255;
+    wsUploadLastProgressSent = 0;
+  };
+  wsDeps.closeFinalize = [] {
+    wsUploadFile.close();
+    wsLastCompleteName = wsUploadFileName;
+    wsLastCompleteSize = wsUploadReceived;
+    wsLastCompleteAt = millis();
+    wsUploadInProgress = false;
+    wsUploadClientNum = 255;
+    wsUploadLastProgressSent = 0;
+  };
+  wsDeps.sendText = [this](uint8_t client, const std::string& text) {
+    if (wsServer) wsServer->sendTXT(client, text.c_str());
+  };
+  wsDeps.nowMs = [] { return static_cast<uint32_t>(millis()); };
+  wsDeps.clearBookCache = [](const std::string& path, const std::string& name) {
+    String full = path.c_str();
+    if (!full.endsWith("/")) full += "/";
+    full += name.c_str();
+    clearBookCacheIfNeeded(full);
+  };
+  g_wsUploadSession.reset(new crosspoint::ws::WsUploadSession(std::move(wsDeps)));
+
+  g_settingsGateway.reset(new crosspoint::network::SettingsGateway(
+      [](const JsonDocument& doc) {
+        auto settings = getSettingsList();
+        int applied = 0;
+        for (auto& s : settings) {
+          if (!s.key) continue;
+          if (!doc[s.key].is<JsonVariant>()) continue;
+          switch (s.type) {
+            case SettingType::TOGGLE: {
+              const int val = doc[s.key].as<int>() ? 1 : 0;
+              if (s.valuePtr) SETTINGS.*(s.valuePtr) = val;
+              applied++;
+              break;
+            }
+            case SettingType::ENUM: {
+              const int val = doc[s.key].as<int>();
+              const int maxEnumValue =
+                  (s.valuePtr == &CrossPointSettings::fontSize)
+                      ? static_cast<int>(CrossPointSettings::fontSizeOptionCount(SETTINGS.fontFamily))
+                      : static_cast<int>(s.enumValues.size());
+              if (val >= 0 && val < maxEnumValue) {
+                if (s.valuePtr) {
+                  if (s.valuePtr == &CrossPointSettings::fontSize) {
+                    SETTINGS.fontSize = CrossPointSettings::displayIndexToFontSize(
+                        SETTINGS.fontFamily, static_cast<uint8_t>(val));
+                  } else if (s.valuePtr == &CrossPointSettings::fontFamily) {
+                    SETTINGS.fontFamily =
+                        CrossPointSettings::displayIndexToFontFamily(static_cast<uint8_t>(val));
+                    SETTINGS.fontSize = CrossPointSettings::normalizeFontSizeForFamily(
+                        SETTINGS.fontFamily, SETTINGS.fontSize);
+                    SETTINGS.lineSpacingPercent = 90;
+                  } else {
+                    SETTINGS.*(s.valuePtr) = static_cast<uint8_t>(val);
+                  }
+                } else if (s.valueSetter) {
+                  s.valueSetter(static_cast<uint8_t>(val));
+                }
+                applied++;
+              }
+              break;
+            }
+            case SettingType::VALUE: {
+              const int val = doc[s.key].as<int>();
+              if (val >= s.valueRange.min && val <= s.valueRange.max) {
+                if (s.valuePtr) SETTINGS.*(s.valuePtr) = static_cast<uint8_t>(val);
+                applied++;
+              }
+              break;
+            }
+            case SettingType::STRING: {
+              const std::string val = doc[s.key].as<std::string>();
+              if (s.stringSetter) {
+                s.stringSetter(val);
+              } else if (s.stringPtr && s.stringMaxLen > 0) {
+                strncpy(s.stringPtr, val.c_str(), s.stringMaxLen - 1);
+                s.stringPtr[s.stringMaxLen - 1] = '\0';
+              }
+              applied++;
+              break;
+            }
+            default:
+              break;
+          }
+        }
+        return applied;
+      },
+      [] { return SETTINGS.saveToFile(); }));
+#endif
+
   running = true;
 
   LOG_DBG("WEB", "Web server started on port %d", port);
@@ -354,13 +498,24 @@ void CrossPointWebServer::stop() {
   LOG_DBG("WEB", "[MEM] Free heap before stop: %d bytes", ESP.getFreeHeap());
 
   // Close any in-progress WebSocket upload and remove partial file
+#if WEBSERVER_V2
+  if (g_wsUploadSession) g_wsUploadSession->abort("server stopping");
+#else
   if (wsUploadInProgress && wsUploadFile) {
     abortWsUpload("WEB");
   }
+#endif
   if (wsDownloadInProgress && wsDownloadFile) {
     wsDownloadFile.close();
     wsDownloadInProgress = false;
   }
+
+#if WEBSERVER_V2
+  // Release V2 state before the WS server goes away, so any pending callbacks
+  // have no session to delegate to (checked at dispatch).
+  g_wsUploadSession.reset();
+  g_settingsGateway.reset();
+#endif
 
   // Stop WebSocket server
   if (wsServer) {
@@ -422,6 +577,12 @@ void CrossPointWebServer::handleClient() {
   }
 
   pumpWsDownload();
+
+#if WEBSERVER_V2
+  // Enforce the idle timeout on WS uploads. If a client dies without sending
+  // TCP FIN the session would otherwise wedge until reboot.
+  if (g_wsUploadSession) g_wsUploadSession->tick(static_cast<uint32_t>(millis()));
+#endif
 
   // Respond to discovery broadcasts
   if (udpActive) {
@@ -673,19 +834,24 @@ void CrossPointWebServer::handleDownload() const {
 
   const size_t fileSize = file.size();
 
-  // Send exact Content-Length so the browser knows when the download is done.
-  // Note: _prepareHeader already adds Connection: close, don't duplicate it.
-  server->setContentLength(fileSize);
-  server->sendHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
-  server->send(200, contentType.c_str(), "");
-
+  // Allocate the copy buffer BEFORE committing to a 200 response. If malloc
+  // fails after headers are flushed, the client hangs waiting for bytes and
+  // only learns about the failure via TCP timeout. Failing early lets us
+  // return a proper 503.
   constexpr size_t DL_BUF_SIZE = 4096;
   auto buf = std::make_unique<uint8_t[]>(DL_BUF_SIZE);
   if (!buf) {
     LOG_ERR("WEB", "Download OOM: cannot allocate %d byte buffer", DL_BUF_SIZE);
     file.close();
+    server->send(503, "text/plain", "out of memory");
     return;
   }
+
+  // Send exact Content-Length so the browser knows when the download is done.
+  // Note: _prepareHeader already adds Connection: close, don't duplicate it.
+  server->setContentLength(fileSize);
+  server->sendHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
+  server->send(200, contentType.c_str(), "");
 
   size_t totalSent = 0;
   bool ok = true;
@@ -1411,6 +1577,23 @@ void CrossPointWebServer::handlePostSettings() {
     return;
   }
 
+#if WEBSERVER_V2
+  if (!g_settingsGateway) {
+    server->send(500, "text/plain", "Settings gateway not initialized");
+    return;
+  }
+  const auto r = g_settingsGateway->applyJson(doc);
+  if (!r.persisted) {
+    // 500 is the bug fix: V1 returned 200 even on disk error, so the browser
+    // UI reported "saved" while settings reverted on the next boot.
+    LOG_ERR("WEB", "Settings save failed: %s", r.error.c_str());
+    server->send(500, "text/plain", String("Applied but not saved: ") + r.error.c_str());
+    return;
+  }
+  LOG_DBG("WEB", "Applied %d setting(s)", r.applied);
+  server->send(200, "text/plain", String("Applied ") + String(r.applied) + " setting(s)");
+  return;
+#else
   auto settings = getSettingsList();
   int applied = 0;
 
@@ -1482,6 +1665,7 @@ void CrossPointWebServer::handlePostSettings() {
 
   LOG_DBG("WEB", "Applied %d setting(s)", applied);
   server->send(200, "text/plain", String("Applied ") + String(applied) + " setting(s)");
+#endif  // WEBSERVER_V2
 }
 
 // WebSocket callback trampoline — check both pointer and running flag.
@@ -1505,12 +1689,16 @@ void CrossPointWebServer::onWebSocketEvent(uint8_t num, WStype_t type, uint8_t* 
   switch (type) {
     case WStype_DISCONNECTED:
       LOG_DBG("WS", "Client %u disconnected", num);
+#if WEBSERVER_V2
+      if (g_wsUploadSession) g_wsUploadSession->onDisconnect(num);
+#else
       // Only clean up if this is the client that owns the active upload.
       // A new client may have already started a fresh upload before this
       // DISCONNECTED event fires (race condition on quick cancel + retry).
       if (num == wsUploadClientNum && wsUploadInProgress && wsUploadFile) {
         abortWsUpload("WS");
       }
+#endif
       // Clean up any in-progress download
       if (wsDownloadInProgress && wsDownloadClientNum == num) {
         wsDownloadFile.close();
@@ -1531,13 +1719,21 @@ void CrossPointWebServer::onWebSocketEvent(uint8_t num, WStype_t type, uint8_t* 
       if (msg.startsWith("DOWNLOAD:")) {
         handleWsDownloadRequest(num, msg);
       } else if (msg.startsWith("START:")) {
+#if WEBSERVER_V2
+        if (g_wsUploadSession) g_wsUploadSession->onStart(num, std::string(msg.c_str()));
+#else
         handleWsUploadStart(num, msg);
+#endif
       }
       break;
     }
 
     case WStype_BIN: {
+#if WEBSERVER_V2
+      if (g_wsUploadSession) g_wsUploadSession->onBinary(num, payload, length);
+#else
       handleWsUploadData(num, payload, length);
+#endif
       break;
     }
 

--- a/src/network/SettingsGateway.cpp
+++ b/src/network/SettingsGateway.cpp
@@ -1,0 +1,22 @@
+#include "SettingsGateway.h"
+
+#include <ArduinoJson.h>
+
+namespace crosspoint {
+namespace network {
+
+SettingsGateway::SettingsGateway(ApplyFn apply, PersistFn persist)
+    : apply_(std::move(apply)), persist_(std::move(persist)) {}
+
+SettingsGateway::Result SettingsGateway::applyJson(const JsonDocument& doc) {
+  Result r;
+  r.applied = apply_ ? apply_(doc) : 0;
+  r.persisted = persist_ ? persist_() : false;
+  if (!r.persisted) {
+    r.error = "save to file failed";
+  }
+  return r;
+}
+
+}  // namespace network
+}  // namespace crosspoint

--- a/src/network/SettingsGateway.h
+++ b/src/network/SettingsGateway.h
@@ -1,0 +1,54 @@
+#pragma once
+
+// SettingsGateway — single boundary between the HTTP settings handler and
+// the CrossPointSettings global.
+//
+// Today handlePostSettings() inlines: JSON parse → per-key switch over the
+// getSettingsList() schema → SETTINGS.saveToFile() — and then ignores the
+// save return value. That silent disk-error path is the primary bug fixed
+// here (user sees "saved" in the browser, settings revert on next boot).
+//
+// The gateway owns orchestration only: it invokes an applier lambda to
+// mutate settings and a persister lambda to write to disk, then reports
+// both outcomes. Device code injects lambdas that wrap the existing switch
+// and SETTINGS.saveToFile(); host tests inject fakes.
+//
+// Forward-compat with RFC #20 (PersistentStore<T>): when saveToFile migrates
+// behind PersistentStore::commit(), only the persister lambda changes.
+
+#include <ArduinoJson.h>
+
+#include <functional>
+#include <string>
+
+namespace crosspoint {
+namespace network {
+
+class SettingsGateway {
+ public:
+  // Applies known keys from <doc> to the settings target. Returns the number
+  // of fields that were actually mutated (unknown keys and out-of-range
+  // values are ignored, matching legacy behavior).
+  using ApplyFn = std::function<int(const JsonDocument& doc)>;
+
+  // Persists the current settings. Returns true on success, false on any
+  // storage error.
+  using PersistFn = std::function<bool()>;
+
+  struct Result {
+    int applied = 0;
+    bool persisted = false;
+    std::string error;  // empty on success
+  };
+
+  SettingsGateway(ApplyFn apply, PersistFn persist);
+
+  Result applyJson(const JsonDocument& doc);
+
+ private:
+  ApplyFn apply_;
+  PersistFn persist_;
+};
+
+}  // namespace network
+}  // namespace crosspoint

--- a/src/network/ws/WsUploadSession.cpp
+++ b/src/network/ws/WsUploadSession.cpp
@@ -1,0 +1,189 @@
+#include "WsUploadSession.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+
+namespace crosspoint {
+namespace ws {
+
+namespace {
+
+std::string sanitizeFileName(std::string name) {
+  // Match prior behavior: strip path separators and ".." sequences so a
+  // hostile client cannot traverse out of the target directory.
+  for (char bad : {'/', '\\'}) {
+    std::string::size_type p;
+    while ((p = name.find(bad)) != std::string::npos) name.erase(p, 1);
+  }
+  std::string::size_type p;
+  while ((p = name.find("..")) != std::string::npos) name.erase(p, 2);
+  return name;
+}
+
+std::string normalizePath(std::string p) {
+  if (p.empty()) p = "/";
+  if (p.front() != '/') p.insert(p.begin(), '/');
+  return p;
+}
+
+}  // namespace
+
+WsUploadSession::WsUploadSession(WsUploadDeps deps) : deps_(std::move(deps)) {}
+
+void WsUploadSession::reset() {
+  state_ = State::Idle;
+  client_ = kNoClient;
+  name_.clear();
+  path_.clear();
+  size_ = 0;
+  received_ = 0;
+  lastProgress_ = 0;
+  lastDataMs_ = 0;
+}
+
+bool WsUploadSession::parseStart(const std::string& msg, std::string& name,
+                                 size_t& size, std::string& path) {
+  // Format: "START:<name>:<size>:<path>"
+  constexpr const char* kPrefix = "START:";
+  constexpr size_t kPrefixLen = 6;
+  if (msg.size() <= kPrefixLen) return false;
+  if (msg.compare(0, kPrefixLen, kPrefix) != 0) return false;
+
+  const size_t firstColon = msg.find(':', kPrefixLen);
+  if (firstColon == std::string::npos) return false;
+  const size_t secondColon = msg.find(':', firstColon + 1);
+  if (secondColon == std::string::npos) return false;
+
+  name = msg.substr(kPrefixLen, firstColon - kPrefixLen);
+  const std::string sizeStr = msg.substr(firstColon + 1, secondColon - firstColon - 1);
+  path = msg.substr(secondColon + 1);
+
+  if (name.empty() || sizeStr.empty()) return false;
+  // Exception-free size parse — device build has -fno-exceptions so stoll is
+  // unusable. strtoll reports failure via endptr + errno.
+  errno = 0;
+  char* end = nullptr;
+  const long long parsed = std::strtoll(sizeStr.c_str(), &end, 10);
+  if (errno != 0 || end == sizeStr.c_str() || *end != '\0' || parsed < 0) {
+    return false;
+  }
+  size = static_cast<size_t>(parsed);
+  return true;
+}
+
+WsUploadSession::Result WsUploadSession::onStart(uint8_t client,
+                                                 const std::string& startMsg) {
+  if (state_ == State::Active) {
+    if (deps_.sendText) deps_.sendText(client, "ERROR:Upload already in progress");
+    return Result::Rejected;
+  }
+
+  std::string name;
+  std::string path;
+  size_t size = 0;
+  if (!parseStart(startMsg, name, size, path)) {
+    if (deps_.sendText) deps_.sendText(client, "ERROR:Invalid START format");
+    return Result::Rejected;
+  }
+
+  name = sanitizeFileName(std::move(name));
+  path = normalizePath(std::move(path));
+  if (name.empty()) {
+    if (deps_.sendText) deps_.sendText(client, "ERROR:Invalid filename");
+    return Result::Rejected;
+  }
+
+  if (!deps_.beginWrite || !deps_.beginWrite(path, name)) {
+    if (deps_.sendText) deps_.sendText(client, "ERROR:Failed to create file");
+    return Result::Rejected;
+  }
+
+  state_ = State::Active;
+  client_ = client;
+  name_ = std::move(name);
+  path_ = std::move(path);
+  size_ = size;
+  received_ = 0;
+  lastProgress_ = 0;
+  lastDataMs_ = deps_.nowMs ? deps_.nowMs() : 0;
+
+  if (deps_.sendText) deps_.sendText(client, "READY");
+  return Result::Ok;
+}
+
+WsUploadSession::Result WsUploadSession::onBinary(uint8_t client,
+                                                  const uint8_t* data, size_t len) {
+  if (state_ != State::Active || client != client_) {
+    if (deps_.sendText) deps_.sendText(client, "ERROR:No upload in progress");
+    return Result::Rejected;
+  }
+
+  const size_t remaining = size_ - received_;
+  if (len > remaining) {
+    abort("Upload overflow");
+    return Result::Aborted;
+  }
+
+  if (!deps_.writeBytes || !deps_.writeBytes(data, len)) {
+    abort("Write failed - disk full?");
+    return Result::Aborted;
+  }
+  received_ += len;
+  if (deps_.nowMs) lastDataMs_ = deps_.nowMs();
+
+  if (received_ - lastProgress_ >= kProgressIntervalBytes || received_ >= size_) {
+    sendProgress();
+    lastProgress_ = received_;
+  }
+
+  if (received_ >= size_) {
+    if (deps_.closeFinalize) deps_.closeFinalize();
+    if (deps_.sendText) deps_.sendText(client_, "DONE");
+    if (deps_.clearBookCache) deps_.clearBookCache(path_, name_);
+    reset();
+    return Result::Completed;
+  }
+  return Result::Ok;
+}
+
+void WsUploadSession::onDisconnect(uint8_t client) {
+  // Only the owning client can end the session — late DISCONNECTED for a
+  // client who never owned the active upload must be ignored.
+  if (state_ != State::Active || client != client_) return;
+  if (deps_.closeAndDelete) deps_.closeAndDelete();
+  reset();
+}
+
+void WsUploadSession::tick(uint32_t nowMs) {
+  if (state_ != State::Active) return;
+  if (nowMs - lastDataMs_ < kIdleTimeoutMs) return;
+  abort("Upload idle timeout");
+}
+
+void WsUploadSession::abort(const std::string& reason) {
+  if (state_ != State::Active) return;
+  const uint8_t owner = client_;
+  if (deps_.closeAndDelete) deps_.closeAndDelete();
+  if (deps_.sendText) deps_.sendText(owner, std::string("ERROR:") + reason);
+  reset();
+}
+
+void WsUploadSession::sendProgress() {
+  if (!deps_.sendText) return;
+  char buf[64];
+  std::snprintf(buf, sizeof(buf), "PROGRESS:%zu:%zu", received_, size_);
+  deps_.sendText(client_, buf);
+}
+
+WsUploadSession::Snapshot WsUploadSession::snapshot() const {
+  Snapshot s;
+  s.active = state_ == State::Active;
+  s.received = received_;
+  s.total = size_;
+  s.filename = name_;
+  return s;
+}
+
+}  // namespace ws
+}  // namespace crosspoint

--- a/src/network/ws/WsUploadSession.h
+++ b/src/network/ws/WsUploadSession.h
@@ -1,0 +1,118 @@
+#pragma once
+
+// WsUploadSession — state machine for the WebSocket file-upload protocol.
+//
+// Extracts the 10-file-scope-static tangle from CrossPointWebServer.cpp
+// (see RFC #24 / GitHub issue #24). Fixes:
+//
+//   1. Client-collision race — onDisconnect(n) only resets state if n owns
+//      the active session. Stale DISCONNECTED for a retired client is a no-op.
+//
+//   2. Idle timeout — tick(nowMs) aborts sessions that have not received a
+//      binary frame in kIdleTimeoutMs. Half-open TCP no longer wedges future
+//      uploads until reboot.
+//
+// The session holds only logical state (strings + counters). File I/O and
+// network I/O flow through Deps lambdas so host tests can inject fakes —
+// no Arduino, no SdFat, no WebSockets dependency in this header or its .cpp.
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+
+namespace crosspoint {
+namespace ws {
+
+struct WsUploadDeps {
+  // Open a file at <path>/<name> for writing. Return true on success, false on
+  // storage error. If the file already exists the production impl removes it
+  // first; this contract is preserved for backward compatibility.
+  std::function<bool(const std::string& path, const std::string& name)> beginWrite;
+
+  // Write a chunk into the currently-open file. Return true if all bytes were
+  // written. On false the session aborts (treated as disk-full / write error).
+  std::function<bool(const uint8_t* data, size_t len)> writeBytes;
+
+  // Close the open file and remove the partial artifact. Called on abort().
+  std::function<void()> closeAndDelete;
+
+  // Close the open file without deletion. Called on successful completion.
+  std::function<void()> closeFinalize;
+
+  // Send a WS TEXT frame to <client>.
+  std::function<void(uint8_t client, const std::string& text)> sendText;
+
+  // Monotonic milliseconds — injected so host tests can drive timeouts.
+  std::function<uint32_t()> nowMs;
+
+  // Clear any cached metadata derived from <path>/<name> (e.g. epub caches).
+  // Called after a successful upload so overwritten books re-parse.
+  std::function<void(const std::string& path, const std::string& name)> clearBookCache;
+};
+
+class WsUploadSession {
+ public:
+  enum class Result { Ok, Rejected, Completed, Aborted };
+
+  static constexpr uint32_t kIdleTimeoutMs = 30000;
+  static constexpr size_t kProgressIntervalBytes = 65536;  // 64 KiB
+  static constexpr uint8_t kNoClient = 255;
+
+  explicit WsUploadSession(WsUploadDeps deps);
+
+  // Parse "START:<name>:<size>:<path>" and open the target file. Rejects
+  // with an error frame if another client already owns the session or the
+  // message is malformed.
+  Result onStart(uint8_t client, const std::string& startMsg);
+
+  // Append bytes to the open file. On overflow / write error aborts and
+  // returns Aborted. On successful completion closes the file, emits DONE,
+  // and returns Completed.
+  Result onBinary(uint8_t client, const uint8_t* data, size_t len);
+
+  // Only transitions the session to Idle if <client> is the current owner.
+  // Late-firing DISCONNECTED for a retired client is explicitly ignored.
+  void onDisconnect(uint8_t client);
+
+  // Must be called from the server loop. Aborts an active session that has
+  // not received data in the last kIdleTimeoutMs.
+  void tick(uint32_t nowMs);
+
+  // Abort the active session. Sends ERROR:<reason> to the owner and cleans
+  // up the partial file. No-op if idle.
+  void abort(const std::string& reason);
+
+  bool inProgress() const { return state_ == State::Active; }
+  uint8_t ownerClient() const { return client_; }
+
+  struct Snapshot {
+    bool active = false;
+    size_t received = 0;
+    size_t total = 0;
+    std::string filename;
+  };
+  Snapshot snapshot() const;
+
+ private:
+  enum class State { Idle, Active };
+
+  State state_ = State::Idle;
+  uint8_t client_ = kNoClient;
+  std::string name_;
+  std::string path_;
+  size_t size_ = 0;
+  size_t received_ = 0;
+  size_t lastProgress_ = 0;
+  uint32_t lastDataMs_ = 0;
+
+  WsUploadDeps deps_;
+
+  void reset();
+  void sendProgress();
+  bool parseStart(const std::string& msg, std::string& name, size_t& size,
+                  std::string& path);
+};
+
+}  // namespace ws
+}  // namespace crosspoint

--- a/test/test_settings_gateway/test_main.cpp
+++ b/test/test_settings_gateway/test_main.cpp
@@ -1,0 +1,103 @@
+// Host-side tests for crosspoint::network::SettingsGateway (RFC #24).
+//
+// Run via:  pio test -e test_host -f test_settings_gateway
+//
+// The gateway is a thin orchestrator — these tests verify its two bug-fix
+// invariants (count propagation + disk-error reporting). The large
+// key-dispatch logic lives in an injected ApplyFn and is exercised on
+// device, not here.
+
+#include <unity.h>
+#include <ArduinoJson.h>
+
+#include "network/SettingsGateway.h"
+
+using crosspoint::network::SettingsGateway;
+
+void setUp() {}
+void tearDown() {}
+
+void test_happy_path_applies_and_persists() {
+  int applyCalls = 0;
+  int persistCalls = 0;
+  SettingsGateway g(
+      [&applyCalls](const JsonDocument&) {
+        applyCalls++;
+        return 3;
+      },
+      [&persistCalls]() {
+        persistCalls++;
+        return true;
+      });
+
+  JsonDocument doc;
+  doc["any"] = "value";
+  auto r = g.applyJson(doc);
+
+  TEST_ASSERT_EQUAL(1, applyCalls);
+  TEST_ASSERT_EQUAL(1, persistCalls);
+  TEST_ASSERT_EQUAL(3, r.applied);
+  TEST_ASSERT_TRUE(r.persisted);
+  TEST_ASSERT_TRUE(r.error.empty());
+}
+
+void test_disk_error_populates_error_message() {
+  SettingsGateway g(
+      [](const JsonDocument&) { return 5; },
+      []() { return false; });
+
+  JsonDocument doc;
+  auto r = g.applyJson(doc);
+
+  TEST_ASSERT_EQUAL(5, r.applied);        // apply still ran
+  TEST_ASSERT_FALSE(r.persisted);
+  TEST_ASSERT_FALSE(r.error.empty());
+}
+
+void test_zero_applied_still_calls_persist() {
+  // Matches legacy behavior: even if no keys were recognized, saveToFile is
+  // still invoked. Preserving that contract means the 500-on-disk-error fix
+  // works the same whether or not the body had known keys.
+  int persistCalls = 0;
+  SettingsGateway g(
+      [](const JsonDocument&) { return 0; },
+      [&persistCalls]() {
+        persistCalls++;
+        return true;
+      });
+
+  JsonDocument doc;
+  auto r = g.applyJson(doc);
+
+  TEST_ASSERT_EQUAL(1, persistCalls);
+  TEST_ASSERT_EQUAL(0, r.applied);
+  TEST_ASSERT_TRUE(r.persisted);
+}
+
+void test_null_apply_fn_defaults_to_zero() {
+  // Defensive: gateway should not crash if a caller forgets to wire apply.
+  SettingsGateway g(nullptr, []() { return true; });
+  JsonDocument doc;
+  auto r = g.applyJson(doc);
+  TEST_ASSERT_EQUAL(0, r.applied);
+  TEST_ASSERT_TRUE(r.persisted);
+}
+
+void test_null_persist_fn_reports_failure() {
+  SettingsGateway g([](const JsonDocument&) { return 1; }, nullptr);
+  JsonDocument doc;
+  auto r = g.applyJson(doc);
+  TEST_ASSERT_EQUAL(1, r.applied);
+  TEST_ASSERT_FALSE(r.persisted);
+  TEST_ASSERT_FALSE(r.error.empty());
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_happy_path_applies_and_persists);
+  RUN_TEST(test_disk_error_populates_error_message);
+  RUN_TEST(test_zero_applied_still_calls_persist);
+  RUN_TEST(test_null_apply_fn_defaults_to_zero);
+  RUN_TEST(test_null_persist_fn_reports_failure);
+  return UNITY_END();
+}

--- a/test/test_ws_upload_session/test_main.cpp
+++ b/test/test_ws_upload_session/test_main.cpp
@@ -1,0 +1,331 @@
+// Host-side tests for crosspoint::ws::WsUploadSession (RFC #24).
+//
+// Run via:  pio test -e test_host -f test_ws_upload_session
+//
+// All file and network I/O is faked through the WsUploadDeps lambda injection
+// points. No Arduino, no SdFat.
+
+#include <unity.h>
+
+#include <string>
+#include <vector>
+
+#include "network/ws/WsUploadSession.h"
+
+using crosspoint::ws::WsUploadDeps;
+using crosspoint::ws::WsUploadSession;
+
+namespace {
+
+struct Fake {
+  std::vector<std::pair<uint8_t, std::string>> sent;       // (client, text)
+  std::vector<std::pair<std::string, std::string>> opened; // (path, name)
+  std::vector<size_t> writes;                              // byte counts
+  std::vector<std::pair<std::string, std::string>> cacheCleared;
+  int closeAndDelete = 0;
+  int closeFinalize = 0;
+
+  bool beginWriteOk = true;
+  bool writeBytesOk = true;
+  uint32_t now = 1000;
+};
+
+Fake g_fake;
+
+WsUploadDeps makeDeps() {
+  WsUploadDeps d;
+  d.beginWrite = [](const std::string& path, const std::string& name) {
+    g_fake.opened.emplace_back(path, name);
+    return g_fake.beginWriteOk;
+  };
+  d.writeBytes = [](const uint8_t*, size_t len) {
+    g_fake.writes.push_back(len);
+    return g_fake.writeBytesOk;
+  };
+  d.closeAndDelete = [] { g_fake.closeAndDelete++; };
+  d.closeFinalize = [] { g_fake.closeFinalize++; };
+  d.sendText = [](uint8_t c, const std::string& t) {
+    g_fake.sent.emplace_back(c, t);
+  };
+  d.nowMs = [] { return g_fake.now; };
+  d.clearBookCache = [](const std::string& path, const std::string& name) {
+    g_fake.cacheCleared.emplace_back(path, name);
+  };
+  return d;
+}
+
+const std::string& lastSent() {
+  TEST_ASSERT_FALSE(g_fake.sent.empty());
+  return g_fake.sent.back().second;
+}
+
+}  // namespace
+
+void setUp() {
+  g_fake = Fake{};
+}
+void tearDown() {}
+
+// ---- START parsing and session opening ----
+
+void test_start_valid_opens_file_and_sends_ready() {
+  WsUploadSession s(makeDeps());
+  auto r = s.onStart(3, "START:book.epub:1024:/books");
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Ok),
+                    static_cast<int>(r));
+  TEST_ASSERT_TRUE(s.inProgress());
+  TEST_ASSERT_EQUAL(3, s.ownerClient());
+  TEST_ASSERT_EQUAL_size_t(1, g_fake.opened.size());
+  TEST_ASSERT_EQUAL_STRING("/books", g_fake.opened[0].first.c_str());
+  TEST_ASSERT_EQUAL_STRING("book.epub", g_fake.opened[0].second.c_str());
+  TEST_ASSERT_EQUAL_STRING("READY", lastSent().c_str());
+}
+
+void test_start_while_active_rejects_new_client() {
+  WsUploadSession s(makeDeps());
+  s.onStart(1, "START:a.epub:10:/");
+  g_fake.sent.clear();
+
+  auto r = s.onStart(2, "START:b.epub:10:/");
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected),
+                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL(2, g_fake.sent.back().first);  // sent to client 2
+  TEST_ASSERT_EQUAL_STRING("ERROR:Upload already in progress",
+                           lastSent().c_str());
+  TEST_ASSERT_EQUAL(1, s.ownerClient());  // owner unchanged
+  TEST_ASSERT_EQUAL_size_t(1, g_fake.opened.size());  // no second open
+}
+
+void test_start_bad_format_rejects() {
+  WsUploadSession s(makeDeps());
+  auto r = s.onStart(1, "START:malformed");
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected),
+                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL_STRING("ERROR:Invalid START format", lastSent().c_str());
+  TEST_ASSERT_FALSE(s.inProgress());
+}
+
+void test_start_negative_size_rejects() {
+  WsUploadSession s(makeDeps());
+  auto r = s.onStart(1, "START:a.epub:-5:/");
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected),
+                    static_cast<int>(r));
+}
+
+void test_start_non_numeric_size_rejects() {
+  WsUploadSession s(makeDeps());
+  auto r = s.onStart(1, "START:a.epub:abc:/");
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected),
+                    static_cast<int>(r));
+}
+
+void test_start_sanitizes_traversal_in_filename() {
+  WsUploadSession s(makeDeps());
+  s.onStart(1, "START:../../etc/passwd:10:/books");
+  TEST_ASSERT_EQUAL_size_t(1, g_fake.opened.size());
+  // "/" and ".." stripped; result is "etcpasswd" (slashes removed, .. removed).
+  const std::string opened = g_fake.opened[0].second;
+  TEST_ASSERT_EQUAL(std::string::npos, opened.find('/'));
+  TEST_ASSERT_EQUAL(std::string::npos, opened.find(".."));
+}
+
+void test_start_open_failure_rejects() {
+  g_fake.beginWriteOk = false;
+  WsUploadSession s(makeDeps());
+  auto r = s.onStart(1, "START:a.epub:10:/");
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected),
+                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL_STRING("ERROR:Failed to create file", lastSent().c_str());
+  TEST_ASSERT_FALSE(s.inProgress());
+}
+
+// ---- Binary frames ----
+
+void test_binary_writes_bytes_and_completes() {
+  WsUploadSession s(makeDeps());
+  s.onStart(1, "START:a.epub:10:/");
+
+  const uint8_t chunk[5] = {1, 2, 3, 4, 5};
+  auto r1 = s.onBinary(1, chunk, 5);
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Ok),
+                    static_cast<int>(r1));
+
+  auto r2 = s.onBinary(1, chunk, 5);
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Completed),
+                    static_cast<int>(r2));
+  TEST_ASSERT_EQUAL(1, g_fake.closeFinalize);
+  TEST_ASSERT_EQUAL(0, g_fake.closeAndDelete);
+  TEST_ASSERT_EQUAL_STRING("DONE", lastSent().c_str());
+  TEST_ASSERT_EQUAL_size_t(1, g_fake.cacheCleared.size());
+  TEST_ASSERT_FALSE(s.inProgress());
+}
+
+void test_binary_overflow_aborts() {
+  WsUploadSession s(makeDeps());
+  s.onStart(1, "START:a.epub:4:/");
+
+  const uint8_t chunk[10] = {0};
+  auto r = s.onBinary(1, chunk, 10);
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Aborted),
+                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL(1, g_fake.closeAndDelete);
+  TEST_ASSERT_EQUAL_STRING("ERROR:Upload overflow", lastSent().c_str());
+  TEST_ASSERT_FALSE(s.inProgress());
+}
+
+void test_binary_write_failure_aborts() {
+  g_fake.writeBytesOk = false;
+  WsUploadSession s(makeDeps());
+  s.onStart(1, "START:a.epub:10:/");
+
+  const uint8_t chunk[5] = {0};
+  auto r = s.onBinary(1, chunk, 5);
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Aborted),
+                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL_STRING("ERROR:Write failed - disk full?",
+                           lastSent().c_str());
+}
+
+void test_binary_from_non_owner_rejected() {
+  WsUploadSession s(makeDeps());
+  s.onStart(1, "START:a.epub:10:/");
+
+  const uint8_t chunk[5] = {0};
+  auto r = s.onBinary(2, chunk, 5);  // client 2, not owner
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected),
+                    static_cast<int>(r));
+  TEST_ASSERT_TRUE(s.inProgress());  // session unaffected
+}
+
+// ---- Disconnect semantics (RFC headline race fix) ----
+
+void test_disconnect_non_owner_is_noop() {
+  WsUploadSession s(makeDeps());
+  s.onStart(1, "START:a.epub:10:/");
+
+  s.onDisconnect(99);  // some other client
+  TEST_ASSERT_TRUE(s.inProgress());
+  TEST_ASSERT_EQUAL(1, s.ownerClient());
+  TEST_ASSERT_EQUAL(0, g_fake.closeAndDelete);
+}
+
+void test_disconnect_owner_aborts_and_resets() {
+  WsUploadSession s(makeDeps());
+  s.onStart(1, "START:a.epub:10:/");
+
+  s.onDisconnect(1);
+  TEST_ASSERT_FALSE(s.inProgress());
+  TEST_ASSERT_EQUAL(1, g_fake.closeAndDelete);
+}
+
+void test_stale_disconnect_after_retire_is_noop() {
+  // Race scenario: client A's upload completes or aborts; then a delayed
+  // DISCONNECTED frame for A arrives. Must not disturb the idle state.
+  WsUploadSession s(makeDeps());
+  s.onStart(1, "START:a.epub:5:/");
+  const uint8_t chunk[5] = {0};
+  s.onBinary(1, chunk, 5);  // completes
+  TEST_ASSERT_FALSE(s.inProgress());
+  g_fake.closeAndDelete = 0;
+
+  s.onDisconnect(1);  // stale event for client that no longer owns
+  TEST_ASSERT_EQUAL(0, g_fake.closeAndDelete);
+}
+
+// ---- Idle timeout ----
+
+void test_tick_noop_when_idle() {
+  WsUploadSession s(makeDeps());
+  s.tick(1'000'000);  // nothing happens
+  TEST_ASSERT_FALSE(s.inProgress());
+  TEST_ASSERT_EQUAL(0, g_fake.closeAndDelete);
+}
+
+void test_tick_before_timeout_keeps_session() {
+  g_fake.now = 1000;
+  WsUploadSession s(makeDeps());
+  s.onStart(1, "START:a.epub:100:/");
+
+  s.tick(1000 + WsUploadSession::kIdleTimeoutMs - 1);
+  TEST_ASSERT_TRUE(s.inProgress());
+}
+
+void test_tick_at_timeout_aborts() {
+  g_fake.now = 1000;
+  WsUploadSession s(makeDeps());
+  s.onStart(1, "START:a.epub:100:/");
+
+  s.tick(1000 + WsUploadSession::kIdleTimeoutMs);
+  TEST_ASSERT_FALSE(s.inProgress());
+  TEST_ASSERT_EQUAL(1, g_fake.closeAndDelete);
+  TEST_ASSERT_EQUAL_STRING("ERROR:Upload idle timeout", lastSent().c_str());
+}
+
+void test_tick_resets_on_every_binary() {
+  // Receiving data refreshes the idle clock.
+  g_fake.now = 1000;
+  WsUploadSession s(makeDeps());
+  s.onStart(1, "START:a.epub:100:/");
+
+  g_fake.now = 20000;
+  const uint8_t chunk[10] = {0};
+  s.onBinary(1, chunk, 10);  // lastDataMs_ advances to 20000
+
+  // One tick shy of timeout from the new reference.
+  g_fake.now = 20000 + WsUploadSession::kIdleTimeoutMs - 1;
+  s.tick(g_fake.now);
+  TEST_ASSERT_TRUE(s.inProgress());
+}
+
+void test_after_timeout_new_client_can_start() {
+  g_fake.now = 1000;
+  WsUploadSession s(makeDeps());
+  s.onStart(1, "START:a.epub:100:/");
+  s.tick(1000 + WsUploadSession::kIdleTimeoutMs);  // aborts client 1
+
+  auto r = s.onStart(2, "START:b.epub:100:/");
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Ok),
+                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL(2, s.ownerClient());
+}
+
+// ---- Snapshot ----
+
+void test_snapshot_reports_active_state() {
+  WsUploadSession s(makeDeps());
+  s.onStart(1, "START:book.epub:1000:/books");
+
+  const uint8_t chunk[100] = {0};
+  s.onBinary(1, chunk, 100);
+
+  auto snap = s.snapshot();
+  TEST_ASSERT_TRUE(snap.active);
+  TEST_ASSERT_EQUAL_size_t(100, snap.received);
+  TEST_ASSERT_EQUAL_size_t(1000, snap.total);
+  TEST_ASSERT_EQUAL_STRING("book.epub", snap.filename.c_str());
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_start_valid_opens_file_and_sends_ready);
+  RUN_TEST(test_start_while_active_rejects_new_client);
+  RUN_TEST(test_start_bad_format_rejects);
+  RUN_TEST(test_start_negative_size_rejects);
+  RUN_TEST(test_start_non_numeric_size_rejects);
+  RUN_TEST(test_start_sanitizes_traversal_in_filename);
+  RUN_TEST(test_start_open_failure_rejects);
+  RUN_TEST(test_binary_writes_bytes_and_completes);
+  RUN_TEST(test_binary_overflow_aborts);
+  RUN_TEST(test_binary_write_failure_aborts);
+  RUN_TEST(test_binary_from_non_owner_rejected);
+  RUN_TEST(test_disconnect_non_owner_is_noop);
+  RUN_TEST(test_disconnect_owner_aborts_and_resets);
+  RUN_TEST(test_stale_disconnect_after_retire_is_noop);
+  RUN_TEST(test_tick_noop_when_idle);
+  RUN_TEST(test_tick_before_timeout_keeps_session);
+  RUN_TEST(test_tick_at_timeout_aborts);
+  RUN_TEST(test_tick_resets_on_every_binary);
+  RUN_TEST(test_after_timeout_new_client_can_start);
+  RUN_TEST(test_snapshot_reports_active_state);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Extracts two seams from the 1709-LOC `CrossPointWebServer.cpp` that each carry a concrete bug. Scope is strictly bug-driven per RFC #24 — HTTP multipart upload, book metadata migration, UDP discovery, and all wire protocols are byte-identical.

Closes #24.

### Bug fixes

1. **WS upload client-collision race** — new `WsUploadSession` with explicit owner tracking. Stale DISCONNECTED for a retired client is a no-op.
2. **WS upload idle timeout** — `tick()` called from `handleClient` aborts sessions idle >30s. Half-open TCP no longer wedges uploads until reboot.
3. **Settings POST silent disk error** — new `SettingsGateway` checks `SETTINGS.saveToFile()` return. On failure: HTTP 500 with error detail instead of lying 200.
4. **4KB download OOM** — `handleDownload` moves the malloc before `send(200)` so an alloc failure returns a real 503 instead of committing headers and hanging the client. **Always-on** (not V2-gated) — ships to production on merge.

### Host tests (new)

25 new Unity tests on top of the harness from #25:
- 20 × `test_ws_upload_session` — START parse, owner-match disconnect, stale disconnect, overflow, write failure, timeout, recovery, snapshot
- 5 × `test_settings_gateway` — applied-count propagation, disk-error path, null-lambda defaults

Full host test suite: `pio test -e test_host` → 37/37 PASSED.

### Rollout

- Gated behind `-DWEBSERVER_V2=1` in `[env:debug]` only. `[env:default]` stays on the V1 path.
- V1 code remains under `#else` branches. No V1 behavior change.
- Flash delta: **+2.5 KB** on debug.

## Test plan

- [x] `pio test -e test_host` — 37/37 PASSED
- [x] `pio run -e default` — SUCCESS
- [x] `pio run -e debug` — SUCCESS
- [ ] Device smoke (debug env, user-assisted):
  - [ ] Upload 50 MB EPUB via WS from desktop → DONE
  - [ ] Kill browser tab mid-upload → within 30s server accepts new upload (log: \"Upload idle timeout\")
  - [ ] Two browsers simultaneously: first wins, second gets `ERROR:Upload already in progress`
  - [ ] Settings POST with SD pre-filled to 100% → browser shows 500 \"Applied but not saved\" (was silent 200)
  - [ ] Download book with heap ~170 KB → no crash; alloc failure returns 503

## Rollout follow-ups

- Promote `WEBSERVER_V2=1` to `[env:default]` after ≥1 release cycle stable.
- Delete V1 bodies under `#else` in a separate PR after 2 release cycles.
- Host tests for #20, #22 — tracked in those RFCs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)