### PR TITLE
fix(sleep): sync-flush APP_STATE on wallpaper advance (PERSIST_V2)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -273,7 +273,19 @@ static void wireWallpaperPlaylist() {
   deps.lastShownFilename = &APP_STATE.lastShownSleepFilename;
   deps.cursor = &APP_STATE.lastSleepImage;
   deps.lastRenderedPath = &APP_STATE.lastSleepWallpaperPath;
-  deps.saveState = []() { return APP_STATE.saveToFile(); };
+  // WallpaperPlaylist::advance() runs inside SleepActivity::onEnter, AFTER
+  // enterDeepSleep's persistAppState flush and milliseconds before the CPU
+  // enters deep sleep. Under PERSIST_V2 saveToFile() is debounced — the
+  // debounce window never fires, so the new lastShownSleepFilename is lost
+  // and the next boot loads the stale value (same wallpaper every wake).
+  // Force a sync flush so rotation survives the deep-sleep boundary.
+  deps.saveState = []() {
+    const bool ok = APP_STATE.saveToFile();
+#ifdef PERSIST_V2
+    crosspoint::persist::PersistManager().flushAll();
+#endif
+    return ok;
+  };
   deps.randomFn = [](long mod) -> long { return ::random(mod); };
   deps.isFavorite = [](const std::string& path) { return FavoriteBmp::isFavoritePath(path); };
   deps.onPathRenamed = [](const std::string& from, const std::string& to) {


### PR DESCRIPTION
## Problem

Hold power → wake → hold power → same wallpaper every time. Rotation broken.

\`WallpaperPlaylist::advance()\` runs inside \`SleepActivity::onEnter\`, which fires AFTER \`enterDeepSleep\`'s \`persistAppState\` flush and milliseconds before the CPU enters deep sleep. Under PERSIST_V2, \`saveToFile()\` is debounced (~1500ms). The debounce window never fires — the new \`lastShownSleepFilename\` never reaches SD. Next boot loads the stale value.

Regression from PR #35 / #36 (PERSIST_V2 promotion). Not caught earlier because dogfood was on debug, which also had the bug.

## Fix

Force a sync \`PersistManager::flushAll()\` inside the wallpaper \`saveState\` callback. 13-line diff in \`src/main.cpp\` \`wireWallpaperPlaylist()\`.

Wallpaper advance is rare (once per sleep, not per page turn) so debounce coalescing was never valuable here.

## Test plan

- [x] \`pio run -e debug\` — clean build
- [ ] Flash debug → hold power → device sleeps with wallpaper A → wake → hold power → wallpaper B (different from A) → wake → hold power → wallpaper C (different again)

🤖 Generated with [Claude Code](https://claude.com/claude-code)