### PR TITLE
chore(persist): promote PERSIST_V2 to base (all envs)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -32,6 +32,9 @@ build_flags =
 # https://libexpat.github.io/doc/api/latest/#XML_GE
   -DXML_GE=0
   -DXML_CONTEXT_BYTES=1024
+  ; PERSIST_V2 routes CrossPointState through persist::AppStateStore (RFC #20).
+  ; Promoted to base after debug smoke (PR #35); applies to all envs.
+  -DPERSIST_V2=1
   -std=gnu++2a
 # Enable UTF-8 long file names in SdFat
   -DUSE_UTF8_LONG_NAMES=1
@@ -100,9 +103,6 @@ build_flags =
   ; SLEEP_V2 routes sleep wallpaper playlist through sleep::WallpaperPlaylist
   ; (RFC #22). Debug env only until ≥1 release cycle stable.
   -DSLEEP_V2=1
-  ; PERSIST_V2 routes CrossPointState through persist::AppStateStore (RFC #20).
-  ; Debug env only until ≥1 release cycle stable.
-  -DPERSIST_V2=1
 
 
 [env:gh_release]


### PR DESCRIPTION
## Summary
- Promotes `PERSIST_V2=1` from `[env:debug]` to `[base]`, so **all** envs (default, gh_release, gh_release_rc, slim) build with `persist::AppStateStore` routing `CrossPointState` writes.
- Follows debug smoke in #35: zero `[PST]`/`[CPS]` errors across ~1h uptime, 26 known-issue `[JSN]` stuck-tmp errors in legacy settings path (unrelated, fallback working).
- Soak period skipped per user decision.

## Scope
- `state.json` only (RFC #20). `settings.json` stays on legacy `JsonSettingsIO` until its own RFC.
- Legacy `saveState`/state path is now dead code at compile time — `CrossPointState::getInstance()` always returns `AppStateStore`.

## Test plan
- [x] `pio run -e default` SUCCESS (RAM 33.6%, Flash 76.8%)
- [x] `pio run -e gh_release` SUCCESS
- [x] `pio run -e gh_release_rc` SUCCESS (with test RC hash)
- [x] `pio run -e slim` SUCCESS (RAM 33.5%, Flash 75.8%)
- [ ] Post-merge: flash default build to device, verify state persistence after reboot
- [ ] Next release cut: users receive V2 binary — monitor feedback channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)