### PR TITLE
fix(ble): detect gamepad buttons; subset-bind remap (#32)

### DIFF
--- a/src/BleHidManager.cpp
+++ b/src/BleHidManager.cpp
@@ -220,8 +220,9 @@ bool BleHidManager::subscribeToHid() {
       protoMode->writeValue(&bootMode, 1);
     }
 
-    bootKbChar->subscribe(
-        true, [this](NimBLERemoteCharacteristic*, uint8_t* data, size_t len, bool) { onHidReport(data, len); });
+    bootKbChar->subscribe(true, [this](NimBLERemoteCharacteristic*, uint8_t* data, size_t len, bool) {
+      onHidReport(data, len, /*isBootKeyboard=*/true);
+    });
     LOG_INF("BLE", "Subscribed to Boot Keyboard Input");
     return true;
   }
@@ -233,8 +234,9 @@ bool BleHidManager::subscribeToHid() {
   if (chars) {
     for (auto* chr : *chars) {
       if (chr->getUUID() == kHidReportCharUuid && chr->canNotify()) {
-        chr->subscribe(
-            true, [this](NimBLERemoteCharacteristic*, uint8_t* data, size_t len, bool) { onHidReport(data, len); });
+        chr->subscribe(true, [this](NimBLERemoteCharacteristic*, uint8_t* data, size_t len, bool) {
+          onHidReport(data, len, /*isBootKeyboard=*/false);
+        });
         subscribed = true;
         LOG_INF("BLE", "Subscribed to HID Report characteristic");
       }
@@ -259,6 +261,8 @@ void BleHidManager::disconnect() {
     edgeReleased[i] = false;
   }
   portEXIT_CRITICAL(&stateLock);
+
+  resetReportBaseline();
 }
 
 // --- Auto-reconnect ---
@@ -284,15 +288,16 @@ void BleHidManager::tryAutoReconnect() {
 
 // --- HID Report Parsing ---
 
-void BleHidManager::onHidReport(const uint8_t* data, size_t len) {
+void BleHidManager::onHidReport(const uint8_t* data, size_t len, bool isBootKeyboard) {
   if (len == 0) return;
 
-  // Boot keyboard protocol: 8 bytes
-  // [0] = modifier keys, [1] = reserved, [2..7] = up to 6 keycodes
-  if (len >= 3 && len <= 8) {
+  // Boot keyboard protocol: [0]=modifiers, [1]=reserved, [2..7]=up to 6 keycodes.
+  // Only apply this interpretation to reports that actually came from the boot-
+  // keyboard input characteristic — a gamepad's generic report may coincidentally
+  // be 3–8 bytes long and would be garbled if parsed as boot keyboard.
+  if (isBootKeyboard && len >= 3 && len <= 8) {
     uint8_t modifiers = data[0];
 
-    // Collect all active keycodes from this report
     uint16_t activeKeycodes[6] = {};
     int activeCount = 0;
     for (size_t i = 2; i < len; i++) {
@@ -305,11 +310,8 @@ void BleHidManager::onHidReport(const uint8_t* data, size_t len) {
       lastRawKeycode = fullCode;
     }
 
-    // Fix #6: In capture mode, don't translate — just store raw keycode
     if (captureMode) return;
 
-    // Fix #7: Per-key release — compute which buttons SHOULD be pressed,
-    // then set all others to false.
     portENTER_CRITICAL(&stateLock);
     bool shouldBePressed[kButtonCount] = {};
     for (int k = 0; k < activeCount; k++) {
@@ -326,38 +328,68 @@ void BleHidManager::onHidReport(const uint8_t* data, size_t len) {
     return;
   }
 
-  // Generic HID report (gamepads, custom remotes)
-  if (len >= 1) {
-    uint16_t rawCode = data[0];
-    if (len >= 2) {
-      rawCode = (uint16_t)((data[1] << 8) | data[0]);
-    }
+  // Generic HID report (gamepads, custom remotes). We don't parse the HID
+  // descriptor, so we can't know which bytes encode buttons vs analog axes.
+  // Instead, snapshot the previous report and diff byte-by-byte: each bit that
+  // transitions 0→1 is treated as a button-press event, 1→0 as release. The
+  // synthesized keycode encodes the (byte, bit) position, which users bind in
+  // the remap activity the same way they'd bind a keyboard key.
+  const size_t n = (len < kMaxDiffBytes) ? len : kMaxDiffBytes;
 
-    if (rawCode != 0) {
-      lastRawKeycode = rawCode;
-    }
+  if (!reportBaselined) {
+    memcpy(lastReport, data, n);
+    for (size_t i = n; i < kMaxDiffBytes; i++) lastReport[i] = 0;
+    lastReportLen = n;
+    reportBaselined = true;
+    return;
+  }
 
-    if (captureMode) return;
+  const size_t diffLen = (n > lastReportLen) ? n : lastReportLen;
 
-    portENTER_CRITICAL(&stateLock);
-    if (rawCode != 0) {
-      // Set the matching button, clear others
-      bool shouldBePressed[kButtonCount] = {};
-      for (int b = 0; b < kButtonCount; b++) {
-        if (SETTINGS.bleKeyMap[b] == rawCode && rawCode != 0) {
-          shouldBePressed[b] = true;
+  portENTER_CRITICAL(&stateLock);
+  for (size_t i = 0; i < diffLen && i < kMaxDiffBytes; i++) {
+    const uint8_t prev = (i < lastReportLen) ? lastReport[i] : 0;
+    const uint8_t curr = (i < n) ? data[i] : 0;
+    if (prev == curr) continue;
+
+    const uint8_t rising = (uint8_t)(curr & ~prev);
+    const uint8_t falling = (uint8_t)(prev & ~curr);
+
+    for (uint8_t b = 0; b < 8; b++) {
+      const uint8_t mask = (uint8_t)(1u << b);
+      const uint16_t code = (uint16_t)(0xF000u | ((i & 0x1Fu) << 3) | (b & 0x07u));
+      if (rising & mask) {
+        if (captureMode) {
+          lastRawKeycode = code;
+        } else {
+          for (int bt = 0; bt < kButtonCount; bt++) {
+            if (SETTINGS.bleKeyMap[bt] == code) currentPressed[bt] = true;
+          }
         }
       }
-      for (int b = 0; b < kButtonCount; b++) {
-        currentPressed[b] = shouldBePressed[b];
-      }
-    } else {
-      for (int b = 0; b < kButtonCount; b++) {
-        currentPressed[b] = false;
+      if ((falling & mask) && !captureMode) {
+        for (int bt = 0; bt < kButtonCount; bt++) {
+          if (SETTINGS.bleKeyMap[bt] == code) currentPressed[bt] = false;
+        }
       }
     }
-    portEXIT_CRITICAL(&stateLock);
   }
+  portEXIT_CRITICAL(&stateLock);
+
+  memcpy(lastReport, data, n);
+  for (size_t i = n; i < kMaxDiffBytes; i++) lastReport[i] = 0;
+  lastReportLen = n;
+}
+
+void BleHidManager::resetReportBaseline() {
+  // Seed baseline with all-zeros and mark as baselined. Gamepads over BLE HID
+  // typically only notify on state change, so if we wait for the first report
+  // to establish the baseline the user's first button press is silently
+  // consumed. Starting from a zeroed baseline makes the first real report
+  // produce correct rising-edge events relative to the resting state.
+  for (size_t i = 0; i < kMaxDiffBytes; i++) lastReport[i] = 0;
+  lastReportLen = kMaxDiffBytes;
+  reportBaselined = true;
 }
 
 void BleHidManager::translateKeycode(uint16_t keycode, bool pressed) {
@@ -434,6 +466,10 @@ void BleHidManager::setCaptureMode(bool enabled) {
       currentPressed[i] = false;
     }
     portEXIT_CRITICAL(&stateLock);
+    // Rebaseline the diff buffer so the next generic report establishes the
+    // resting state — otherwise the first user-initiated edge might be missed
+    // (or an old edge from before capture began would fire).
+    resetReportBaseline();
   }
 }
 

--- a/src/BleHidManager.h
+++ b/src/BleHidManager.h
@@ -97,11 +97,24 @@ class BleHidManager {
   mutable portMUX_TYPE stateLock = portMUX_INITIALIZER_UNLOCKED;
 
   // HID report callback — translates raw reports into button state.
-  void onHidReport(const uint8_t* data, size_t len);
+  // isBootKeyboard = true for reports from UUID 0x2A22 (boot-keyboard input);
+  // false for generic report chars (UUID 0x2A4D) like gamepads and custom remotes,
+  // which may use arbitrary bit-field layouts we can't know a priori.
+  void onHidReport(const uint8_t* data, size_t len, bool isBootKeyboard);
 
   // Raw keycode for remap capture mode.
   volatile uint16_t lastRawKeycode = 0;
   bool captureMode = false;
+
+  // Baseline of the last generic HID report. We diff each incoming report
+  // against this to find rising/falling bits — that lets us treat arbitrary
+  // gamepad button layouts as synthetic keycodes (0xF000 | byte<<3 | bit)
+  // without parsing the HID descriptor.
+  static constexpr size_t kMaxDiffBytes = 20;
+  uint8_t lastReport[kMaxDiffBytes] = {};
+  size_t lastReportLen = 0;
+  bool reportBaselined = false;
+  void resetReportBaseline();
 
   // Button state arrays (protected by stateLock).
   bool currentPressed[kButtonCount] = {};

--- a/src/activities/settings/BleRemapActivity.cpp
+++ b/src/activities/settings/BleRemapActivity.cpp
@@ -16,14 +16,18 @@ constexpr unsigned long kErrorDisplayMs = 1500;
 
 void BleRemapActivity::onEnter() {
   Activity::onEnter();
-  currentStep = 0;
-  for (int i = 0; i < kRoleCount; i++) tempMapping[i] = 0;
+  uiMode = UiMode::List;
+  selectedRole = 0;
+  for (int i = 0; i < kRoleCount; i++) {
+    tempMapping[i] = SETTINGS.bleKeyMap[i];
+  }
   errorMessage.clear();
   errorUntil = 0;
 
-  // Enable capture mode so BLE keycodes are NOT translated into button
-  // presses (which would leak into MappedInputManager side-button checks).
-  BLE_HID.setCaptureMode(true);
+  // Capture mode stays OFF while in the list; we only flip it on when the
+  // user enters Waiting, so browsing the list with a still-connected BT device
+  // doesn't accidentally trigger mapped presses.
+  BLE_HID.setCaptureMode(false);
   requestUpdate();
 }
 
@@ -33,7 +37,6 @@ void BleRemapActivity::onExit() {
 }
 
 void BleRemapActivity::loop() {
-  // Clear error banner after timeout
   if (errorUntil > 0 && millis() > errorUntil) {
     errorMessage.clear();
     errorUntil = 0;
@@ -41,46 +44,90 @@ void BleRemapActivity::loop() {
     return;
   }
 
-  // Use MappedInputManager for side buttons — safe because capture mode
-  // prevents BLE keypresses from reaching button translation.
-  // Side Up: reset to defaults and exit
-  if (mappedInput.wasPressed(MappedInputManager::Button::Up)) {
-    for (int i = 0; i < CrossPointSettings::BLE_KEY_MAP_SIZE; i++) {
-      SETTINGS.bleKeyMap[i] = 0;
+  switch (uiMode) {
+    case UiMode::List: {
+      // Side Up: reset every binding to unassigned (does not exit)
+      if (mappedInput.wasPressed(MappedInputManager::Button::Up)) {
+        for (int i = 0; i < kRoleCount; i++) tempMapping[i] = 0;
+        requestUpdate();
+        return;
+      }
+
+      // Side Down: cancel — exit without saving
+      if (mappedInput.wasPressed(MappedInputManager::Button::Down)) {
+        onBack();
+        return;
+      }
+
+      // Back: save whatever subset is currently bound and exit
+      if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+        commitMapping();
+        SETTINGS.saveToFile();
+        onBack();
+        return;
+      }
+
+      // Left/Right: move selection through the role list
+      if (mappedInput.wasPressed(MappedInputManager::Button::Right)) {
+        selectedRole = (uint8_t)((selectedRole + 1) % kRoleCount);
+        requestUpdate();
+      }
+      if (mappedInput.wasPressed(MappedInputManager::Button::Left)) {
+        selectedRole = (uint8_t)((selectedRole + kRoleCount - 1) % kRoleCount);
+        requestUpdate();
+      }
+
+      // PageForward: begin capture for the selected role
+      if (mappedInput.wasPressed(MappedInputManager::Button::PageForward) ||
+          mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+        uiMode = UiMode::Waiting;
+        BLE_HID.setCaptureMode(true);
+        BLE_HID.clearCapturedKeycode();
+        requestUpdate();
+      }
+
+      // PageBack: clear this role's binding
+      if (mappedInput.wasPressed(MappedInputManager::Button::PageBack)) {
+        tempMapping[selectedRole] = 0;
+        requestUpdate();
+      }
+      break;
     }
-    SETTINGS.saveToFile();
-    onBack();
-    return;
+
+    case UiMode::Waiting: {
+      // Back: cancel wait, return to list without changing the binding
+      if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+        BLE_HID.setCaptureMode(false);
+        uiMode = UiMode::List;
+        requestUpdate();
+        return;
+      }
+
+      // Side Down: also acts as "cancel capture"
+      if (mappedInput.wasPressed(MappedInputManager::Button::Down)) {
+        BLE_HID.setCaptureMode(false);
+        uiMode = UiMode::List;
+        requestUpdate();
+        return;
+      }
+
+      // Wait for a BLE keypress
+      const uint16_t rawCode = BLE_HID.captureRawKeycode();
+      if (rawCode == 0) return;
+
+      if (!validateUnassigned(rawCode)) {
+        requestUpdate();
+        return;
+      }
+
+      tempMapping[selectedRole] = rawCode;
+      BLE_HID.setCaptureMode(false);
+      BLE_HID.clearCapturedKeycode();
+      uiMode = UiMode::List;
+      requestUpdate();
+      break;
+    }
   }
-
-  // Side Down: cancel without saving
-  if (mappedInput.wasPressed(MappedInputManager::Button::Down)) {
-    onBack();
-    return;
-  }
-
-  // Wait for BLE keypress
-  uint16_t rawCode = BLE_HID.captureRawKeycode();
-  if (rawCode == 0) return;
-
-  // Validate not already assigned to another role
-  if (!validateUnassigned(rawCode)) {
-    requestUpdate();
-    return;
-  }
-
-  tempMapping[currentStep] = rawCode;
-  currentStep++;
-
-  if (currentStep >= kRoleCount) {
-    applyMapping();
-    SETTINGS.saveToFile();
-    onBack();
-    return;
-  }
-
-  BLE_HID.clearCapturedKeycode();
-  requestUpdate();
 }
 
 void BleRemapActivity::render(Activity::RenderLock&&) {
@@ -88,11 +135,14 @@ void BleRemapActivity::render(Activity::RenderLock&&) {
   const auto pageWidth = renderer.getScreenWidth();
 
   renderer.drawCenteredText(UI_12_FONT_ID, 15, tr(STR_BLE_REMAP_TITLE), true, EpdFontFamily::REGULAR);
-  renderer.drawCenteredText(UI_10_FONT_ID, 40, tr(STR_BLE_REMAP_PROMPT));
+
+  if (uiMode == UiMode::Waiting) {
+    renderer.drawCenteredText(UI_10_FONT_ID, 40, tr(STR_BLE_REMAP_PROMPT));
+  }
 
   for (uint8_t i = 0; i < kRoleCount; i++) {
     const int y = 70 + i * 28;
-    const bool isSelected = (i == currentStep);
+    const bool isSelected = (i == selectedRole);
 
     if (isSelected) {
       renderer.fillRect(0, y - 2, pageWidth - 1, 28);
@@ -109,13 +159,19 @@ void BleRemapActivity::render(Activity::RenderLock&&) {
     renderer.drawCenteredText(UI_10_FONT_ID, 250, errorMessage.c_str(), true);
   }
 
-  renderer.drawCenteredText(SMALL_FONT_ID, 270, tr(STR_BLE_REMAP_RESET_HINT), true);
-  renderer.drawCenteredText(SMALL_FONT_ID, 290, tr(STR_BLE_REMAP_CANCEL_HINT), true);
+  // Hints differ by mode. Line-wrap them so the existing two-line layout covers both.
+  if (uiMode == UiMode::List) {
+    renderer.drawCenteredText(SMALL_FONT_ID, 270, "Left/Right: Select  PageFwd: Bind  PageBack: Clear", true);
+    renderer.drawCenteredText(SMALL_FONT_ID, 290, "Back: Save & exit  Side Up: Reset  Side Down: Cancel", true);
+  } else {
+    renderer.drawCenteredText(SMALL_FONT_ID, 270, "Press a button on the BT device", true);
+    renderer.drawCenteredText(SMALL_FONT_ID, 290, "Back or Side Down: cancel", true);
+  }
 
   renderer.displayBuffer();
 }
 
-void BleRemapActivity::applyMapping() {
+void BleRemapActivity::commitMapping() {
   for (int i = 0; i < kRoleCount; i++) {
     SETTINGS.bleKeyMap[i] = tempMapping[i];
   }
@@ -123,17 +179,21 @@ void BleRemapActivity::applyMapping() {
 
 bool BleRemapActivity::validateUnassigned(uint16_t keycode) {
   for (uint8_t i = 0; i < kRoleCount; i++) {
-    if (tempMapping[i] == keycode && i != currentStep && tempMapping[i] != 0) {
-      errorMessage = tr(STR_ALREADY_ASSIGNED);
-      errorUntil = millis() + kErrorDisplayMs;
+    if (tempMapping[i] == keycode && i != selectedRole && tempMapping[i] != 0) {
+      showError(tr(STR_ALREADY_ASSIGNED));
       return false;
     }
   }
   return true;
 }
 
-const char* BleRemapActivity::getRoleName(uint8_t step) const {
-  switch (step) {
+void BleRemapActivity::showError(const char* msg) {
+  errorMessage = msg;
+  errorUntil = millis() + kErrorDisplayMs;
+}
+
+const char* BleRemapActivity::getRoleName(uint8_t role) const {
+  switch (role) {
     case 0:
       return tr(STR_BACK);
     case 1:
@@ -152,6 +212,16 @@ const char* BleRemapActivity::getRoleName(uint8_t step) const {
 }
 
 const char* BleRemapActivity::getKeycodeName(uint16_t keycode) {
+  // Synthetic gamepad codes from the generic-report diff parser: 0xF000 | byte<<3 | bit.
+  // Display as "Btn <byte>.<bit>" so the user has a stable label for any bit-field button.
+  if ((keycode & 0xFF00u) == 0xF000u) {
+    static char btnBuf[16];
+    const uint8_t byteIdx = (uint8_t)((keycode >> 3) & 0x1Fu);
+    const uint8_t bitIdx = (uint8_t)(keycode & 0x07u);
+    snprintf(btnBuf, sizeof(btnBuf), "Btn %u.%u", (unsigned)byteIdx, (unsigned)bitIdx);
+    return btnBuf;
+  }
+
   const uint8_t key = keycode & 0xFF;
   const uint8_t mod = (keycode >> 8) & 0xFF;
 

--- a/src/activities/settings/BleRemapActivity.h
+++ b/src/activities/settings/BleRemapActivity.h
@@ -16,15 +16,23 @@ class BleRemapActivity final : public Activity {
   void render(Activity::RenderLock&&) override;
 
  private:
+  enum class UiMode : uint8_t {
+    List,      // Navigate the role list, pick one to bind or clear
+    Waiting,   // Waiting for a BLE keypress to bind to selectedRole
+  };
+
   const std::function<void()> onBack;
-  uint8_t currentStep = 0;
   static constexpr uint8_t kRoleCount = 6;
+
+  UiMode uiMode = UiMode::List;
+  uint8_t selectedRole = 0;
   uint16_t tempMapping[kRoleCount] = {};
   unsigned long errorUntil = 0;
   std::string errorMessage;
 
-  void applyMapping();
+  void commitMapping();
   bool validateUnassigned(uint16_t keycode);
-  const char* getRoleName(uint8_t step) const;
+  void showError(const char* msg);
+  const char* getRoleName(uint8_t role) const;
   static const char* getKeycodeName(uint16_t keycode);
 };


### PR DESCRIPTION
## Summary
- Fixes [#32](https://github.com/diogo7dias/crosspoint-reader-DX34/issues/32). Generic HID reports (0x2A4D) were mis-parsed as boot-keyboard whenever length fell in 3–8 bytes, so IINE Gamebrick button bit-fields came through as garbage and remap never captured anything.
- `onHidReport` now takes an `isBootKeyboard` flag routed from the subscription site, and generic reports run through a byte-diff path that synthesizes `0xF000 | byte<<3 | bit` keycodes for rising/falling edges. Works for any bit-field gamepad layout without parsing HID descriptors.
- `BleRemapActivity` is now a list where the user picks which of Back/Confirm/Left/Right/Up/Down to bind. Binding 1–6 of them is fine; unbound roles emit no presses. Left/Right navigate, PageForward or Confirm starts capture, PageBack clears a row, Back saves+exits, Side Up resets all, Side Down cancels.

## Test plan
- [ ] Reporter test: pair IINE Gamebrick via BT, enter Remap, press a button on the gamepad — a "Btn X.Y" label should appear next to the selected role.
- [ ] Bind only 2–3 buttons, exit via Back, verify unbound roles do nothing when pressed on device.
- [ ] Side Up clears all rows without exiting; Side Down cancels without saving.
- [ ] Existing BT keyboards (boot-keyboard path) still behave as before — keycodes shown by name, no regression in binding UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)