### PR TITLE
chore(persist): enable PERSIST_V2 in debug env

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -100,6 +100,9 @@ build_flags =
   ; SLEEP_V2 routes sleep wallpaper playlist through sleep::WallpaperPlaylist
   ; (RFC #22). Debug env only until ≥1 release cycle stable.
   -DSLEEP_V2=1
+  ; PERSIST_V2 routes CrossPointState through persist::AppStateStore (RFC #20).
+  ; Debug env only until ≥1 release cycle stable.
+  -DPERSIST_V2=1
 
 
 [env:gh_release]


### PR DESCRIPTION
## Summary
- Flips `PERSIST_V2=1` in `[env:debug]` only (matches existing V2-flag pattern: LIFECYCLE_V2, WEBSERVER_V2, SLEEP_V2).
- Routes `CrossPointState` through `persist::AppStateStore` per RFC #20; infra landed in #34.
- Default / release envs unchanged — legacy persist path until ≥1 release cycle stable on debug.

## Test plan
- [x] `pio run -e debug` compiles clean (RAM 33.6%, Flash 76.8%)
- [ ] Device smoke on debug build: settings save/load, state.json write after sleep/reboot, no corrupted .tmp
- [ ] Soak ≥1 release cycle before promoting to `[env:default]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)