### PR TITLE
style: repo-wide clang-format pass

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"c90c1b9f-5246-47d3-9037-b9a15d5fd17f","pid":19948,"acquiredAt":1776525374923}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"c90c1b9f-5246-47d3-9037-b9a15d5fd17f","pid":19948,"acquiredAt":1776525374923}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ backups/
 .claude/settings.local.json
 .claude/worktrees/
 .claude/.DS_Store
+.claude/scheduled_tasks.lock

--- a/lib/I18n/I18nKeys.h
+++ b/lib/I18n/I18nKeys.h
@@ -9,10 +9,7 @@ extern const char* const STRINGS_EN[];
 }  // namespace i18n_strings
 
 // Language enum
-enum class Language : uint8_t {
-  ENGLISH = 0,
-  _COUNT
-};
+enum class Language : uint8_t { ENGLISH = 0, _COUNT };
 
 // Language display names (defined in I18nStrings.cpp)
 extern const char* const LANGUAGE_NAMES[];

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -52,8 +52,7 @@ inline std::vector<SettingInfo> getSettingsList() {
   // --- Reader ---
   s.push_back(SettingInfo::Enum(StrId::STR_FONT_FAMILY, &CrossPointSettings::fontFamily,
                                 {StrId::STR_CHAREINK, StrId::STR_BOOKERLY, StrId::STR_VOLLKORN, StrId::STR_IMFELL},
-                                "fontFamily",
-                                StrId::STR_CAT_READER));
+                                "fontFamily", StrId::STR_CAT_READER));
   s.push_back(SettingInfo::Enum(StrId::STR_FONT_SIZE, &CrossPointSettings::fontSize,
                                 {StrId::STR_SMALL, StrId::STR_MEDIUM, StrId::STR_LARGE}, "fontSize",
                                 StrId::STR_CAT_READER));

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2158,8 +2158,8 @@ void EpubReaderActivity::renderContents(const Page& page, const int orientedMarg
     renderHighlights(page, SETTINGS.getReaderFontId(), orientedMarginLeft, contentY);
     // Draw dashed border around text area to indicate highlight mode —
     // same dashed styling (2px, dash=8, gap=4) as the word cursor.
-    constexpr int frameOffset = 6;    // padding from text area to the frame
-    constexpr int frameThickness = 3; // match cursor border thickness
+    constexpr int frameOffset = 6;     // padding from text area to the frame
+    constexpr int frameThickness = 3;  // match cursor border thickness
     const int bx = orientedMarginLeft - frameOffset;
     const int by = contentY - frameOffset;
     const int bw = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight + 2 * frameOffset;

--- a/src/activities/reader/ReaderSettingsActivity.cpp
+++ b/src/activities/reader/ReaderSettingsActivity.cpp
@@ -251,9 +251,9 @@ void ReaderSettingsActivity::buildSettingsList() {
   };
 
   // --- Build reader settings directly (no intermediate vector) ---
-  pushReader(ReaderSettingInfo::Enum(
-      StrId::STR_FONT_FAMILY, &CrossPointSettings::fontFamily,
-      {StrId::STR_CHAREINK, StrId::STR_BOOKERLY, StrId::STR_VOLLKORN, StrId::STR_IMFELL}));
+  pushReader(
+      ReaderSettingInfo::Enum(StrId::STR_FONT_FAMILY, &CrossPointSettings::fontFamily,
+                              {StrId::STR_CHAREINK, StrId::STR_BOOKERLY, StrId::STR_VOLLKORN, StrId::STR_IMFELL}));
   pushReader(ReaderSettingInfo::Enum(StrId::STR_FONT_SIZE, &CrossPointSettings::fontSize,
                                      {StrId::STR_SMALL, StrId::STR_MEDIUM, StrId::STR_LARGE}));
   pushReader(ReaderSettingInfo::Value(StrId::STR_LINE_SPACING, &CrossPointSettings::lineSpacingPercent, {35, 150, 5}));

--- a/src/lifecycle/ActivityRouter.cpp
+++ b/src/lifecycle/ActivityRouter.cpp
@@ -13,13 +13,9 @@ ActivityRouter& ActivityRouter::instance() {
   return s_instance;
 }
 
-void ActivityRouter::begin(const Nav& initial) {
-  dispatch(initial);
-}
+void ActivityRouter::begin(const Nav& initial) { dispatch(initial); }
 
-void ActivityRouter::request(const Nav& nav) {
-  pending_ = nav;
-}
+void ActivityRouter::request(const Nav& nav) { pending_ = nav; }
 
 void ActivityRouter::applyIfPending() {
   if (!pending_ || busy_) return;

--- a/src/lifecycle/ActivityRouter.h
+++ b/src/lifecycle/ActivityRouter.h
@@ -41,13 +41,13 @@ class ActivityRouter {
   void setRouteFactory(RouteId route, Factory factory);
 
   std::function<void(const std::string&)> makeGoToReader() const;
-  std::function<void()>                   makeGoHome() const;
-  std::function<void()>                   makeGoToSettings() const;
-  std::function<void()>                   makeGoToMyLibrary() const;
+  std::function<void()> makeGoHome() const;
+  std::function<void()> makeGoToSettings() const;
+  std::function<void()> makeGoToMyLibrary() const;
   std::function<void(const std::string&)> makeGoToMyLibraryWithPath() const;
-  std::function<void()>                   makeGoToRecentBooks() const;
-  std::function<void()>                   makeGoToFileTransfer() const;
-  std::function<void()>                   makeGoToBrowser() const;
+  std::function<void()> makeGoToRecentBooks() const;
+  std::function<void()> makeGoToFileTransfer() const;
+  std::function<void()> makeGoToBrowser() const;
 
   // Injection seam for main.cpp (production) and host tests (stubs).
   // All side-effecting calls flow through these — router itself never touches

--- a/src/lifecycle/Nav.h
+++ b/src/lifecycle/Nav.h
@@ -7,9 +7,9 @@ namespace lifecycle {
 
 enum class RouteId : uint8_t {
   Home,
-  Reader,        // payload: path
+  Reader,  // payload: path
   MyLibrary,
-  MyLibraryAt,   // payload: path
+  MyLibraryAt,  // payload: path
   RecentBooks,
   Settings,
   FileTransfer,
@@ -32,14 +32,22 @@ struct RoutePolicy {
 
 constexpr RoutePolicy policyFor(RouteId r) {
   switch (r) {
-    case RouteId::Home:         return {true,  true,  "go home"};
-    case RouteId::Reader:       return {false, false, nullptr};
-    case RouteId::MyLibrary:    return {true,  false, "go to library"};
-    case RouteId::MyLibraryAt:  return {true,  false, "go to library path"};
-    case RouteId::RecentBooks:  return {true,  false, "go to recents"};
-    case RouteId::Settings:     return {false, false, nullptr};
-    case RouteId::FileTransfer: return {false, false, nullptr};
-    case RouteId::Browser:      return {false, false, nullptr};
+    case RouteId::Home:
+      return {true, true, "go home"};
+    case RouteId::Reader:
+      return {false, false, nullptr};
+    case RouteId::MyLibrary:
+      return {true, false, "go to library"};
+    case RouteId::MyLibraryAt:
+      return {true, false, "go to library path"};
+    case RouteId::RecentBooks:
+      return {true, false, "go to recents"};
+    case RouteId::Settings:
+      return {false, false, nullptr};
+    case RouteId::FileTransfer:
+      return {false, false, nullptr};
+    case RouteId::Browser:
+      return {false, false, nullptr};
   }
   return {};  // unreachable; satisfies non-void return warning
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -607,9 +607,7 @@ void setup() {
       LOG_DBG("MAIN", "Entering deep sleep");
       powerManager.startDeepSleep(gpio);
     };
-    deps.enterSleepActivity = []() {
-      enterNewActivity(new SleepActivity(renderer, mappedInputManager));
-    };
+    deps.enterSleepActivity = []() { enterNewActivity(new SleepActivity(renderer, mappedInputManager)); };
     router.setDeps(std::move(deps));
 
     router.setRouteFactory(lifecycle::RouteId::Settings, [](const std::string& /*payload*/) {
@@ -617,27 +615,17 @@ void setup() {
       exitActivity();
       enterNewActivity(new SettingsActivity(renderer, mappedInputManager, onGoHome));
     });
-    router.setRouteFactory(lifecycle::RouteId::Reader, [](const std::string& payload) {
-      openReaderInline(payload);
-    });
-    router.setRouteFactory(lifecycle::RouteId::MyLibrary, [](const std::string& /*payload*/) {
-      openMyLibraryInline("");
-    });
-    router.setRouteFactory(lifecycle::RouteId::MyLibraryAt, [](const std::string& payload) {
-      openMyLibraryInline(payload);
-    });
-    router.setRouteFactory(lifecycle::RouteId::RecentBooks, [](const std::string& /*payload*/) {
-      openRecentBooksInline();
-    });
-    router.setRouteFactory(lifecycle::RouteId::FileTransfer, [](const std::string& /*payload*/) {
-      openFileTransferInline();
-    });
-    router.setRouteFactory(lifecycle::RouteId::Browser, [](const std::string& /*payload*/) {
-      openBrowserInline();
-    });
-    router.setRouteFactory(lifecycle::RouteId::Home, [](const std::string& /*payload*/) {
-      openHomeInline();
-    });
+    router.setRouteFactory(lifecycle::RouteId::Reader, [](const std::string& payload) { openReaderInline(payload); });
+    router.setRouteFactory(lifecycle::RouteId::MyLibrary,
+                           [](const std::string& /*payload*/) { openMyLibraryInline(""); });
+    router.setRouteFactory(lifecycle::RouteId::MyLibraryAt,
+                           [](const std::string& payload) { openMyLibraryInline(payload); });
+    router.setRouteFactory(lifecycle::RouteId::RecentBooks,
+                           [](const std::string& /*payload*/) { openRecentBooksInline(); });
+    router.setRouteFactory(lifecycle::RouteId::FileTransfer,
+                           [](const std::string& /*payload*/) { openFileTransferInline(); });
+    router.setRouteFactory(lifecycle::RouteId::Browser, [](const std::string& /*payload*/) { openBrowserInline(); });
+    router.setRouteFactory(lifecycle::RouteId::Home, [](const std::string& /*payload*/) { openHomeInline(); });
   }
 #endif
 

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -365,13 +365,12 @@ void CrossPointWebServer::begin() {
               if (val >= 0 && val < maxEnumValue) {
                 if (s.valuePtr) {
                   if (s.valuePtr == &CrossPointSettings::fontSize) {
-                    SETTINGS.fontSize = CrossPointSettings::displayIndexToFontSize(
-                        SETTINGS.fontFamily, static_cast<uint8_t>(val));
+                    SETTINGS.fontSize =
+                        CrossPointSettings::displayIndexToFontSize(SETTINGS.fontFamily, static_cast<uint8_t>(val));
                   } else if (s.valuePtr == &CrossPointSettings::fontFamily) {
-                    SETTINGS.fontFamily =
-                        CrossPointSettings::displayIndexToFontFamily(static_cast<uint8_t>(val));
-                    SETTINGS.fontSize = CrossPointSettings::normalizeFontSizeForFamily(
-                        SETTINGS.fontFamily, SETTINGS.fontSize);
+                    SETTINGS.fontFamily = CrossPointSettings::displayIndexToFontFamily(static_cast<uint8_t>(val));
+                    SETTINGS.fontSize =
+                        CrossPointSettings::normalizeFontSizeForFamily(SETTINGS.fontFamily, SETTINGS.fontSize);
                     SETTINGS.lineSpacingPercent = 90;
                   } else {
                     SETTINGS.*(s.valuePtr) = static_cast<uint8_t>(val);

--- a/src/network/ws/WsUploadSession.cpp
+++ b/src/network/ws/WsUploadSession.cpp
@@ -42,8 +42,7 @@ void WsUploadSession::reset() {
   lastDataMs_ = 0;
 }
 
-bool WsUploadSession::parseStart(const std::string& msg, std::string& name,
-                                 size_t& size, std::string& path) {
+bool WsUploadSession::parseStart(const std::string& msg, std::string& name, size_t& size, std::string& path) {
   // Format: "START:<name>:<size>:<path>"
   constexpr const char* kPrefix = "START:";
   constexpr size_t kPrefixLen = 6;
@@ -72,8 +71,7 @@ bool WsUploadSession::parseStart(const std::string& msg, std::string& name,
   return true;
 }
 
-WsUploadSession::Result WsUploadSession::onStart(uint8_t client,
-                                                 const std::string& startMsg) {
+WsUploadSession::Result WsUploadSession::onStart(uint8_t client, const std::string& startMsg) {
   if (state_ == State::Active) {
     if (deps_.sendText) deps_.sendText(client, "ERROR:Upload already in progress");
     return Result::Rejected;
@@ -112,8 +110,7 @@ WsUploadSession::Result WsUploadSession::onStart(uint8_t client,
   return Result::Ok;
 }
 
-WsUploadSession::Result WsUploadSession::onBinary(uint8_t client,
-                                                  const uint8_t* data, size_t len) {
+WsUploadSession::Result WsUploadSession::onBinary(uint8_t client, const uint8_t* data, size_t len) {
   if (state_ != State::Active || client != client_) {
     if (deps_.sendText) deps_.sendText(client, "ERROR:No upload in progress");
     return Result::Rejected;

--- a/src/network/ws/WsUploadSession.h
+++ b/src/network/ws/WsUploadSession.h
@@ -110,8 +110,7 @@ class WsUploadSession {
 
   void reset();
   void sendProgress();
-  bool parseStart(const std::string& msg, std::string& name, size_t& size,
-                  std::string& path);
+  bool parseStart(const std::string& msg, std::string& name, size_t& size, std::string& path);
 };
 
 }  // namespace ws

--- a/test/test_activity_router/test_main.cpp
+++ b/test/test_activity_router/test_main.cpp
@@ -17,8 +17,8 @@
 
 using lifecycle::ActivityRouter;
 using lifecycle::Nav;
-using lifecycle::RouteId;
 using lifecycle::policyFor;
+using lifecycle::RouteId;
 
 namespace {
 
@@ -41,29 +41,33 @@ void thunkAfter() { g_afterSleep++; }
 
 const char* routeName(RouteId r) {
   switch (r) {
-    case RouteId::Home: return "Home";
-    case RouteId::Reader: return "Reader";
-    case RouteId::MyLibrary: return "MyLibrary";
-    case RouteId::MyLibraryAt: return "MyLibraryAt";
-    case RouteId::RecentBooks: return "RecentBooks";
-    case RouteId::Settings: return "Settings";
-    case RouteId::FileTransfer: return "FileTransfer";
-    case RouteId::Browser: return "Browser";
+    case RouteId::Home:
+      return "Home";
+    case RouteId::Reader:
+      return "Reader";
+    case RouteId::MyLibrary:
+      return "MyLibrary";
+    case RouteId::MyLibraryAt:
+      return "MyLibraryAt";
+    case RouteId::RecentBooks:
+      return "RecentBooks";
+    case RouteId::Settings:
+      return "Settings";
+    case RouteId::FileTransfer:
+      return "FileTransfer";
+    case RouteId::Browser:
+      return "Browser";
   }
   return "?";
 }
 
 void registerRecordingFactories() {
   auto& r = ActivityRouter::instance();
-  const RouteId all[] = {RouteId::Home, RouteId::Reader, RouteId::MyLibrary,
-                         RouteId::MyLibraryAt, RouteId::RecentBooks,
-                         RouteId::Settings, RouteId::FileTransfer,
-                         RouteId::Browser};
+  const RouteId all[] = {RouteId::Home,        RouteId::Reader,   RouteId::MyLibrary,    RouteId::MyLibraryAt,
+                         RouteId::RecentBooks, RouteId::Settings, RouteId::FileTransfer, RouteId::Browser};
   for (RouteId id : all) {
     const char* name = routeName(id);
-    r.setRouteFactory(id, [name](const std::string& p) {
-      g_factoryCalls.push_back(std::string(name) + ":" + p);
-    });
+    r.setRouteFactory(id, [name](const std::string& p) { g_factoryCalls.push_back(std::string(name) + ":" + p); });
   }
 }
 
@@ -127,8 +131,7 @@ void test_no_persist_routes_skip_persist() {
   d.trimSleepFolderIfDirty = &thunkTrim;
   ActivityRouter::setDepsForTest(d);
 
-  const RouteId skipRoutes[] = {RouteId::Reader, RouteId::Settings,
-                                RouteId::FileTransfer, RouteId::Browser};
+  const RouteId skipRoutes[] = {RouteId::Reader, RouteId::Settings, RouteId::FileTransfer, RouteId::Browser};
   for (RouteId r : skipRoutes) {
     ActivityRouter::instance().request({r, "x"});
     ActivityRouter::instance().applyIfPending();
@@ -204,9 +207,7 @@ void test_unmigrated_route_is_noop() {
 // Ordering is captured by recording every hook into a single vector of tags.
 std::vector<std::string> g_sleepOrder;
 
-void orderBefore(bool fromReader) {
-  g_sleepOrder.push_back(fromReader ? "before:true" : "before:false");
-}
+void orderBefore(bool fromReader) { g_sleepOrder.push_back(fromReader ? "before:true" : "before:false"); }
 bool orderPersist(const char* ctx) {
   g_sleepOrder.push_back(std::string("persist:") + (ctx ? ctx : ""));
   return true;

--- a/test/test_settings_gateway/test_main.cpp
+++ b/test/test_settings_gateway/test_main.cpp
@@ -7,8 +7,8 @@
 // key-dispatch logic lives in an injected ApplyFn and is exercised on
 // device, not here.
 
-#include <unity.h>
 #include <ArduinoJson.h>
+#include <unity.h>
 
 #include "network/SettingsGateway.h"
 
@@ -42,14 +42,12 @@ void test_happy_path_applies_and_persists() {
 }
 
 void test_disk_error_populates_error_message() {
-  SettingsGateway g(
-      [](const JsonDocument&) { return 5; },
-      []() { return false; });
+  SettingsGateway g([](const JsonDocument&) { return 5; }, []() { return false; });
 
   JsonDocument doc;
   auto r = g.applyJson(doc);
 
-  TEST_ASSERT_EQUAL(5, r.applied);        // apply still ran
+  TEST_ASSERT_EQUAL(5, r.applied);  // apply still ran
   TEST_ASSERT_FALSE(r.persisted);
   TEST_ASSERT_FALSE(r.error.empty());
 }
@@ -59,12 +57,11 @@ void test_zero_applied_still_calls_persist() {
   // still invoked. Preserving that contract means the 500-on-disk-error fix
   // works the same whether or not the body had known keys.
   int persistCalls = 0;
-  SettingsGateway g(
-      [](const JsonDocument&) { return 0; },
-      [&persistCalls]() {
-        persistCalls++;
-        return true;
-      });
+  SettingsGateway g([](const JsonDocument&) { return 0; },
+                    [&persistCalls]() {
+                      persistCalls++;
+                      return true;
+                    });
 
   JsonDocument doc;
   auto r = g.applyJson(doc);

--- a/test/test_ws_upload_session/test_main.cpp
+++ b/test/test_ws_upload_session/test_main.cpp
@@ -18,9 +18,9 @@ using crosspoint::ws::WsUploadSession;
 namespace {
 
 struct Fake {
-  std::vector<std::pair<uint8_t, std::string>> sent;       // (client, text)
-  std::vector<std::pair<std::string, std::string>> opened; // (path, name)
-  std::vector<size_t> writes;                              // byte counts
+  std::vector<std::pair<uint8_t, std::string>> sent;        // (client, text)
+  std::vector<std::pair<std::string, std::string>> opened;  // (path, name)
+  std::vector<size_t> writes;                               // byte counts
   std::vector<std::pair<std::string, std::string>> cacheCleared;
   int closeAndDelete = 0;
   int closeFinalize = 0;
@@ -44,9 +44,7 @@ WsUploadDeps makeDeps() {
   };
   d.closeAndDelete = [] { g_fake.closeAndDelete++; };
   d.closeFinalize = [] { g_fake.closeFinalize++; };
-  d.sendText = [](uint8_t c, const std::string& t) {
-    g_fake.sent.emplace_back(c, t);
-  };
+  d.sendText = [](uint8_t c, const std::string& t) { g_fake.sent.emplace_back(c, t); };
   d.nowMs = [] { return g_fake.now; };
   d.clearBookCache = [](const std::string& path, const std::string& name) {
     g_fake.cacheCleared.emplace_back(path, name);
@@ -61,9 +59,7 @@ const std::string& lastSent() {
 
 }  // namespace
 
-void setUp() {
-  g_fake = Fake{};
-}
+void setUp() { g_fake = Fake{}; }
 void tearDown() {}
 
 // ---- START parsing and session opening ----
@@ -71,8 +67,7 @@ void tearDown() {}
 void test_start_valid_opens_file_and_sends_ready() {
   WsUploadSession s(makeDeps());
   auto r = s.onStart(3, "START:book.epub:1024:/books");
-  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Ok),
-                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Ok), static_cast<int>(r));
   TEST_ASSERT_TRUE(s.inProgress());
   TEST_ASSERT_EQUAL(3, s.ownerClient());
   TEST_ASSERT_EQUAL_size_t(1, g_fake.opened.size());
@@ -87,20 +82,17 @@ void test_start_while_active_rejects_new_client() {
   g_fake.sent.clear();
 
   auto r = s.onStart(2, "START:b.epub:10:/");
-  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected),
-                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected), static_cast<int>(r));
   TEST_ASSERT_EQUAL(2, g_fake.sent.back().first);  // sent to client 2
-  TEST_ASSERT_EQUAL_STRING("ERROR:Upload already in progress",
-                           lastSent().c_str());
-  TEST_ASSERT_EQUAL(1, s.ownerClient());  // owner unchanged
+  TEST_ASSERT_EQUAL_STRING("ERROR:Upload already in progress", lastSent().c_str());
+  TEST_ASSERT_EQUAL(1, s.ownerClient());              // owner unchanged
   TEST_ASSERT_EQUAL_size_t(1, g_fake.opened.size());  // no second open
 }
 
 void test_start_bad_format_rejects() {
   WsUploadSession s(makeDeps());
   auto r = s.onStart(1, "START:malformed");
-  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected),
-                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected), static_cast<int>(r));
   TEST_ASSERT_EQUAL_STRING("ERROR:Invalid START format", lastSent().c_str());
   TEST_ASSERT_FALSE(s.inProgress());
 }
@@ -108,15 +100,13 @@ void test_start_bad_format_rejects() {
 void test_start_negative_size_rejects() {
   WsUploadSession s(makeDeps());
   auto r = s.onStart(1, "START:a.epub:-5:/");
-  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected),
-                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected), static_cast<int>(r));
 }
 
 void test_start_non_numeric_size_rejects() {
   WsUploadSession s(makeDeps());
   auto r = s.onStart(1, "START:a.epub:abc:/");
-  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected),
-                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected), static_cast<int>(r));
 }
 
 void test_start_sanitizes_traversal_in_filename() {
@@ -133,8 +123,7 @@ void test_start_open_failure_rejects() {
   g_fake.beginWriteOk = false;
   WsUploadSession s(makeDeps());
   auto r = s.onStart(1, "START:a.epub:10:/");
-  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected),
-                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected), static_cast<int>(r));
   TEST_ASSERT_EQUAL_STRING("ERROR:Failed to create file", lastSent().c_str());
   TEST_ASSERT_FALSE(s.inProgress());
 }
@@ -147,12 +136,10 @@ void test_binary_writes_bytes_and_completes() {
 
   const uint8_t chunk[5] = {1, 2, 3, 4, 5};
   auto r1 = s.onBinary(1, chunk, 5);
-  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Ok),
-                    static_cast<int>(r1));
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Ok), static_cast<int>(r1));
 
   auto r2 = s.onBinary(1, chunk, 5);
-  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Completed),
-                    static_cast<int>(r2));
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Completed), static_cast<int>(r2));
   TEST_ASSERT_EQUAL(1, g_fake.closeFinalize);
   TEST_ASSERT_EQUAL(0, g_fake.closeAndDelete);
   TEST_ASSERT_EQUAL_STRING("DONE", lastSent().c_str());
@@ -166,8 +153,7 @@ void test_binary_overflow_aborts() {
 
   const uint8_t chunk[10] = {0};
   auto r = s.onBinary(1, chunk, 10);
-  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Aborted),
-                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Aborted), static_cast<int>(r));
   TEST_ASSERT_EQUAL(1, g_fake.closeAndDelete);
   TEST_ASSERT_EQUAL_STRING("ERROR:Upload overflow", lastSent().c_str());
   TEST_ASSERT_FALSE(s.inProgress());
@@ -180,10 +166,8 @@ void test_binary_write_failure_aborts() {
 
   const uint8_t chunk[5] = {0};
   auto r = s.onBinary(1, chunk, 5);
-  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Aborted),
-                    static_cast<int>(r));
-  TEST_ASSERT_EQUAL_STRING("ERROR:Write failed - disk full?",
-                           lastSent().c_str());
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Aborted), static_cast<int>(r));
+  TEST_ASSERT_EQUAL_STRING("ERROR:Write failed - disk full?", lastSent().c_str());
 }
 
 void test_binary_from_non_owner_rejected() {
@@ -192,8 +176,7 @@ void test_binary_from_non_owner_rejected() {
 
   const uint8_t chunk[5] = {0};
   auto r = s.onBinary(2, chunk, 5);  // client 2, not owner
-  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected),
-                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Rejected), static_cast<int>(r));
   TEST_ASSERT_TRUE(s.inProgress());  // session unaffected
 }
 
@@ -284,8 +267,7 @@ void test_after_timeout_new_client_can_start() {
   s.tick(1000 + WsUploadSession::kIdleTimeoutMs);  // aborts client 1
 
   auto r = s.onStart(2, "START:b.epub:100:/");
-  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Ok),
-                    static_cast<int>(r));
+  TEST_ASSERT_EQUAL(static_cast<int>(WsUploadSession::Result::Ok), static_cast<int>(r));
   TEST_ASSERT_EQUAL(2, s.ownerClient());
 }
 


### PR DESCRIPTION
## Summary
- Mechanical formatting-only pass across 14 files drifted from the repo \`.clang-format\` config.
- Brings clang-format CI check to green after the build job started passing (PR #28 scope uncovered these pre-existing fails once the submodule fetch was fixed).
- Removes an accidentally-committed \`.claude/scheduled_tasks.lock\` local state file.

## Scope
Files touched were exactly the set reported by the CI \`clang-format\` job:
- \`lib/I18n/I18nKeys.h\`
- \`src/SettingsList.h\`
- \`src/activities/reader/{EpubReaderActivity,ReaderSettingsActivity}.cpp\`
- \`src/lifecycle/{ActivityRouter.cpp,ActivityRouter.h,Nav.h}\`
- \`src/main.cpp\`
- \`src/network/CrossPointWebServer.cpp\`
- \`src/network/ws/{WsUploadSession.cpp,WsUploadSession.h}\`
- \`test/test_activity_router/test_main.cpp\`
- \`test/test_settings_gateway/test_main.cpp\`
- \`test/test_ws_upload_session/test_main.cpp\`

Whitespace / brace placement / argument wrap only. No semantic change.

## Test plan
- [x] \`pio test -e test_host\` — 37/37 pass
- [x] \`pio run -e default\` — builds clean
- [ ] CI \`clang-format\` job goes green
- [ ] \`cppcheck\` still fails on pre-existing \`EpubReaderActivity.cpp:402\` null-check warning — separate PR

## Follow-up
Next PR fixes the remaining cppcheck warning to bring CI fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)