### PR TITLE
refactor(reader): HighlightController state machine (RFC #21 stage 2)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -165,6 +165,7 @@ build_src_filter =
   +<persist/PersistManager.cpp>
   +<persist/CrossPointStateJson.cpp>
   +<activities/reader/ReaderProgressTracker.cpp>
+  +<activities/reader/HighlightController.cpp>
 build_flags =
   -std=gnu++2a
   -DUNIT_TEST_HOST=1

--- a/src/activities/reader/EpubProgressSink.cpp
+++ b/src/activities/reader/EpubProgressSink.cpp
@@ -1,9 +1,9 @@
 #include "EpubProgressSink.h"
 
-#include <cstdint>
-
 #include <HalStorage.h>
 #include <Logging.h>
+
+#include <cstdint>
 
 namespace crosspoint {
 namespace reader {

--- a/src/activities/reader/EpubProgressSink.h
+++ b/src/activities/reader/EpubProgressSink.h
@@ -28,8 +28,7 @@ class EpubProgressSink : public IProgressSink {
   // `cachePath` is the per-book cache dir (no trailing slash), e.g.
   // /.crosspoint/cache/<fingerprint>. `spineCount` is the total number of
   // spine items — used for bounds clamping matching legacy behaviour.
-  EpubProgressSink(std::string cachePath, int spineCount)
-      : cachePath_(std::move(cachePath)), spineCount_(spineCount) {}
+  EpubProgressSink(std::string cachePath, int spineCount) : cachePath_(std::move(cachePath)), spineCount_(spineCount) {}
 
   // IProgressSink
   bool write(const ReaderPosition& p) override;

--- a/src/activities/reader/HighlightController.cpp
+++ b/src/activities/reader/HighlightController.cpp
@@ -1,0 +1,218 @@
+#include "HighlightController.h"
+
+#include <algorithm>
+#include <climits>
+#include <cstdlib>
+
+namespace crosspoint {
+namespace reader {
+
+void HighlightController::clearIndices_() {
+  cursorIndex_ = 0;
+  startSpine_ = -1;
+  startPage_ = -1;
+  startWordIndex_ = -1;
+  endPage_ = -1;
+  endWordIndex_ = -1;
+  underlineStartMs_ = 0;
+}
+
+void HighlightController::enter() {
+  state_ = State::SELECT_START;
+  clearIndices_();
+  wordCachePage_ = -1;
+  words_.clear();
+  cursorIndex_ = 0;
+}
+
+void HighlightController::exit() {
+  state_ = State::NONE;
+  clearIndices_();
+  words_.clear();
+  words_.shrink_to_fit();  // mirrors legacy free-on-exit behaviour
+  wordCachePage_ = -1;
+}
+
+void HighlightController::setWordsForPage(int pageIndex, std::vector<WordPos> words) {
+  words_ = std::move(words);
+  wordCachePage_ = pageIndex;
+}
+
+void HighlightController::invalidateWordCache() {
+  wordCachePage_ = -1;
+  // NB: keep words_ populated — render will overwrite via setWordsForPage.
+  // Callers that need the storage released should call exit().
+}
+
+bool HighlightController::wordCacheValidFor(int pageIndex) const {
+  return wordCachePage_ == pageIndex;
+}
+
+void HighlightController::onPageChanged(int newPage) {
+  if (wordCachePage_ != newPage) {
+    wordCachePage_ = -1;
+  }
+}
+
+bool HighlightController::underlineTimedOut(uint32_t nowMs) const {
+  if (state_ != State::SHOW_UNDERLINE) return false;
+  return (nowMs - underlineStartMs_) >= kUnderlineTimeoutMs;
+}
+
+MoveOutcome HighlightController::moveCursor(int direction, PageContext ctx) {
+  MoveOutcome out{};
+
+  if (state_ == State::SELECT_START) {
+    if (ctx.wordCount == 0) return out;
+    int newIndex = cursorIndex_ + direction;
+    if (newIndex < 0) newIndex = 0;
+    if (newIndex >= ctx.wordCount) newIndex = ctx.wordCount - 1;
+    if (newIndex != cursorIndex_) {
+      cursorIndex_ = newIndex;
+      out.stateChanged = true;
+    }
+    return out;
+  }
+
+  if (state_ != State::SELECT_END) return out;
+
+  // Clamp stale end index against current page's word count.
+  if (endWordIndex_ >= ctx.wordCount) {
+    endWordIndex_ = ctx.wordCount > 0 ? ctx.wordCount - 1 : 0;
+  }
+
+  int newIndex = endWordIndex_ + direction;
+
+  // Forward past last word on page → next page if available.
+  if (newIndex >= ctx.wordCount) {
+    if (ctx.currentPage < ctx.pageCount - 1) {
+      out.pageDelta = +1;
+      endPage_ = ctx.currentPage + 1;
+      wordCachePage_ = -1;  // force rebuild on next render
+      endWordIndex_ = 0;
+      out.stateChanged = true;
+      return out;
+    }
+    newIndex = ctx.wordCount > 0 ? ctx.wordCount - 1 : 0;
+  }
+
+  // Backward past first word → previous page if we're past the start page.
+  if (newIndex < 0) {
+    if (ctx.currentPage > startPage_) {
+      out.pageDelta = -1;
+      endPage_ = ctx.currentPage - 1;
+      wordCachePage_ = -1;
+      // We don't know the new page's word count yet; set to INT_MAX and let
+      // the next render / clamp pull it back to wordCount-1.
+      endWordIndex_ = INT_MAX;
+      out.stateChanged = true;
+      return out;
+    }
+    if (ctx.currentPage == startPage_) {
+      newIndex = startWordIndex_;
+    } else {
+      newIndex = 0;
+    }
+  }
+
+  // On the start page, end cursor can't go before start word.
+  if (ctx.currentPage == startPage_ && newIndex < startWordIndex_) {
+    newIndex = startWordIndex_;
+  }
+
+  if (newIndex != endWordIndex_) {
+    endWordIndex_ = newIndex;
+    out.stateChanged = true;
+  }
+  return out;
+}
+
+MoveOutcome HighlightController::moveCursorLine(int direction, PageContext ctx) {
+  MoveOutcome out{};
+  if (words_.empty()) return out;
+  if (state_ != State::SELECT_START && state_ != State::SELECT_END) return out;
+
+  const bool isEnd = (state_ == State::SELECT_END);
+  const int curIdx = isEnd ? endWordIndex_ : cursorIndex_;
+  if (curIdx < 0 || curIdx >= static_cast<int>(words_.size())) return out;
+
+  const int curY = words_[curIdx].y;
+  const int curX = words_[curIdx].x;
+
+  int targetY = -1;
+  if (direction < 0) {
+    for (const auto& w : words_) {
+      if (w.y < curY && (targetY < 0 || w.y > targetY)) targetY = w.y;
+    }
+  } else {
+    for (const auto& w : words_) {
+      if (w.y > curY && (targetY < 0 || w.y < targetY)) targetY = w.y;
+    }
+  }
+
+  if (targetY < 0) {
+    // No other line exists in that direction — fall through to word-level move,
+    // which handles cross-page transitions.
+    return moveCursor(direction, ctx);
+  }
+
+  int bestIdx = -1;
+  int bestDist = INT_MAX;
+  for (int i = 0; i < static_cast<int>(words_.size()); i++) {
+    if (words_[i].y == targetY) {
+      int dist = std::abs(words_[i].x - curX);
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestIdx = i;
+      }
+    }
+  }
+  if (bestIdx < 0) return out;
+
+  if (isEnd && ctx.currentPage == startPage_ && bestIdx < startWordIndex_) {
+    bestIdx = startWordIndex_;
+  }
+
+  if (isEnd) {
+    if (bestIdx != endWordIndex_) {
+      endWordIndex_ = bestIdx;
+      out.stateChanged = true;
+    }
+  } else {
+    if (bestIdx != cursorIndex_) {
+      cursorIndex_ = bestIdx;
+      out.stateChanged = true;
+    }
+  }
+  return out;
+}
+
+MoveOutcome HighlightController::confirm(int currentSpine, int currentPage, uint32_t nowMs) {
+  MoveOutcome out{};
+
+  if (state_ == State::SELECT_START) {
+    startSpine_ = currentSpine;
+    startPage_ = currentPage;
+    startWordIndex_ = cursorIndex_;
+    endPage_ = currentPage;
+    endWordIndex_ = wordCount() - 1;
+    if (endWordIndex_ < 0) endWordIndex_ = 0;
+    state_ = State::SELECT_END;
+    out.stateChanged = true;
+    return out;
+  }
+
+  if (state_ == State::SELECT_END) {
+    out.pageDelta = startPage_ - currentPage;
+    wordCachePage_ = -1;
+    state_ = State::SHOW_UNDERLINE;
+    underlineStartMs_ = nowMs;
+    out.stateChanged = true;
+    return out;
+  }
+
+  return out;
+}
+
+}  // namespace reader
+}  // namespace crosspoint

--- a/src/activities/reader/HighlightController.cpp
+++ b/src/activities/reader/HighlightController.cpp
@@ -44,9 +44,7 @@ void HighlightController::invalidateWordCache() {
   // Callers that need the storage released should call exit().
 }
 
-bool HighlightController::wordCacheValidFor(int pageIndex) const {
-  return wordCachePage_ == pageIndex;
-}
+bool HighlightController::wordCacheValidFor(int pageIndex) const { return wordCachePage_ == pageIndex; }
 
 void HighlightController::onPageChanged(int newPage) {
   if (wordCachePage_ != newPage) {

--- a/src/activities/reader/HighlightController.h
+++ b/src/activities/reader/HighlightController.h
@@ -42,8 +42,8 @@ struct PageContext {
 };
 
 struct MoveOutcome {
-  int pageDelta = 0;         // caller adds this to section->currentPage
-  bool stateChanged = false; // caller requestUpdate()
+  int pageDelta = 0;          // caller adds this to section->currentPage
+  bool stateChanged = false;  // caller requestUpdate()
 };
 
 class HighlightController {

--- a/src/activities/reader/HighlightController.h
+++ b/src/activities/reader/HighlightController.h
@@ -1,0 +1,139 @@
+/**
+ * @file HighlightController.h
+ * @brief Text highlight / quote selection state machine + word-position cache.
+ *
+ * Design (RFC #21 Stage 2 — EPUB reader decomposition, code-only):
+ *   - Swallows the 5 highlight* indices + cursor + start/end page + word cache
+ *     currently scattered across EpubReaderActivity.
+ *   - Single chokepoint for cache invalidation: onPageChanged(). Fixes the
+ *     fragility flagged in MEMORY.md where exit paths + cursor cross-page
+ *     moves each manually reset highlightWordCachePage = -1 in 4 separate
+ *     places (lines 1791, 1804, 1901, 1954).
+ *   - Pure state machine: no GfxRenderer, no Page, no Section. Caller owns
+ *     rendering, page mutation, quote extraction (which need those). Caller
+ *     passes current page / pageCount / word count via PageContext.
+ *   - Word-position cache holds WordPos (6 bytes/word) so render overlay
+ *     can draw dashed border + underline without recomputing geometry.
+ *     Caller populates via setWordsForPage after layout finishes.
+ *
+ * Not wired into EpubReaderActivity in this stage. Stage 4 (final)
+ * integrates behind READER_V2 gate.
+ */
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace crosspoint {
+namespace reader {
+
+// Word geometry for cursor / underline rendering (matches the legacy
+// EpubReaderActivity::WordPos layout: 6 bytes/word).
+struct WordPos {
+  int16_t x = 0;
+  int16_t y = 0;
+  int16_t width = 0;
+};
+
+struct PageContext {
+  int currentPage = 0;
+  int pageCount = 0;
+  int wordCount = 0;  // words on currentPage per the cache
+};
+
+struct MoveOutcome {
+  int pageDelta = 0;         // caller adds this to section->currentPage
+  bool stateChanged = false; // caller requestUpdate()
+};
+
+class HighlightController {
+ public:
+  enum class State {
+    NONE,
+    SELECT_START,
+    SELECT_END,
+    SHOW_UNDERLINE,
+  };
+
+  static constexpr uint32_t kUnderlineTimeoutMs = 3000;
+
+  // --- Lifecycle ---
+  // Move state from NONE → SELECT_START, reset cursor/indices, clear cache.
+  void enter();
+
+  // Force back to NONE. Post-condition: state()==NONE, cursor/indices zeroed,
+  // word cache empty (and shrunk to free memory).
+  void exit();
+
+  State state() const { return state_; }
+
+  // --- Word-position cache ---
+  // Replace the cache with the geometry for `pageIndex`. Controller treats
+  // this as the authoritative word list for cursor math.
+  void setWordsForPage(int pageIndex, std::vector<WordPos> words);
+
+  // Force-invalidate the cache (e.g. page turned without render yet). Caller
+  // must refresh via setWordsForPage before next moveCursor.
+  void invalidateWordCache();
+
+  bool wordCacheValidFor(int pageIndex) const;
+  int wordCount() const { return static_cast<int>(words_.size()); }
+  const std::vector<WordPos>& words() const { return words_; }
+  int cachedPage() const { return wordCachePage_; }
+
+  // --- Cursor / selection indices ---
+  int cursorIndex() const { return cursorIndex_; }
+  int startSpine() const { return startSpine_; }
+  int startPage() const { return startPage_; }
+  int startWordIndex() const { return startWordIndex_; }
+  int endPage() const { return endPage_; }
+  int endWordIndex() const { return endWordIndex_; }
+
+  // --- Input: cursor nav ---
+  // Word-by-word cursor move. Direction = ±1.
+  // In SELECT_START: clamps to [0, wordCount-1] on current page.
+  // In SELECT_END: crosses page boundaries when reaching edge, returning
+  // pageDelta=±1. On forward cross-page, endWordIndex = 0; on backward,
+  // endWordIndex = INT_MAX (caller re-renders, refreshes cache, clamps).
+  MoveOutcome moveCursor(int direction, PageContext ctx);
+
+  // Line-based cursor move using cached word y-positions. If no other line
+  // exists in that direction, falls through to moveCursor.
+  MoveOutcome moveCursorLine(int direction, PageContext ctx);
+
+  // Confirms selection anchor or end-cursor, advancing state machine.
+  // In SELECT_START: capture start position (spine/page/word), jump end
+  // cursor to last word on page, advance to SELECT_END.
+  // In SELECT_END: request jump back to startPage (pageDelta = startPage-
+  // currentPage), invalidate cache, advance to SHOW_UNDERLINE, store
+  // nowMs for timeout.
+  MoveOutcome confirm(int currentSpine, int currentPage, uint32_t nowMs);
+
+  // --- Render-phase helpers ---
+  // Caller calls this after layout produces the page. If the page changed
+  // since last render, cache is invalidated so caller knows to rebuild.
+  void onPageChanged(int newPage);
+
+  // True iff state is SHOW_UNDERLINE AND now - startMs >= kUnderlineTimeoutMs.
+  bool underlineTimedOut(uint32_t nowMs) const;
+
+  uint32_t underlineStartMs() const { return underlineStartMs_; }
+
+ private:
+  void clearIndices_();
+
+  State state_ = State::NONE;
+  int cursorIndex_ = 0;
+  int startSpine_ = -1;
+  int startPage_ = -1;
+  int startWordIndex_ = -1;
+  int endPage_ = -1;
+  int endWordIndex_ = -1;
+  uint32_t underlineStartMs_ = 0;
+
+  std::vector<WordPos> words_;
+  int wordCachePage_ = -1;
+};
+
+}  // namespace reader
+}  // namespace crosspoint

--- a/test/test_highlight_controller/test_main.cpp
+++ b/test/test_highlight_controller/test_main.cpp
@@ -1,0 +1,281 @@
+/**
+ * Host-side tests for reader::HighlightController. State machine + cursor
+ * math only — no rendering, no Page, no SD. Runs via:
+ *   pio test -e test_host -f test_highlight_controller
+ */
+#include <unity.h>
+
+#include <climits>
+#include <vector>
+
+#include "activities/reader/HighlightController.h"
+
+using crosspoint::reader::HighlightController;
+using crosspoint::reader::MoveOutcome;
+using crosspoint::reader::PageContext;
+using crosspoint::reader::WordPos;
+
+namespace {
+std::vector<WordPos> makeWordsSingleLine(int count) {
+  std::vector<WordPos> w;
+  w.reserve(count);
+  for (int i = 0; i < count; ++i) {
+    w.push_back(WordPos{static_cast<int16_t>(10 + i * 40), 50, 30});
+  }
+  return w;
+}
+
+// Two lines of `perLine` words each, y=50 and y=90.
+std::vector<WordPos> makeWordsTwoLines(int perLine) {
+  std::vector<WordPos> w;
+  w.reserve(perLine * 2);
+  for (int line = 0; line < 2; ++line) {
+    for (int i = 0; i < perLine; ++i) {
+      w.push_back(WordPos{static_cast<int16_t>(10 + i * 40), static_cast<int16_t>(50 + line * 40), 30});
+    }
+  }
+  return w;
+}
+
+PageContext ctx(int cur, int pc, int wc) { return PageContext{cur, pc, wc}; }
+}  // namespace
+
+void setUp() {}
+void tearDown() {}
+
+// ---- enter/exit invariants ----
+void test_enter_sets_select_start() {
+  HighlightController h;
+  h.enter();
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(HighlightController::State::SELECT_START), static_cast<int>(h.state()));
+  TEST_ASSERT_EQUAL_INT(0, h.cursorIndex());
+  TEST_ASSERT_EQUAL_INT(-1, h.startPage());
+  TEST_ASSERT_EQUAL_INT(0, h.wordCount());
+}
+
+void test_exit_clears_everything() {
+  HighlightController h;
+  h.enter();
+  h.setWordsForPage(3, makeWordsSingleLine(5));
+  h.confirm(/*spine=*/2, /*page=*/3, /*nowMs=*/100);  // SELECT_START → SELECT_END
+
+  h.exit();
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(HighlightController::State::NONE), static_cast<int>(h.state()));
+  TEST_ASSERT_EQUAL_INT(0, h.cursorIndex());
+  TEST_ASSERT_EQUAL_INT(-1, h.startPage());
+  TEST_ASSERT_EQUAL_INT(-1, h.startWordIndex());
+  TEST_ASSERT_EQUAL_INT(-1, h.endPage());
+  TEST_ASSERT_EQUAL_INT(0, h.wordCount());
+  TEST_ASSERT_EQUAL_INT(-1, h.cachedPage());
+}
+
+// ---- SELECT_START cursor clamping ----
+void test_select_start_cursor_clamps() {
+  HighlightController h;
+  h.enter();
+  h.setWordsForPage(0, makeWordsSingleLine(4));
+
+  auto r1 = h.moveCursor(+1, ctx(0, 1, 4));
+  TEST_ASSERT_EQUAL_INT(0, r1.pageDelta);
+  TEST_ASSERT_EQUAL_INT(1, h.cursorIndex());
+
+  // Past the end just clamps, no page change.
+  h.moveCursor(+1, ctx(0, 1, 4));
+  h.moveCursor(+1, ctx(0, 1, 4));
+  auto r4 = h.moveCursor(+1, ctx(0, 1, 4));
+  TEST_ASSERT_EQUAL_INT(0, r4.pageDelta);
+  TEST_ASSERT_EQUAL_INT(3, h.cursorIndex());
+}
+
+// ---- Confirm transitions ----
+void test_confirm_select_start_captures_anchor() {
+  HighlightController h;
+  h.enter();
+  h.setWordsForPage(5, makeWordsSingleLine(4));
+  h.moveCursor(+1, ctx(5, 10, 4));  // cursor=1
+  h.moveCursor(+1, ctx(5, 10, 4));  // cursor=2
+
+  auto r = h.confirm(/*spine=*/7, /*page=*/5, /*nowMs=*/100);
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(HighlightController::State::SELECT_END), static_cast<int>(h.state()));
+  TEST_ASSERT_EQUAL_INT(7, h.startSpine());
+  TEST_ASSERT_EQUAL_INT(5, h.startPage());
+  TEST_ASSERT_EQUAL_INT(2, h.startWordIndex());
+  TEST_ASSERT_EQUAL_INT(5, h.endPage());
+  TEST_ASSERT_EQUAL_INT(3, h.endWordIndex());  // last word on 4-word page
+  TEST_ASSERT_TRUE(r.stateChanged);
+  TEST_ASSERT_EQUAL_INT(0, r.pageDelta);
+}
+
+void test_confirm_select_end_jumps_back_and_starts_timer() {
+  HighlightController h;
+  h.enter();
+  h.setWordsForPage(3, makeWordsSingleLine(6));
+  h.confirm(10, 3, 0);          // SELECT_END, endPage=3, endIdx=5
+  h.setWordsForPage(4, makeWordsSingleLine(6));
+  h.moveCursor(+1, ctx(3, 10, 6));  // pageDelta=+1 (off end), endPage=4, endIdx=0
+  // simulate caller advancing to page 4
+  auto r = h.confirm(10, 4, /*nowMs=*/2000);
+
+  TEST_ASSERT_EQUAL_INT(static_cast<int>(HighlightController::State::SHOW_UNDERLINE), static_cast<int>(h.state()));
+  TEST_ASSERT_EQUAL_INT(-1, r.pageDelta);  // 3 (startPage) - 4 (current)
+  TEST_ASSERT_EQUAL_INT(-1, h.cachedPage());  // invalidated
+  TEST_ASSERT_EQUAL_INT(2000, static_cast<int>(h.underlineStartMs()));
+}
+
+// ---- Cross-page cursor (forward) ----
+void test_end_cursor_crosses_page_forward() {
+  HighlightController h;
+  h.enter();
+  h.setWordsForPage(3, makeWordsSingleLine(4));
+  h.confirm(0, 3, 0);  // SELECT_END, endPage=3, endIdx=3 (last word)
+
+  // Page has 4 words, end cursor at 3. Another +1 must cross to page 4.
+  auto r = h.moveCursor(+1, ctx(/*current=*/3, /*pages=*/10, /*words=*/4));
+  TEST_ASSERT_EQUAL_INT(+1, r.pageDelta);
+  TEST_ASSERT_TRUE(r.stateChanged);
+  TEST_ASSERT_EQUAL_INT(4, h.endPage());
+  TEST_ASSERT_EQUAL_INT(0, h.endWordIndex());
+  TEST_ASSERT_EQUAL_INT(-1, h.cachedPage());
+}
+
+void test_end_cursor_last_page_no_cross() {
+  HighlightController h;
+  h.enter();
+  h.setWordsForPage(9, makeWordsSingleLine(3));
+  h.confirm(0, 9, 0);  // endPage=9, endIdx=2
+
+  // currentPage=9, pageCount=10 → lastPage. Can't cross.
+  auto r = h.moveCursor(+1, ctx(9, 10, 3));
+  TEST_ASSERT_EQUAL_INT(0, r.pageDelta);
+  TEST_ASSERT_EQUAL_INT(2, h.endWordIndex());  // clamped to last word
+}
+
+// ---- Cross-page cursor (backward) ----
+void test_end_cursor_crosses_page_backward() {
+  HighlightController h;
+  h.enter();
+  h.setWordsForPage(3, makeWordsSingleLine(5));
+  h.confirm(0, 3, 0);                          // SELECT_END, endPage=3, endIdx=4
+  h.setWordsForPage(4, makeWordsSingleLine(5));
+  h.moveCursor(+1, ctx(3, 10, 5));             // cross to page 4, endIdx=0
+  // simulate caller advanced to page 4 and refreshed cache
+
+  auto r = h.moveCursor(-1, ctx(4, 10, 5));
+  TEST_ASSERT_EQUAL_INT(-1, r.pageDelta);
+  TEST_ASSERT_EQUAL_INT(3, h.endPage());
+  TEST_ASSERT_EQUAL_INT(INT_MAX, h.endWordIndex());  // sentinel for next-render clamp
+  TEST_ASSERT_EQUAL_INT(-1, h.cachedPage());
+}
+
+void test_end_cursor_on_start_page_clamps_to_start_word() {
+  HighlightController h;
+  h.enter();
+  h.setWordsForPage(3, makeWordsSingleLine(6));
+  h.moveCursor(+1, ctx(3, 10, 6));
+  h.moveCursor(+1, ctx(3, 10, 6));  // cursor=2
+  h.confirm(0, 3, 0);                // startPage=3, startWord=2, SELECT_END
+
+  // End cursor was auto-set to word 5 (last on page). Drag it back.
+  for (int i = 0; i < 5; ++i) h.moveCursor(-1, ctx(3, 10, 6));
+  // Should clamp at startWordIndex=2 — can't go below start on start page.
+  TEST_ASSERT_EQUAL_INT(2, h.endWordIndex());
+
+  // Another -1 tries to go below 2. currentPage==startPage, so stays.
+  auto r = h.moveCursor(-1, ctx(3, 10, 6));
+  TEST_ASSERT_EQUAL_INT(0, r.pageDelta);
+  TEST_ASSERT_EQUAL_INT(2, h.endWordIndex());
+}
+
+// ---- Word cache ----
+void test_word_cache_set_and_invalidate() {
+  HighlightController h;
+  h.setWordsForPage(7, makeWordsSingleLine(3));
+  TEST_ASSERT_EQUAL_INT(7, h.cachedPage());
+  TEST_ASSERT_TRUE(h.wordCacheValidFor(7));
+  TEST_ASSERT_FALSE(h.wordCacheValidFor(6));
+  TEST_ASSERT_EQUAL_INT(3, h.wordCount());
+
+  h.invalidateWordCache();
+  TEST_ASSERT_FALSE(h.wordCacheValidFor(7));
+  // words_ may still be populated; caller's job to refresh.
+}
+
+void test_on_page_changed_invalidates_when_different() {
+  HighlightController h;
+  h.setWordsForPage(5, makeWordsSingleLine(3));
+  h.onPageChanged(5);
+  TEST_ASSERT_TRUE(h.wordCacheValidFor(5));
+  h.onPageChanged(6);
+  TEST_ASSERT_FALSE(h.wordCacheValidFor(6));
+}
+
+// ---- Underline timeout ----
+void test_underline_timeout() {
+  HighlightController h;
+  h.enter();
+  h.setWordsForPage(2, makeWordsSingleLine(3));
+  h.confirm(0, 2, 0);          // SELECT_END
+  h.confirm(0, 2, 1000);       // SHOW_UNDERLINE @ 1000
+
+  TEST_ASSERT_FALSE(h.underlineTimedOut(1000));
+  TEST_ASSERT_FALSE(h.underlineTimedOut(2000));
+  TEST_ASSERT_FALSE(h.underlineTimedOut(3999));
+  TEST_ASSERT_TRUE(h.underlineTimedOut(4000));   // 1000 + 3000
+  TEST_ASSERT_TRUE(h.underlineTimedOut(9999));
+}
+
+void test_underline_timeout_false_when_not_showing() {
+  HighlightController h;
+  h.enter();
+  TEST_ASSERT_FALSE(h.underlineTimedOut(UINT32_MAX));
+  h.setWordsForPage(0, makeWordsSingleLine(3));
+  h.confirm(0, 0, 0);  // SELECT_END
+  TEST_ASSERT_FALSE(h.underlineTimedOut(UINT32_MAX));
+}
+
+// ---- Line-based cursor ----
+void test_line_move_nearest_x_on_target_line() {
+  HighlightController h;
+  h.enter();
+  h.setWordsForPage(0, makeWordsTwoLines(4));  // y=50 (0..3), y=90 (4..7)
+  // cursor at word 1 (x=50, y=50)
+  h.moveCursor(+1, ctx(0, 1, 8));
+  TEST_ASSERT_EQUAL_INT(1, h.cursorIndex());
+
+  auto r = h.moveCursorLine(+1, ctx(0, 1, 8));
+  TEST_ASSERT_TRUE(r.stateChanged);
+  // Target line has words at x=10,50,90,130. Closest to x=50 is word 5 (x=50).
+  TEST_ASSERT_EQUAL_INT(5, h.cursorIndex());
+}
+
+void test_line_move_no_line_falls_through_to_word() {
+  HighlightController h;
+  h.enter();
+  h.setWordsForPage(0, makeWordsSingleLine(4));
+  // Single line only — moving up/down has no target; falls through to moveCursor.
+  h.moveCursor(+1, ctx(0, 1, 4));  // cursor=1
+  auto r = h.moveCursorLine(+1, ctx(0, 1, 4));
+  // Fallthrough advances by 1 in SELECT_START within-page.
+  TEST_ASSERT_EQUAL_INT(2, h.cursorIndex());
+  TEST_ASSERT_TRUE(r.stateChanged);
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_enter_sets_select_start);
+  RUN_TEST(test_exit_clears_everything);
+  RUN_TEST(test_select_start_cursor_clamps);
+  RUN_TEST(test_confirm_select_start_captures_anchor);
+  RUN_TEST(test_confirm_select_end_jumps_back_and_starts_timer);
+  RUN_TEST(test_end_cursor_crosses_page_forward);
+  RUN_TEST(test_end_cursor_last_page_no_cross);
+  RUN_TEST(test_end_cursor_crosses_page_backward);
+  RUN_TEST(test_end_cursor_on_start_page_clamps_to_start_word);
+  RUN_TEST(test_word_cache_set_and_invalidate);
+  RUN_TEST(test_on_page_changed_invalidates_when_different);
+  RUN_TEST(test_underline_timeout);
+  RUN_TEST(test_underline_timeout_false_when_not_showing);
+  RUN_TEST(test_line_move_nearest_x_on_target_line);
+  RUN_TEST(test_line_move_no_line_falls_through_to_word);
+  return UNITY_END();
+}

--- a/test/test_highlight_controller/test_main.cpp
+++ b/test/test_highlight_controller/test_main.cpp
@@ -110,14 +110,14 @@ void test_confirm_select_end_jumps_back_and_starts_timer() {
   HighlightController h;
   h.enter();
   h.setWordsForPage(3, makeWordsSingleLine(6));
-  h.confirm(10, 3, 0);          // SELECT_END, endPage=3, endIdx=5
+  h.confirm(10, 3, 0);  // SELECT_END, endPage=3, endIdx=5
   h.setWordsForPage(4, makeWordsSingleLine(6));
   h.moveCursor(+1, ctx(3, 10, 6));  // pageDelta=+1 (off end), endPage=4, endIdx=0
   // simulate caller advancing to page 4
   auto r = h.confirm(10, 4, /*nowMs=*/2000);
 
   TEST_ASSERT_EQUAL_INT(static_cast<int>(HighlightController::State::SHOW_UNDERLINE), static_cast<int>(h.state()));
-  TEST_ASSERT_EQUAL_INT(-1, r.pageDelta);  // 3 (startPage) - 4 (current)
+  TEST_ASSERT_EQUAL_INT(-1, r.pageDelta);     // 3 (startPage) - 4 (current)
   TEST_ASSERT_EQUAL_INT(-1, h.cachedPage());  // invalidated
   TEST_ASSERT_EQUAL_INT(2000, static_cast<int>(h.underlineStartMs()));
 }
@@ -155,9 +155,9 @@ void test_end_cursor_crosses_page_backward() {
   HighlightController h;
   h.enter();
   h.setWordsForPage(3, makeWordsSingleLine(5));
-  h.confirm(0, 3, 0);                          // SELECT_END, endPage=3, endIdx=4
+  h.confirm(0, 3, 0);  // SELECT_END, endPage=3, endIdx=4
   h.setWordsForPage(4, makeWordsSingleLine(5));
-  h.moveCursor(+1, ctx(3, 10, 5));             // cross to page 4, endIdx=0
+  h.moveCursor(+1, ctx(3, 10, 5));  // cross to page 4, endIdx=0
   // simulate caller advanced to page 4 and refreshed cache
 
   auto r = h.moveCursor(-1, ctx(4, 10, 5));
@@ -173,7 +173,7 @@ void test_end_cursor_on_start_page_clamps_to_start_word() {
   h.setWordsForPage(3, makeWordsSingleLine(6));
   h.moveCursor(+1, ctx(3, 10, 6));
   h.moveCursor(+1, ctx(3, 10, 6));  // cursor=2
-  h.confirm(0, 3, 0);                // startPage=3, startWord=2, SELECT_END
+  h.confirm(0, 3, 0);               // startPage=3, startWord=2, SELECT_END
 
   // End cursor was auto-set to word 5 (last on page). Drag it back.
   for (int i = 0; i < 5; ++i) h.moveCursor(-1, ctx(3, 10, 6));
@@ -214,13 +214,13 @@ void test_underline_timeout() {
   HighlightController h;
   h.enter();
   h.setWordsForPage(2, makeWordsSingleLine(3));
-  h.confirm(0, 2, 0);          // SELECT_END
-  h.confirm(0, 2, 1000);       // SHOW_UNDERLINE @ 1000
+  h.confirm(0, 2, 0);     // SELECT_END
+  h.confirm(0, 2, 1000);  // SHOW_UNDERLINE @ 1000
 
   TEST_ASSERT_FALSE(h.underlineTimedOut(1000));
   TEST_ASSERT_FALSE(h.underlineTimedOut(2000));
   TEST_ASSERT_FALSE(h.underlineTimedOut(3999));
-  TEST_ASSERT_TRUE(h.underlineTimedOut(4000));   // 1000 + 3000
+  TEST_ASSERT_TRUE(h.underlineTimedOut(4000));  // 1000 + 3000
   TEST_ASSERT_TRUE(h.underlineTimedOut(9999));
 }
 

--- a/test/test_reader_progress_tracker/test_main.cpp
+++ b/test/test_reader_progress_tracker/test_main.cpp
@@ -128,9 +128,9 @@ void test_observe_matching_saved_not_dirty() {
   ReaderProgressTracker t(sink, 500);
   t.seed(P(0, 5, 10));
 
-  t.observe(P(0, 6, 10), 100);    // dirty
+  t.observe(P(0, 6, 10), 100);  // dirty
   TEST_ASSERT_TRUE(t.dirty());
-  t.observe(P(0, 5, 10), 200);    // matches saved — dirty stays false after
+  t.observe(P(0, 5, 10), 200);  // matches saved — dirty stays false after
   TEST_ASSERT_FALSE(t.dirty());
   TEST_ASSERT_FALSE(t.flush(5000, true));
   TEST_ASSERT_EQUAL_INT(0u, sink.writes.size());
@@ -144,11 +144,11 @@ void test_failed_write_retries() {
 
   t.observe(P(0, 1, 1), 0);
   sink.nextWriteFails = true;
-  TEST_ASSERT_FALSE(t.flush(1000, true));   // write failed
-  TEST_ASSERT_TRUE(t.dirty());              // still dirty
+  TEST_ASSERT_FALSE(t.flush(1000, true));  // write failed
+  TEST_ASSERT_TRUE(t.dirty());             // still dirty
   TEST_ASSERT_EQUAL_INT(0u, sink.writes.size());
 
-  TEST_ASSERT_TRUE(t.flush(2000, true));    // retry succeeds
+  TEST_ASSERT_TRUE(t.flush(2000, true));  // retry succeeds
   TEST_ASSERT_FALSE(t.dirty());
   TEST_ASSERT_EQUAL_INT(1u, sink.writes.size());
   TEST_ASSERT_EQUAL_INT(1, sink.writes[0].page);
@@ -162,7 +162,7 @@ void test_snapshot_for_reset_flushes_then_seeds() {
   ReaderProgressTracker t(sink, 5000);
   t.seed(P(0, 10, 100));
 
-  t.observe(P(0, 11, 100), 100);   // local page turn, debounced
+  t.observe(P(0, 11, 100), 100);  // local page turn, debounced
   TEST_ASSERT_TRUE(t.dirty());
 
   // KOReader says jump to chapter 2, page 0.


### PR DESCRIPTION
## Summary

Stage 2 of [#21](https://github.com/diogo7dias/crosspoint-reader-DX34/issues/21). Extracts the 4-state highlight/quote selection machine (`NONE → SELECT_START → SELECT_END → SHOW_UNDERLINE`) out of `EpubReaderActivity` into a host-testable module.

**Fixes MEMORY.md-flagged fragility**: cache invalidation was previously scattered across 4 sites in `EpubReaderActivity` (`highlightWordCachePage = -1` at lines 1791, 1804, 1901, 1954). Controller now has a single chokepoint (`onPageChanged` / `invalidateWordCache`) so a forgotten reset can no longer leak stale selection state on exit or cross-page nav.

- `HighlightController` — state, cursor/start/end indices, word-geometry cache, `moveCursor` (within-page + cross-page), `moveCursorLine` (nearest-x with fallback), `confirm` transitions, underline timeout.
- Host-testable: no `GfxRenderer` / no `Page` / no `Section`. `MoveOutcome` tells caller when to change page (`section->currentPage += pageDelta`) and when to `requestUpdate`. Rendering + quote extraction stay in activity (they touch `Page`/`renderer`).
- 15 host tests: enter/exit invariants, cursor clamping, cross-page transitions (forward + backward), start-page word clamp, underline timeout (kUnderlineTimeoutMs = 3000ms), word-cache set/invalidate, line-based navigation fall-through.

## Stacking

Stacked on [#37](https://github.com/diogo7dias/crosspoint-reader-DX34/pull/37) (stage 1). Merge #37 first or rebase this branch onto main after #37 merges — `platformio.ini` will conflict trivially (both add lines to `build_src_filter`).

**Pure infra — not wired into any activity in this PR.** Stage 3 = `SectionPageCache` (cache + pending-nav). Stage 4 = wire all three into `EpubReaderActivityV2` behind `READER_V2` gate.

## Test plan

- [x] \`pio test -e test_host\` — all 90 host tests pass (15 new)
- [x] \`pio run -e debug\` — clean build, flash usage unchanged (confirms dead code)
- [ ] Stage 4 will device-smoke the integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)