### PR TITLE
refactor(reader): SectionPageCache + PendingNav (RFC #21 stage 3)

### DIFF
--- a/src/activities/reader/SectionPageCache.h
+++ b/src/activities/reader/SectionPageCache.h
@@ -1,0 +1,187 @@
+/**
+ * @file SectionPageCache.h
+ * @brief 3-page sliding window + pending-nav bundle for the reader.
+ *
+ * Design (RFC #21 Stage 3 — EPUB reader decomposition, code-only):
+ *   - Absorbs pageCache[3] + pageCacheSpineIndex + clearPageCache +
+ *     getCachedPage + loadAndCachePage + refreshPageCacheWindow from
+ *     EpubReaderActivity (lines 115-116, 246-322).
+ *   - Also carries PendingNav (pendingPercentJump + pendingSpineProgress +
+ *     pendingAnchor, RFC #21 lines 1483-1500) as a passive bundle — the
+ *     cache is the natural owner since the block runs exactly when a new
+ *     section loads and its cache is empty. Resolution logic stays in the
+ *     activity (it needs Section to compute the target page).
+ *   - Templated on PageT so host tests can use a stub Page type without
+ *     pulling in HalStorage / Epub headers.
+ *
+ * Not wired into EpubReaderActivity in this stage. Stage 4 integrates
+ * behind READER_V2 gate with V1 parallel.
+ */
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace crosspoint {
+namespace reader {
+
+struct PendingNav {
+  bool hasPercentJump = false;
+  float spineProgress = 0.0f;   // 0..1 within the target spine item
+  bool hasAnchor = false;
+  std::string anchor;           // element id (e.g. "#chap3")
+
+  bool empty() const { return !hasPercentJump && !hasAnchor; }
+  void clear() {
+    hasPercentJump = false;
+    spineProgress = 0.0f;
+    hasAnchor = false;
+    anchor.clear();
+  }
+};
+
+template <typename PageT>
+class SectionPageCache {
+ public:
+  using PagePtr = std::shared_ptr<PageT>;
+  using PageLoader = std::function<PagePtr(int pageIndex)>;
+
+  static constexpr size_t kWindow = 3;
+
+  // --- Lifecycle ---
+  // Attach to a spine. Does not load anything; clears prior entries.
+  void attach(int spineIndex) {
+    clearEntries_();
+    spineIndex_ = spineIndex;
+  }
+
+  // Drop all entries and the spine association.
+  void detach() {
+    clearEntries_();
+    spineIndex_ = -1;
+  }
+
+  // Same as detach() but preserves spine index. Used on page-load failure
+  // to force a clean rebuild without abandoning the current spine.
+  void clear() { clearEntries_(); }
+
+  int spineIndex() const { return spineIndex_; }
+
+  // --- Lookup ---
+  // Returns the cached page for `pageIndex` on the current spine, or nullptr.
+  // Returns nullptr if the cache's spineIndex does not match `expectedSpine`.
+  PagePtr get(int pageIndex, int expectedSpine) const {
+    if (spineIndex_ != expectedSpine) return {};
+    for (const auto& e : entries_) {
+      if (e.pageIndex == pageIndex && e.page) return e.page;
+    }
+    return {};
+  }
+
+  bool contains(int pageIndex) const {
+    for (const auto& e : entries_) {
+      if (e.pageIndex == pageIndex && e.page) return true;
+    }
+    return false;
+  }
+
+  int entryCount() const {
+    int n = 0;
+    for (const auto& e : entries_) {
+      if (e.page) ++n;
+    }
+    return n;
+  }
+
+  // --- Insert ---
+  // Adds `pageIndex → page` to the window. If `pageIndex` is already cached,
+  // the entry is refreshed in place (no eviction). Otherwise the oldest slot
+  // rotates out (entries shift: [1]→[0], [2]→[1], new into [2]).
+  void insert(int pageIndex, PagePtr page) {
+    if (!page) return;
+    for (auto& e : entries_) {
+      if (e.pageIndex == pageIndex) {
+        e.page = std::move(page);
+        return;
+      }
+    }
+    entries_[0] = std::move(entries_[1]);
+    entries_[1] = std::move(entries_[2]);
+    entries_[2] = Entry{pageIndex, std::move(page)};
+  }
+
+  // --- Window slide ---
+  // Rebuilds the window centered on `centerPage`. Slots map to
+  // [centerPage-1, centerPage, centerPage+1]. Out-of-bounds slots
+  // (< 0 or >= sectionPageCount) are left empty.
+  //
+  // `currentPage` is injected as the centerPage entry (saves a reload).
+  // Neighbours are first looked up in the current cache; on miss, `loader`
+  // is invoked.
+  //
+  // If centerPage is out of bounds, cache is cleared.
+  void refreshWindow(int centerPage, PagePtr currentPage, int sectionPageCount, const PageLoader& loader) {
+    if (centerPage < 0 || centerPage >= sectionPageCount) {
+      clearEntries_();
+      return;
+    }
+
+    std::array<Entry, kWindow> next{};
+    const int targets[kWindow] = {centerPage - 1, centerPage, centerPage + 1};
+
+    for (size_t i = 0; i < kWindow; ++i) {
+      const int t = targets[i];
+      if (t < 0 || t >= sectionPageCount) continue;
+
+      PagePtr p;
+      if (t == centerPage) {
+        p = currentPage;
+      } else {
+        p = getRaw_(t);
+        if (!p && loader) p = loader(t);
+      }
+      next[i] = Entry{t, std::move(p)};
+    }
+    entries_ = std::move(next);
+  }
+
+  // --- Pending-nav bundle ---
+  void setPending(PendingNav nav) { pending_ = std::move(nav); }
+  void clearPending() { pending_.clear(); }
+  bool hasPending() const { return !pending_.empty(); }
+  const PendingNav& pending() const { return pending_; }
+  PendingNav& mutablePending() { return pending_; }
+
+ private:
+  struct Entry {
+    int pageIndex = -1;
+    PagePtr page;
+  };
+
+  // Non-spine-checked lookup used during window slide (we may be
+  // transitioning and the spine has not yet been re-attached).
+  PagePtr getRaw_(int pageIndex) const {
+    for (const auto& e : entries_) {
+      if (e.pageIndex == pageIndex && e.page) return e.page;
+    }
+    return {};
+  }
+
+  void clearEntries_() {
+    for (auto& e : entries_) {
+      e.pageIndex = -1;
+      e.page.reset();
+    }
+  }
+
+  std::array<Entry, kWindow> entries_{};
+  int spineIndex_ = -1;
+  PendingNav pending_{};
+};
+
+}  // namespace reader
+}  // namespace crosspoint

--- a/src/activities/reader/SectionPageCache.h
+++ b/src/activities/reader/SectionPageCache.h
@@ -31,9 +31,9 @@ namespace reader {
 
 struct PendingNav {
   bool hasPercentJump = false;
-  float spineProgress = 0.0f;   // 0..1 within the target spine item
+  float spineProgress = 0.0f;  // 0..1 within the target spine item
   bool hasAnchor = false;
-  std::string anchor;           // element id (e.g. "#chap3")
+  std::string anchor;  // element id (e.g. "#chap3")
 
   bool empty() const { return !hasPercentJump && !hasAnchor; }
   void clear() {

--- a/test/test_section_page_cache/test_main.cpp
+++ b/test/test_section_page_cache/test_main.cpp
@@ -1,0 +1,303 @@
+/**
+ * Host-side tests for reader::SectionPageCache<PageT>. Templated on PageT
+ * so host tests use a stub FakePage without pulling in HalStorage / Epub.
+ * Runs via:  pio test -e test_host -f test_section_page_cache
+ */
+#include <unity.h>
+
+#include <memory>
+#include <set>
+#include <utility>
+
+#include "activities/reader/SectionPageCache.h"
+
+using crosspoint::reader::PendingNav;
+using crosspoint::reader::SectionPageCache;
+
+namespace {
+// Minimal stand-in for ::Page. Stores the page index it was loaded for so
+// tests can verify which instance landed in which slot.
+struct FakePage {
+  int marker = -1;
+  explicit FakePage(int m) : marker(m) {}
+};
+
+using Cache = SectionPageCache<FakePage>;
+using Ptr = std::shared_ptr<FakePage>;
+
+Ptr makePage(int marker) { return std::make_shared<FakePage>(marker); }
+
+// Loader factory — returns a loader that makes a FakePage with marker=page
+// and records invocations.
+struct LoaderRec {
+  std::set<int> loaded;
+  Cache::PageLoader fn() {
+    return [this](int p) -> Ptr {
+      loaded.insert(p);
+      return makePage(p);
+    };
+  }
+};
+}  // namespace
+
+void setUp() {}
+void tearDown() {}
+
+// ---- Lifecycle ----
+void test_attach_sets_spine_clears_entries() {
+  Cache c;
+  c.insert(5, makePage(5));
+  c.attach(2);
+  TEST_ASSERT_EQUAL_INT(2, c.spineIndex());
+  TEST_ASSERT_EQUAL_INT(0, c.entryCount());
+  TEST_ASSERT_FALSE(c.contains(5));
+}
+
+void test_detach_resets_spine_and_entries() {
+  Cache c;
+  c.attach(3);
+  c.insert(1, makePage(1));
+  c.detach();
+  TEST_ASSERT_EQUAL_INT(-1, c.spineIndex());
+  TEST_ASSERT_EQUAL_INT(0, c.entryCount());
+}
+
+void test_clear_keeps_spine() {
+  Cache c;
+  c.attach(9);
+  c.insert(1, makePage(1));
+  c.clear();
+  TEST_ASSERT_EQUAL_INT(9, c.spineIndex());
+  TEST_ASSERT_EQUAL_INT(0, c.entryCount());
+}
+
+// ---- Lookup ----
+void test_get_requires_matching_spine() {
+  Cache c;
+  c.attach(2);
+  c.insert(5, makePage(5));
+  TEST_ASSERT_NOT_NULL(c.get(5, 2).get());
+  TEST_ASSERT_NULL(c.get(5, 3).get());  // wrong spine
+}
+
+void test_get_missing_page_returns_null() {
+  Cache c;
+  c.attach(0);
+  c.insert(10, makePage(10));
+  TEST_ASSERT_NULL(c.get(11, 0).get());
+}
+
+// ---- Insert ----
+void test_insert_rotates_lru_on_new_page() {
+  Cache c;
+  c.attach(0);
+  c.insert(1, makePage(1));
+  c.insert(2, makePage(2));
+  c.insert(3, makePage(3));
+  // All 3 slots filled: [1, 2, 3]
+  TEST_ASSERT_EQUAL_INT(3, c.entryCount());
+  TEST_ASSERT_TRUE(c.contains(1));
+
+  c.insert(4, makePage(4));  // rotation evicts oldest (1)
+  TEST_ASSERT_FALSE(c.contains(1));
+  TEST_ASSERT_TRUE(c.contains(2));
+  TEST_ASSERT_TRUE(c.contains(3));
+  TEST_ASSERT_TRUE(c.contains(4));
+  TEST_ASSERT_EQUAL_INT(3, c.entryCount());
+}
+
+void test_insert_existing_page_refreshes_in_place() {
+  Cache c;
+  c.attach(0);
+  c.insert(1, makePage(1));
+  c.insert(2, makePage(2));
+  c.insert(3, makePage(3));
+
+  // Re-insert page 1 with a new marker; must NOT rotate out page 2 or 3.
+  c.insert(1, makePage(100));
+  TEST_ASSERT_TRUE(c.contains(1));
+  TEST_ASSERT_TRUE(c.contains(2));
+  TEST_ASSERT_TRUE(c.contains(3));
+  TEST_ASSERT_EQUAL_INT(100, c.get(1, 0)->marker);
+}
+
+void test_insert_null_is_noop() {
+  Cache c;
+  c.attach(0);
+  c.insert(5, Ptr{});
+  TEST_ASSERT_EQUAL_INT(0, c.entryCount());
+}
+
+// ---- refreshWindow ----
+void test_refresh_window_middle_page() {
+  Cache c;
+  c.attach(0);
+  LoaderRec rec;
+
+  c.refreshWindow(/*center=*/5, /*current=*/makePage(5), /*pc=*/10, rec.fn());
+
+  TEST_ASSERT_EQUAL_INT(3, c.entryCount());
+  TEST_ASSERT_TRUE(c.contains(4));
+  TEST_ASSERT_TRUE(c.contains(5));
+  TEST_ASSERT_TRUE(c.contains(6));
+  // Loader invoked only for neighbours, not the center.
+  TEST_ASSERT_EQUAL_INT(2u, rec.loaded.size());
+  TEST_ASSERT_TRUE(rec.loaded.count(4) == 1);
+  TEST_ASSERT_TRUE(rec.loaded.count(6) == 1);
+  TEST_ASSERT_TRUE(rec.loaded.count(5) == 0);
+  // Center page is the one we injected.
+  TEST_ASSERT_EQUAL_INT(5, c.get(5, 0)->marker);
+}
+
+void test_refresh_window_first_page_leaves_prev_empty() {
+  Cache c;
+  c.attach(0);
+  LoaderRec rec;
+
+  c.refreshWindow(0, makePage(0), 10, rec.fn());
+
+  TEST_ASSERT_EQUAL_INT(2, c.entryCount());  // only 0 and 1
+  TEST_ASSERT_TRUE(c.contains(0));
+  TEST_ASSERT_TRUE(c.contains(1));
+  TEST_ASSERT_FALSE(c.contains(-1));
+  TEST_ASSERT_EQUAL_INT(1u, rec.loaded.size());
+  TEST_ASSERT_TRUE(rec.loaded.count(1) == 1);
+}
+
+void test_refresh_window_last_page_leaves_next_empty() {
+  Cache c;
+  c.attach(0);
+  LoaderRec rec;
+
+  c.refreshWindow(9, makePage(9), 10, rec.fn());
+
+  TEST_ASSERT_EQUAL_INT(2, c.entryCount());
+  TEST_ASSERT_TRUE(c.contains(8));
+  TEST_ASSERT_TRUE(c.contains(9));
+  TEST_ASSERT_FALSE(c.contains(10));
+  TEST_ASSERT_EQUAL_INT(1u, rec.loaded.size());
+  TEST_ASSERT_TRUE(rec.loaded.count(8) == 1);
+}
+
+void test_refresh_window_out_of_bounds_clears() {
+  Cache c;
+  c.attach(0);
+  c.insert(1, makePage(1));
+  LoaderRec rec;
+
+  c.refreshWindow(-1, makePage(-1), 10, rec.fn());
+  TEST_ASSERT_EQUAL_INT(0, c.entryCount());
+  TEST_ASSERT_EQUAL_INT(0u, rec.loaded.size());
+
+  c.insert(5, makePage(5));
+  c.refreshWindow(20, makePage(20), 10, rec.fn());
+  TEST_ASSERT_EQUAL_INT(0, c.entryCount());
+}
+
+void test_refresh_window_reuses_cached_neighbours() {
+  Cache c;
+  c.attach(0);
+  LoaderRec rec;
+
+  // Seed cache with 5's neighbours first.
+  c.refreshWindow(5, makePage(5), 10, rec.fn());
+  rec.loaded.clear();
+
+  // Slide to 6 — neighbour 5 is already cached; loader shouldn't re-fetch it.
+  // Only page 7 (new neighbour) needs loading. Page 4 falls out.
+  c.refreshWindow(6, makePage(6), 10, rec.fn());
+  TEST_ASSERT_TRUE(c.contains(5));
+  TEST_ASSERT_TRUE(c.contains(6));
+  TEST_ASSERT_TRUE(c.contains(7));
+  TEST_ASSERT_FALSE(c.contains(4));
+  TEST_ASSERT_EQUAL_INT(1u, rec.loaded.size());
+  TEST_ASSERT_TRUE(rec.loaded.count(7) == 1);
+}
+
+void test_refresh_window_single_page_section() {
+  Cache c;
+  c.attach(0);
+  LoaderRec rec;
+
+  c.refreshWindow(0, makePage(0), 1, rec.fn());
+  TEST_ASSERT_EQUAL_INT(1, c.entryCount());
+  TEST_ASSERT_TRUE(c.contains(0));
+  TEST_ASSERT_EQUAL_INT(0u, rec.loaded.size());
+}
+
+// ---- Pending-nav bundle ----
+void test_pending_nav_empty_by_default() {
+  Cache c;
+  TEST_ASSERT_FALSE(c.hasPending());
+  TEST_ASSERT_TRUE(c.pending().empty());
+}
+
+void test_pending_nav_percent_jump() {
+  Cache c;
+  PendingNav n;
+  n.hasPercentJump = true;
+  n.spineProgress = 0.42f;
+  c.setPending(n);
+
+  TEST_ASSERT_TRUE(c.hasPending());
+  TEST_ASSERT_TRUE(c.pending().hasPercentJump);
+  TEST_ASSERT_EQUAL_FLOAT(0.42f, c.pending().spineProgress);
+  TEST_ASSERT_FALSE(c.pending().hasAnchor);
+
+  c.clearPending();
+  TEST_ASSERT_FALSE(c.hasPending());
+  TEST_ASSERT_FALSE(c.pending().hasPercentJump);
+  TEST_ASSERT_EQUAL_FLOAT(0.0f, c.pending().spineProgress);
+}
+
+void test_pending_nav_anchor() {
+  Cache c;
+  PendingNav n;
+  n.hasAnchor = true;
+  n.anchor = "chap3";
+  c.setPending(std::move(n));
+
+  TEST_ASSERT_TRUE(c.hasPending());
+  TEST_ASSERT_EQUAL_STRING("chap3", c.pending().anchor.c_str());
+
+  c.clearPending();
+  TEST_ASSERT_TRUE(c.pending().anchor.empty());
+  TEST_ASSERT_FALSE(c.pending().hasAnchor);
+}
+
+// Attach/detach must NOT touch pending-nav — it describes navigation
+// intent for the spine we're about to attach to.
+void test_pending_nav_survives_attach() {
+  Cache c;
+  PendingNav n;
+  n.hasPercentJump = true;
+  n.spineProgress = 0.7f;
+  c.setPending(n);
+
+  c.attach(5);
+  TEST_ASSERT_TRUE(c.hasPending());
+  TEST_ASSERT_EQUAL_FLOAT(0.7f, c.pending().spineProgress);
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_attach_sets_spine_clears_entries);
+  RUN_TEST(test_detach_resets_spine_and_entries);
+  RUN_TEST(test_clear_keeps_spine);
+  RUN_TEST(test_get_requires_matching_spine);
+  RUN_TEST(test_get_missing_page_returns_null);
+  RUN_TEST(test_insert_rotates_lru_on_new_page);
+  RUN_TEST(test_insert_existing_page_refreshes_in_place);
+  RUN_TEST(test_insert_null_is_noop);
+  RUN_TEST(test_refresh_window_middle_page);
+  RUN_TEST(test_refresh_window_first_page_leaves_prev_empty);
+  RUN_TEST(test_refresh_window_last_page_leaves_next_empty);
+  RUN_TEST(test_refresh_window_out_of_bounds_clears);
+  RUN_TEST(test_refresh_window_reuses_cached_neighbours);
+  RUN_TEST(test_refresh_window_single_page_section);
+  RUN_TEST(test_pending_nav_empty_by_default);
+  RUN_TEST(test_pending_nav_percent_jump);
+  RUN_TEST(test_pending_nav_anchor);
+  RUN_TEST(test_pending_nav_survives_attach);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Stage 3 of [#21](https://github.com/diogo7dias/crosspoint-reader-DX34/issues/21). Extracts the 3-page sliding window cache + pending-navigation bundle out of `EpubReaderActivity` into a host-testable module.

- `SectionPageCache<PageT>` — templated on page type so host tests use a stub `FakePage` without dragging in `HalStorage` / `Epub`. Header-only — the template plus a struct, no `.cpp` to compile. Operations: `attach` / `detach` / `clear`, `get` / `contains` / `entryCount`, `insert` (LRU rotation, in-place refresh on repeat), `refreshWindow` (slides the `[center-1, center, center+1]` triplet, reuses cached neighbours to avoid reloading).
- `PendingNav` bundle — `hasPercentJump` / `spineProgress` / `hasAnchor` / `anchor`. Owned by the cache since the legacy resolution block (`EpubReaderActivity.cpp` lines 1483-1500) runs exactly when a new section loads and its cache is empty. Resolution logic (computing target page from percent) stays in the activity — needs `Section`. Cache survives `attach` to carry nav intent into the new spine.
- 18 host tests: lifecycle (attach / detach / clear), lookup with spine mismatch, LRU rotation + in-place refresh, null-insert no-op, `refreshWindow` middle / first / last / OOB / single-page, neighbour reuse (loader not re-invoked when cache hit), pending-nav lifecycle + anchor/percent independence + `attach`-survival invariant.

## Stacking

Stacked on [#38](https://github.com/diogo7dias/crosspoint-reader-DX34/pull/38) (stage 2). Merge order: #37 → #38 → this → stage 4.

**Pure infra — not wired into any activity in this PR.** Stage 4 = `EpubReaderActivityV2` behind `READER_V2` gate, composing all three modules (tracker + highlights + cache).

## Test plan

- [x] \`pio test -e test_host\` — all 108 host tests pass (18 new)
- [x] \`pio run -e debug\` — clean build, flash usage unchanged (confirms dead code)
- [ ] Stage 4 will device-smoke the integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)