### PR TITLE
feat: add reset-to-global action in reading themes menu

### DIFF
--- a/src/ReadingThemeStore.cpp
+++ b/src/ReadingThemeStore.cpp
@@ -468,14 +468,29 @@ bool ReadingThemeStore::loadBookSettingsIntoCurrent(const std::string& cachePath
 }
 
 bool ReadingThemeStore::resetBookSettingsToGlobal(const std::string& cachePath) {
-  if (!cachePath.empty()) {
-    const std::string settingsPath = bookReaderSettingsPath(cachePath);
-    if (Storage.exists(settingsPath.c_str()) && !Storage.remove(settingsPath.c_str())) {
-      return false;
-    }
+  const ReadingTheme previousSettings = fromSettings(instance.lastAppliedThemeName, SETTINGS);
+  const std::string settingsPath = bookReaderSettingsPath(cachePath);
+  const bool hasBookSettings = !cachePath.empty() && Storage.exists(settingsPath.c_str());
+
+  if (!SETTINGS.loadFromFile()) {
+    return false;
   }
 
-  return SETTINGS.loadFromFile();
+  if (hasBookSettings && !Storage.remove(settingsPath.c_str())) {
+    applyThemeToSettings(previousSettings, SETTINGS);
+    instance.lastAppliedThemeName = previousSettings.name;
+    return false;
+  }
+
+  instance.lastAppliedThemeName.clear();
+  const int matchingThemeIndex = instance.findMatchingTheme();
+  if (matchingThemeIndex >= 0) {
+    const ReadingTheme* matchingTheme = instance.getTheme(static_cast<size_t>(matchingThemeIndex));
+    if (matchingTheme != nullptr) {
+      instance.lastAppliedThemeName = matchingTheme->name;
+    }
+  }
+  return true;
 }
 
 ReadingTheme ReadingThemeStore::normalizeTheme(const ReadingTheme& theme) {

--- a/src/ReadingThemeStore.cpp
+++ b/src/ReadingThemeStore.cpp
@@ -467,6 +467,17 @@ bool ReadingThemeStore::loadBookSettingsIntoCurrent(const std::string& cachePath
   return true;
 }
 
+bool ReadingThemeStore::resetBookSettingsToGlobal(const std::string& cachePath) {
+  if (!cachePath.empty()) {
+    const std::string settingsPath = bookReaderSettingsPath(cachePath);
+    if (Storage.exists(settingsPath.c_str()) && !Storage.remove(settingsPath.c_str())) {
+      return false;
+    }
+  }
+
+  return SETTINGS.loadFromFile();
+}
+
 ReadingTheme ReadingThemeStore::normalizeTheme(const ReadingTheme& theme) {
   ReadingTheme normalized = theme;
   normalized.name = sanitizeName(theme.name);

--- a/src/ReadingThemeStore.h
+++ b/src/ReadingThemeStore.h
@@ -102,6 +102,7 @@ class ReadingThemeStore {
   static bool loadBookSettings(const std::string& cachePath, ReadingTheme& theme);
   static bool saveCurrentBookSettings(const std::string& cachePath);
   static bool loadBookSettingsIntoCurrent(const std::string& cachePath);
+  static bool resetBookSettingsToGlobal(const std::string& cachePath);
 
   static ReadingTheme fromSettings(const std::string& name, const CrossPointSettings& settings);
   static ReadingTheme normalizeTheme(const ReadingTheme& theme);

--- a/src/activities/reader/ReadingThemesActivity.cpp
+++ b/src/activities/reader/ReadingThemesActivity.cpp
@@ -16,7 +16,7 @@
 #include "util/TransitionFeedback.h"
 
 namespace {
-constexpr int kBaseRowCount = 2;
+constexpr int kBaseRowCount = 3;
 constexpr int kThemeActionCount = 5;
 
 const char* themeActionLabel(const int index) {
@@ -249,6 +249,24 @@ void ReadingThemesActivity::loop() {
       openKeyboardForNewTheme();
       return;
     }
+    if (selectedRowIndex == 2) {
+      enterNewActivity(new ConfirmDialogActivity(
+          renderer, mappedInput, "Reset current book style to global settings?",
+          [this]() {
+            exitActivity();
+            if (!READING_THEMES.resetBookSettingsToGlobal(bookCachePath)) {
+              showMessage("Failed to reset to global settings");
+              return;
+            }
+            settingsDirty = true;
+            showMessage("Now following global reader style");
+          },
+          [this]() {
+            exitActivity();
+            requestUpdate();
+          }));
+      return;
+    }
     if (isThemeRow(selectedRowIndex)) {
       actionPopupOpen = true;
       actionPopupThemeIndex = themeIndexForRow(selectedRowIndex);
@@ -304,6 +322,8 @@ void ReadingThemesActivity::render(Activity::RenderLock&&) {
       label = tr(STR_ADJUST_CURRENT_SETTINGS);
     } else if (i == 1) {
       label = tr(STR_SAVE_CURRENT_AS_NEW);
+    } else if (i == 2) {
+      label = "Reset to Global Reader Style";
     } else {
       const int themeIndex = themeIndexForRow(i);
       const ReadingTheme* theme = READING_THEMES.getTheme(themeIndex);
@@ -320,7 +340,7 @@ void ReadingThemesActivity::render(Activity::RenderLock&&) {
     }
     renderer.drawText(UI_10_FONT_ID, metrics.contentSidePadding, rowY, label.c_str(), !isSelected);
 
-    if (i >= 2) {
+    if (i >= kBaseRowCount) {
       const int themeIndex = themeIndexForRow(i);
       const char* stateLabel = nullptr;
       if (themeIndex == currentThemeIndex) {


### PR DESCRIPTION
### Motivation
- Provide a quick way for a book to stop using per-book reader overrides and instead follow the user's global reader settings. 
- Require confirmation and clear feedback so users don't accidentally remove per-book overrides.

### Description
- Added a new top-level menu row after `Save Current as New` by increasing `kBaseRowCount` to `3` and rendering the label `Reset to Global Reader Style` in `ReadingThemesActivity`.
- Wired selection of that row to open a `ConfirmDialogActivity` which, on confirm, calls `READING_THEMES.resetBookSettingsToGlobal(bookCachePath)` and shows success or failure popups and sets `settingsDirty` as appropriate.
- Implemented `ReadingThemeStore::resetBookSettingsToGlobal(const std::string& cachePath)` which removes the per-book `reader_settings.json` via `Storage.remove` when present and then reloads global defaults with `SETTINGS.loadFromFile()`.
- Exposed the new API in `src/ReadingThemeStore.h` and updated rendering logic to treat the extra static rows via `kBaseRowCount` so theme state labels remain aligned.

### Testing
- Attempted to run the native activity router test with `pio test -e native -f test_activity_router`, but the command failed in this environment with `pio: command not found` so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e56474d7f88322917785bec49f91d6)