### PR TITLE
refactor(reader): ReaderProgressTracker + EpubProgressSink (RFC #21 stage 1)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -164,6 +164,7 @@ build_src_filter =
   +<persist/InMemoryFileIO.cpp>
   +<persist/PersistManager.cpp>
   +<persist/CrossPointStateJson.cpp>
+  +<activities/reader/ReaderProgressTracker.cpp>
 build_flags =
   -std=gnu++2a
   -DUNIT_TEST_HOST=1

--- a/src/activities/reader/EpubProgressSink.cpp
+++ b/src/activities/reader/EpubProgressSink.cpp
@@ -1,9 +1,9 @@
 #include "EpubProgressSink.h"
 
-#include <cstdint>
-
 #include <HalStorage.h>
 #include <Logging.h>
+
+#include <cstdint>
 
 namespace crosspoint {
 namespace reader {

--- a/src/activities/reader/EpubProgressSink.cpp
+++ b/src/activities/reader/EpubProgressSink.cpp
@@ -1,0 +1,62 @@
+#include "EpubProgressSink.h"
+
+#include <cstdint>
+
+#include <HalStorage.h>
+#include <Logging.h>
+
+namespace crosspoint {
+namespace reader {
+
+bool EpubProgressSink::write(const ReaderPosition& pos) {
+  if (spineCount_ <= 0) {
+    return false;
+  }
+
+  int32_t spineIndex = pos.spineIndex;
+  int32_t page = pos.page;
+  int32_t pageCount = pos.pageCount;
+  if (spineIndex < 0) {
+    spineIndex = 0;
+  } else if (spineIndex >= spineCount_) {
+    spineIndex = spineCount_ - 1;
+    page = UINT16_MAX;  // legacy past-end sentinel preserved for byte-compat
+  }
+  if (pageCount <= 0) {
+    pageCount = 1;
+  }
+
+  const std::string progPath = cachePath_ + "/progress.bin";
+  const std::string tmpPath = cachePath_ + "/progress_tmp.bin";
+
+  if (Storage.exists(tmpPath.c_str())) {
+    Storage.remove(tmpPath.c_str());
+  }
+
+  HalFile f;
+  if (!Storage.openFileForWrite("ERS", tmpPath.c_str(), f)) {
+    LOG_ERR("ERS", "Could not save progress!");
+    return false;
+  }
+
+  uint8_t data[6];
+  data[0] = static_cast<uint8_t>(spineIndex & 0xFF);
+  data[1] = static_cast<uint8_t>((spineIndex >> 8) & 0xFF);
+  data[2] = static_cast<uint8_t>(page & 0xFF);
+  data[3] = static_cast<uint8_t>((page >> 8) & 0xFF);
+  data[4] = static_cast<uint8_t>(pageCount & 0xFF);
+  data[5] = static_cast<uint8_t>((pageCount >> 8) & 0xFF);
+  f.write(data, 6);
+  f.close();
+
+  if (Storage.exists(progPath.c_str())) {
+    Storage.remove(progPath.c_str());
+  }
+  Storage.rename(tmpPath.c_str(), progPath.c_str());
+
+  LOG_DBG("ERS", "Progress saved: Chapter %d, Page %d", static_cast<int>(spineIndex), static_cast<int>(page));
+  return true;
+}
+
+}  // namespace reader
+}  // namespace crosspoint

--- a/src/activities/reader/EpubProgressSink.h
+++ b/src/activities/reader/EpubProgressSink.h
@@ -28,8 +28,7 @@ class EpubProgressSink : public IProgressSink {
   // `cachePath` is the per-book cache dir (no trailing slash), e.g.
   // /.crosspoint/cache/<fingerprint>. `spineCount` is the total number of
   // spine items — used for bounds clamping matching legacy behaviour.
-  EpubProgressSink(std::string cachePath, int spineCount)
-      : cachePath_(std::move(cachePath)), spineCount_(spineCount) {}
+  EpubProgressSink(std::string cachePath, int spineCount) : cachePath_(std::move(cachePath)), spineCount_(spineCount) {}
 
   // IProgressSink
   bool write(const ReaderPosition& p) override;

--- a/src/activities/reader/EpubProgressSink.h
+++ b/src/activities/reader/EpubProgressSink.h
@@ -1,0 +1,45 @@
+/**
+ * @file EpubProgressSink.h
+ * @brief SD-backed IProgressSink producing byte-identical EPUB progress.bin.
+ *
+ * Wraps the atomic-write pattern previously inlined in
+ * EpubReaderActivity::saveProgress (lines 1610-1656 before RFC #21 stage 1):
+ *   write → /<cache>/progress_tmp.bin
+ *   remove /<cache>/progress.bin
+ *   rename tmp → progress.bin
+ *
+ * Layout (6 bytes LE): spineIndex[u16], page[u16], pageCount[u16]. Clamps
+ * spineIndex into [0, spineCount); if clamped to spineCount-1, page → UINT16_MAX
+ * (legacy "past end" sentinel). pageCount <= 0 coerced to 1.
+ *
+ * Device-only — pulls HalStorage. Host tests use a fake sink.
+ */
+#pragma once
+
+#include <string>
+
+#include "ReaderProgressTracker.h"
+
+namespace crosspoint {
+namespace reader {
+
+class EpubProgressSink : public IProgressSink {
+ public:
+  // `cachePath` is the per-book cache dir (no trailing slash), e.g.
+  // /.crosspoint/cache/<fingerprint>. `spineCount` is the total number of
+  // spine items — used for bounds clamping matching legacy behaviour.
+  EpubProgressSink(std::string cachePath, int spineCount)
+      : cachePath_(std::move(cachePath)), spineCount_(spineCount) {}
+
+  // IProgressSink
+  bool write(const ReaderPosition& p) override;
+
+  void setSpineCount(int n) { spineCount_ = n; }
+
+ private:
+  std::string cachePath_;
+  int spineCount_;
+};
+
+}  // namespace reader
+}  // namespace crosspoint

--- a/src/activities/reader/ReaderProgressTracker.cpp
+++ b/src/activities/reader/ReaderProgressTracker.cpp
@@ -1,0 +1,56 @@
+#include "ReaderProgressTracker.h"
+
+namespace crosspoint {
+namespace reader {
+
+void ReaderProgressTracker::seed(const ReaderPosition& loaded) {
+  lastObserved_ = loaded;
+  lastSaved_ = loaded;
+  dirty_ = false;
+  lastChangeMs_ = 0;
+}
+
+void ReaderProgressTracker::observe(const ReaderPosition& rendered, uint32_t nowMs) {
+  if (rendered == lastObserved_) {
+    return;
+  }
+  lastObserved_ = rendered;
+  if (rendered != lastSaved_) {
+    dirty_ = true;
+    lastChangeMs_ = nowMs;
+  } else {
+    // User navigated back to the last-persisted position before the debounce
+    // window fired — nothing left to write.
+    dirty_ = false;
+  }
+}
+
+bool ReaderProgressTracker::flush(uint32_t nowMs, bool force) {
+  if (!dirty_) {
+    return false;
+  }
+  if (!force && (nowMs - lastChangeMs_) < debounceMs_) {
+    return false;
+  }
+  if (!sink_.write(lastObserved_)) {
+    // Leave dirty set so next flush retries. Don't advance lastSaved.
+    return false;
+  }
+  lastSaved_ = lastObserved_;
+  dirty_ = false;
+  flushCount_++;
+  return true;
+}
+
+void ReaderProgressTracker::snapshotForReset(const ReaderPosition& p, uint32_t nowMs) {
+  // Preserve any pending write before we clobber observed/saved; otherwise a
+  // debounced page-turn could be dropped on KOReader pull.
+  flush(nowMs, /*force=*/true);
+  lastObserved_ = p;
+  lastSaved_ = p;
+  dirty_ = false;
+  lastChangeMs_ = nowMs;
+}
+
+}  // namespace reader
+}  // namespace crosspoint

--- a/src/activities/reader/ReaderProgressTracker.h
+++ b/src/activities/reader/ReaderProgressTracker.h
@@ -1,0 +1,94 @@
+/**
+ * @file ReaderProgressTracker.h
+ * @brief Debounce + dirty-tracking for reader progress persistence.
+ *
+ * Design (RFC #21 Stage 1 — EPUB reader decomposition, code-only):
+ *   - Owns the 6 lastObserved/lastSaved fields + progressDirty + debounce clock
+ *     that were scattered across EpubReaderActivity (9 call sites, 7-line dance
+ *     at each site with easy-to-miss bookkeeping).
+ *   - Format-neutral: Position carries {spineIndex, page, pageCount}; single-page
+ *     formats (TXT/XTC) leave spineIndex=0, pageCount=1. Byte layout of
+ *     progress.bin lives in the Sink, not here.
+ *   - Host-testable: IProgressSink is a pure virtual (prod writes SD via HalStorage,
+ *     tests use an in-memory vector). No SdFat, no Arduino, no millis().
+ *   - Caller passes nowMs every call. Tracker does not read the clock itself.
+ *
+ * Intentionally NOT wired into EpubReaderActivity in this stage. Stage 2 (next
+ * PR) integrates behind READER_V2 gate with V1 parallel; stage 3 migrates
+ * TxtReaderActivity + XtcReaderActivity which duplicate the same pattern.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace crosspoint {
+namespace reader {
+
+struct ReaderPosition {
+  int32_t spineIndex = -1;
+  int32_t page = -1;
+  int32_t pageCount = -1;
+
+  bool operator==(const ReaderPosition& o) const {
+    return spineIndex == o.spineIndex && page == o.page && pageCount == o.pageCount;
+  }
+  bool operator!=(const ReaderPosition& o) const { return !(*this == o); }
+};
+
+// Sink = "where do the bytes go". Production impl (EpubProgressSink) writes
+// the 6-byte progress.bin via HalStorage; host tests use a fake that records
+// into std::vector<ReaderPosition>.
+struct IProgressSink {
+  virtual ~IProgressSink() = default;
+  // Write the position. Returns true on success. Called at most once per
+  // tracker flush; sink is responsible for atomic rename / crash safety.
+  virtual bool write(const ReaderPosition& p) = 0;
+};
+
+class ReaderProgressTracker {
+ public:
+  static constexpr uint32_t kDefaultDebounceMs = 800;
+
+  explicit ReaderProgressTracker(IProgressSink& sink, uint32_t debounceMs = kDefaultDebounceMs)
+      : sink_(sink), debounceMs_(debounceMs) {}
+
+  // Seed after boot-time load. Clears dirty; both observed and saved snap to
+  // `loaded`. No write performed.
+  void seed(const ReaderPosition& loaded);
+
+  // Report what the reader just rendered. If it differs from lastSaved, the
+  // tracker becomes dirty and the debounce timer (anchored at nowMs) starts.
+  // Idempotent when `rendered` matches lastObserved.
+  void observe(const ReaderPosition& rendered, uint32_t nowMs);
+
+  // Flush to the sink if dirty AND (force OR debounce elapsed). Returns true
+  // iff a write was performed AND succeeded. On success, lastSaved = last
+  // observed and dirty is cleared.
+  bool flush(uint32_t nowMs, bool force);
+
+  // Bridge for out-of-band resets (e.g. KOReaderSync pulling a new position
+  // from the server): flushes any pending write first (force), then reseeds
+  // lastObserved + lastSaved to `p`. After this call, dirty is false.
+  void snapshotForReset(const ReaderPosition& p, uint32_t nowMs);
+
+  bool dirty() const { return dirty_; }
+  const ReaderPosition& lastObserved() const { return lastObserved_; }
+  const ReaderPosition& lastSaved() const { return lastSaved_; }
+  uint32_t debounceMs() const { return debounceMs_; }
+  size_t flushCount() const { return flushCount_; }
+
+  void setDebounceMs(uint32_t ms) { debounceMs_ = ms; }
+
+ private:
+  IProgressSink& sink_;
+  uint32_t debounceMs_;
+  ReaderPosition lastObserved_{};
+  ReaderPosition lastSaved_{};
+  bool dirty_ = false;
+  uint32_t lastChangeMs_ = 0;
+  size_t flushCount_ = 0;
+};
+
+}  // namespace reader
+}  // namespace crosspoint

--- a/test/test_reader_progress_tracker/test_main.cpp
+++ b/test/test_reader_progress_tracker/test_main.cpp
@@ -1,0 +1,226 @@
+/**
+ * Host-side tests for reader::ReaderProgressTracker. Pure state-machine +
+ * debounce tests; no ESP32 / SD / Hal. Runs via:
+ *   pio test -e test_host -f test_reader_progress_tracker
+ */
+#include <unity.h>
+
+#include <vector>
+
+#include "activities/reader/ReaderProgressTracker.h"
+
+using crosspoint::reader::IProgressSink;
+using crosspoint::reader::ReaderPosition;
+using crosspoint::reader::ReaderProgressTracker;
+
+namespace {
+
+// Records every successful write. Fails on demand to exercise retry path.
+class FakeSink : public IProgressSink {
+ public:
+  std::vector<ReaderPosition> writes;
+  bool nextWriteFails = false;
+
+  bool write(const ReaderPosition& p) override {
+    if (nextWriteFails) {
+      nextWriteFails = false;
+      return false;
+    }
+    writes.push_back(p);
+    return true;
+  }
+};
+
+ReaderPosition P(int32_t s, int32_t pg, int32_t pc) { return ReaderPosition{s, pg, pc}; }
+
+}  // namespace
+
+void setUp() {}
+void tearDown() {}
+
+// Seed snaps observed+saved, clears dirty, no write.
+void test_seed_no_write() {
+  FakeSink sink;
+  ReaderProgressTracker t(sink, 800);
+  t.seed(P(3, 10, 20));
+  TEST_ASSERT_EQUAL_INT(0u, sink.writes.size());
+  TEST_ASSERT_FALSE(t.dirty());
+  TEST_ASSERT_EQUAL_INT(3, t.lastSaved().spineIndex);
+  TEST_ASSERT_EQUAL_INT(10, t.lastSaved().page);
+}
+
+// Observing same position never marks dirty or writes.
+void test_observe_same_position_noop() {
+  FakeSink sink;
+  ReaderProgressTracker t(sink, 800);
+  t.seed(P(0, 0, 1));
+  t.observe(P(0, 0, 1), 100);
+  t.observe(P(0, 0, 1), 500);
+  TEST_ASSERT_FALSE(t.dirty());
+  TEST_ASSERT_FALSE(t.flush(10'000, false));
+  TEST_ASSERT_EQUAL_INT(0u, sink.writes.size());
+}
+
+// Rapid observes coalesce into one write under debounce.
+void test_debounce_coalesces() {
+  FakeSink sink;
+  ReaderProgressTracker t(sink, 1000);
+  t.seed(P(0, 0, 10));
+
+  t.observe(P(0, 1, 10), 100);
+  t.observe(P(0, 2, 10), 200);
+  t.observe(P(0, 3, 10), 300);
+  TEST_ASSERT_TRUE(t.dirty());
+
+  // Not enough time passed since lastChangeMs (300). 900 < 300+1000.
+  TEST_ASSERT_FALSE(t.flush(900, false));
+  TEST_ASSERT_EQUAL_INT(0u, sink.writes.size());
+
+  // Debounce elapsed.
+  TEST_ASSERT_TRUE(t.flush(1500, false));
+  TEST_ASSERT_EQUAL_INT(1u, sink.writes.size());
+  TEST_ASSERT_EQUAL_INT(3, sink.writes[0].page);
+  TEST_ASSERT_FALSE(t.dirty());
+}
+
+// Force flush bypasses debounce.
+void test_force_flush_ignores_debounce() {
+  FakeSink sink;
+  ReaderProgressTracker t(sink, 5000);
+  t.seed(P(0, 0, 1));
+
+  t.observe(P(1, 5, 10), 100);
+  TEST_ASSERT_TRUE(t.flush(100, /*force=*/true));
+  TEST_ASSERT_EQUAL_INT(1u, sink.writes.size());
+  TEST_ASSERT_EQUAL_INT(1, sink.writes[0].spineIndex);
+  TEST_ASSERT_EQUAL_INT(5, sink.writes[0].page);
+}
+
+// Clean tracker (never dirtied) does not write on force flush.
+void test_flush_clean_is_noop() {
+  FakeSink sink;
+  ReaderProgressTracker t(sink, 800);
+  t.seed(P(2, 4, 8));
+  TEST_ASSERT_FALSE(t.flush(10'000, true));
+  TEST_ASSERT_EQUAL_INT(0u, sink.writes.size());
+}
+
+// After flush, re-observing the same rendered position must NOT re-dirty.
+void test_no_redirty_after_flush() {
+  FakeSink sink;
+  ReaderProgressTracker t(sink, 500);
+  t.seed(P(0, 0, 10));
+
+  t.observe(P(0, 5, 10), 100);
+  TEST_ASSERT_TRUE(t.flush(1000, true));
+  TEST_ASSERT_EQUAL_INT(1u, sink.writes.size());
+
+  t.observe(P(0, 5, 10), 2000);
+  TEST_ASSERT_FALSE(t.dirty());
+  TEST_ASSERT_FALSE(t.flush(3000, true));
+  TEST_ASSERT_EQUAL_INT(1u, sink.writes.size());
+}
+
+// Observing back-and-forth between current render and lastSaved clears dirty:
+// if rendered matches lastSaved, tracker is not dirty.
+void test_observe_matching_saved_not_dirty() {
+  FakeSink sink;
+  ReaderProgressTracker t(sink, 500);
+  t.seed(P(0, 5, 10));
+
+  t.observe(P(0, 6, 10), 100);    // dirty
+  TEST_ASSERT_TRUE(t.dirty());
+  t.observe(P(0, 5, 10), 200);    // matches saved — dirty stays false after
+  TEST_ASSERT_FALSE(t.dirty());
+  TEST_ASSERT_FALSE(t.flush(5000, true));
+  TEST_ASSERT_EQUAL_INT(0u, sink.writes.size());
+}
+
+// Failed write leaves tracker dirty so next flush retries.
+void test_failed_write_retries() {
+  FakeSink sink;
+  ReaderProgressTracker t(sink, 100);
+  t.seed(P(0, 0, 1));
+
+  t.observe(P(0, 1, 1), 0);
+  sink.nextWriteFails = true;
+  TEST_ASSERT_FALSE(t.flush(1000, true));   // write failed
+  TEST_ASSERT_TRUE(t.dirty());              // still dirty
+  TEST_ASSERT_EQUAL_INT(0u, sink.writes.size());
+
+  TEST_ASSERT_TRUE(t.flush(2000, true));    // retry succeeds
+  TEST_ASSERT_FALSE(t.dirty());
+  TEST_ASSERT_EQUAL_INT(1u, sink.writes.size());
+  TEST_ASSERT_EQUAL_INT(1, sink.writes[0].page);
+}
+
+// snapshotForReset flushes any pending write THEN seeds new position.
+// Simulates KOReaderSync pulling a new position while a debounced turn is
+// pending.
+void test_snapshot_for_reset_flushes_then_seeds() {
+  FakeSink sink;
+  ReaderProgressTracker t(sink, 5000);
+  t.seed(P(0, 10, 100));
+
+  t.observe(P(0, 11, 100), 100);   // local page turn, debounced
+  TEST_ASSERT_TRUE(t.dirty());
+
+  // KOReader says jump to chapter 2, page 0.
+  t.snapshotForReset(P(2, 0, 0), 200);
+
+  // Pending local turn was persisted before swap — zero data loss.
+  TEST_ASSERT_EQUAL_INT(1u, sink.writes.size());
+  TEST_ASSERT_EQUAL_INT(11, sink.writes[0].page);
+
+  // Tracker now reports the KOReader position as both observed and saved.
+  TEST_ASSERT_FALSE(t.dirty());
+  TEST_ASSERT_EQUAL_INT(2, t.lastSaved().spineIndex);
+  TEST_ASSERT_EQUAL_INT(0, t.lastSaved().page);
+
+  // Subsequent observe of same post-reset position stays clean.
+  t.observe(P(2, 0, 0), 300);
+  TEST_ASSERT_FALSE(t.dirty());
+}
+
+// After seed, setting new debounce takes effect on next observe.
+void test_set_debounce_changes_window() {
+  FakeSink sink;
+  ReaderProgressTracker t(sink, 5000);
+  t.seed(P(0, 0, 1));
+
+  t.setDebounceMs(100);
+  t.observe(P(0, 1, 1), 0);
+  TEST_ASSERT_FALSE(t.flush(50, false));
+  TEST_ASSERT_TRUE(t.flush(200, false));
+  TEST_ASSERT_EQUAL_INT(1u, sink.writes.size());
+}
+
+// flushCount tracks successful writes.
+void test_flush_count() {
+  FakeSink sink;
+  ReaderProgressTracker t(sink, 100);
+  t.seed(P(0, 0, 1));
+
+  for (int i = 1; i <= 3; ++i) {
+    t.observe(P(0, i, 1), i * 1000);
+    TEST_ASSERT_TRUE(t.flush(i * 1000 + 200, false));
+  }
+  TEST_ASSERT_EQUAL_INT(3u, t.flushCount());
+  TEST_ASSERT_EQUAL_INT(3u, sink.writes.size());
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_seed_no_write);
+  RUN_TEST(test_observe_same_position_noop);
+  RUN_TEST(test_debounce_coalesces);
+  RUN_TEST(test_force_flush_ignores_debounce);
+  RUN_TEST(test_flush_clean_is_noop);
+  RUN_TEST(test_no_redirty_after_flush);
+  RUN_TEST(test_observe_matching_saved_not_dirty);
+  RUN_TEST(test_failed_write_retries);
+  RUN_TEST(test_snapshot_for_reset_flushes_then_seeds);
+  RUN_TEST(test_set_debounce_changes_window);
+  RUN_TEST(test_flush_count);
+  return UNITY_END();
+}

--- a/test/test_reader_progress_tracker/test_main.cpp
+++ b/test/test_reader_progress_tracker/test_main.cpp
@@ -128,9 +128,9 @@ void test_observe_matching_saved_not_dirty() {
   ReaderProgressTracker t(sink, 500);
   t.seed(P(0, 5, 10));
 
-  t.observe(P(0, 6, 10), 100);    // dirty
+  t.observe(P(0, 6, 10), 100);  // dirty
   TEST_ASSERT_TRUE(t.dirty());
-  t.observe(P(0, 5, 10), 200);    // matches saved — dirty stays false after
+  t.observe(P(0, 5, 10), 200);  // matches saved — dirty stays false after
   TEST_ASSERT_FALSE(t.dirty());
   TEST_ASSERT_FALSE(t.flush(5000, true));
   TEST_ASSERT_EQUAL_INT(0u, sink.writes.size());
@@ -144,11 +144,11 @@ void test_failed_write_retries() {
 
   t.observe(P(0, 1, 1), 0);
   sink.nextWriteFails = true;
-  TEST_ASSERT_FALSE(t.flush(1000, true));   // write failed
-  TEST_ASSERT_TRUE(t.dirty());              // still dirty
+  TEST_ASSERT_FALSE(t.flush(1000, true));  // write failed
+  TEST_ASSERT_TRUE(t.dirty());             // still dirty
   TEST_ASSERT_EQUAL_INT(0u, sink.writes.size());
 
-  TEST_ASSERT_TRUE(t.flush(2000, true));    // retry succeeds
+  TEST_ASSERT_TRUE(t.flush(2000, true));  // retry succeeds
   TEST_ASSERT_FALSE(t.dirty());
   TEST_ASSERT_EQUAL_INT(1u, sink.writes.size());
   TEST_ASSERT_EQUAL_INT(1, sink.writes[0].page);
@@ -162,7 +162,7 @@ void test_snapshot_for_reset_flushes_then_seeds() {
   ReaderProgressTracker t(sink, 5000);
   t.seed(P(0, 10, 100));
 
-  t.observe(P(0, 11, 100), 100);   // local page turn, debounced
+  t.observe(P(0, 11, 100), 100);  // local page turn, debounced
   TEST_ASSERT_TRUE(t.dirty());
 
   // KOReader says jump to chapter 2, page 0.


### PR DESCRIPTION
## Summary

First of three staged PRs delivering [#21](https://github.com/diogo7dias/crosspoint-reader-DX34/issues/21). Extracts debounce/dirty-tracking for reader progress persistence out of `EpubReaderActivity` into a format-neutral module.

- `ReaderProgressTracker` — `seed` / `observe` / `flush` / `snapshotForReset`, host-testable, no Arduino / no SD. `IProgressSink` injection seam.
- `EpubProgressSink` — writes the 6-byte `progress.bin` byte-identical to `EpubReaderActivity::saveProgress` (lines 1610-1656) so V1↔V2 stays format-compatible.
- 11 host tests: debounce coalesce, force flush, back-to-saved clears dirty, failed-write retry, KOReaderSync reset bridge, clean-flush no-op, per-call debounce tuning.

**Pure infra — not wired into any activity in this PR.** Stage 2 integrates behind `READER_V2` gate with V1 parallel class; stage 3 migrates `TxtReaderActivity` + `XtcReaderActivity` which duplicate the same 7-line save dance across 9 call sites (Epub) + 4 sites (Txt) + 4 sites (Xtc).

## Why staged

RFC proposed a single parallel `EpubReaderActivityV2` class (~2300 LOC). Staging lowers blast radius: progress path lands alone first (byte-compare gate for later stages), cache module next, highlight module last. Rollback via revert, not firmware reflash.

## Test plan

- [x] `pio test -e test_host` — all 75 host tests pass (11 new)
- [x] `pio run -e debug` — clean build
- [ ] Stage 2 will device-smoke the integration; this PR ships unused code so no device test needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)