### PR TITLE
fix(reader): guard epub null-deref in buildStatusBarLayout

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -393,7 +393,7 @@ EpubReaderActivity::StatusBarLayout EpubReaderActivity::buildStatusBarLayout(con
                                                                   "ERS", "status width");
   layout.topReservedHeight = topReservedHeight;
   layout.bottomReservedHeight = bottomReservedHeight;
-  if (!SETTINGS.statusBarEnabled || !section) {
+  if (!SETTINGS.statusBarEnabled || !section || !epub) {
     return layout;
   }
 
@@ -423,7 +423,7 @@ EpubReaderActivity::StatusBarLayout EpubReaderActivity::buildStatusBarLayout(con
         renderer.getTextWidth(SETTINGS.getStatusBarFontId(), layout.chapterPercentageText.c_str());
   }
 
-  if (SETTINGS.statusBarShowBookPageCounter && epub && section->pageCount > 0) {
+  if (SETTINGS.statusBarShowBookPageCounter && section->pageCount > 0) {
     // Estimate total book pages by extrapolating the current chapter's
     // pages-per-byte ratio to the entire book. This is approximate —
     // chapters with images or code have different density than prose,


### PR DESCRIPTION
## Summary
- cppcheck flagged [EpubReaderActivity.cpp:402](src/activities/reader/EpubReaderActivity.cpp#L402) as a possible null-deref of \`epub\` inside \`buildStatusBarLayout\`.
- The early-return on line 396 guarded \`!section\` but not \`!epub\`, yet line 402 dereferences \`epub\` unconditionally.
- A later block (line 426) already redundantly re-checks \`&& epub\` — which is what cppcheck's \"redundant-or-nullptr\" heuristic caught.

## Fix
- Add \`!epub\` to the early-return guard (line 396).
- Drop the now-redundant \`&& epub\` from line 426.

Behavior preserved — the book-page-counter block was already no-op when \`epub\` was null, via the outer guard's new coverage.

## Test plan
- [x] \`pio run -e default\` — builds clean
- [ ] CI \`cppcheck\` job goes green

## Context
This warning pre-dated [#28](https://github.com/diogo7dias/crosspoint-reader-DX34/pull/28) — it was masked by the build job failing on a broken submodule fetch. Once the submodule issue was resolved, cppcheck surfaced. Filed separately from the mechanical clang-format pass in [#29](https://github.com/diogo7dias/crosspoint-reader-DX34/pull/29) so the one real code change gets its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)