### PR TITLE
feat: paginate reader menu + disable BLE Controller entry (strikethrough)

### DIFF
--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -139,7 +139,9 @@ void EpubReaderMenuActivity::loop() {
 void EpubReaderMenuActivity::render(Activity::RenderLock&&) {
   renderer.clearScreen();
   const auto pageWidth = renderer.getScreenWidth();
+  const auto pageHeight = renderer.getScreenHeight();
   const auto orientation = renderer.getOrientation();
+  const auto metrics = BaseMetrics::values;
   // Landscape orientation: button hints are drawn along a vertical edge, so we
   // reserve a horizontal gutter to prevent overlap with menu content.
   const bool isLandscapeCw = orientation == GfxRenderer::Orientation::LandscapeClockwise;
@@ -174,9 +176,13 @@ void EpubReaderMenuActivity::render(Activity::RenderLock&&) {
   // Menu Items
   const int startY = 75 + contentY;
   constexpr int lineHeight = 30;
+  const int footerReserve = metrics.buttonHintsHeight + metrics.verticalSpacing;
+  const int contentHeight = std::max(lineHeight, pageHeight - (startY + footerReserve));
+  const int pageItems = std::max(1, contentHeight / lineHeight);
+  const int pageStartIndex = (selectedIndex / pageItems) * pageItems;
 
-  for (size_t i = 0; i < menuItems.size(); ++i) {
-    const int displayY = startY + (i * lineHeight);
+  for (int i = pageStartIndex; i < static_cast<int>(menuItems.size()) && i < pageStartIndex + pageItems; ++i) {
+    const int displayY = startY + ((i - pageStartIndex) * lineHeight);
     const auto& item = menuItems[i];
 
     if (item.isSeparator) {
@@ -213,6 +219,15 @@ void EpubReaderMenuActivity::render(Activity::RenderLock&&) {
   // Footer / Hints
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+
+  if (static_cast<int>(menuItems.size()) > pageItems) {
+    const int currentPage = pageStartIndex / pageItems + 1;
+    const int totalPages = (static_cast<int>(menuItems.size()) + pageItems - 1) / pageItems;
+    const std::string pageCounter = std::to_string(currentPage) + "/" + std::to_string(totalPages);
+    const int counterWidth = renderer.getTextWidth(UI_10_FONT_ID, pageCounter.c_str());
+    const int counterY = pageHeight - metrics.buttonHintsHeight - renderer.getLineHeight(UI_10_FONT_ID) - 4;
+    renderer.drawText(UI_10_FONT_ID, contentX + contentWidth - 12 - counterWidth, counterY, pageCounter.c_str());
+  }
 
   renderer.displayBuffer();
 }

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -629,8 +629,8 @@ void SettingsActivity::render(Activity::RenderLock&&) {
     const int chipH = textH + kChipPad * 2;
     const int chipY = rowY + (rowHeight - chipH) / 2;
 
-    const bool isDisabledAction = (setting.type == SettingType::ACTION &&
-                                   setting.action == SettingAction::BluetoothHID);
+    const bool isDisabledAction =
+        (setting.type == SettingType::ACTION && setting.action == SettingAction::BluetoothHID);
 
     if (isSelected) {
       const int nameWidth = renderer.getTextWidth(rowFont, settingName);
@@ -644,8 +644,7 @@ void SettingsActivity::render(Activity::RenderLock&&) {
       // background black, so the line must be drawn white to remain visible).
       const int strikeWidth = renderer.getTextWidth(rowFont, settingName);
       const int strikeY = rowY + textH / 2;
-      renderer.drawLine(metrics.contentSidePadding, strikeY,
-                        metrics.contentSidePadding + strikeWidth, strikeY,
+      renderer.drawLine(metrics.contentSidePadding, strikeY, metrics.contentSidePadding + strikeWidth, strikeY,
                         !isSelected);
     }
 

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -540,18 +540,11 @@ void SettingsActivity::toggleCurrentSetting() {
         enterSubActivity(new ButtonRemapActivity(renderer, mappedInput, onComplete));
         break;
       case SettingAction::BluetoothHID: {
-        // Always go to connect screen first — it shows paired device,
-        // allows unpair/re-pair, and transitions to remap on success.
-        auto onPaired = [this, onComplete](bool paired) {
-          if (paired) {
-            exitActivity();
-            enterNewActivity(new BleRemapActivity(renderer, mappedInput, onComplete));
-          } else {
-            exitActivity();
-            requestUpdate();
-          }
-        };
-        enterSubActivity(new BleConnectActivity(renderer, mappedInput, onPaired));
+        // Temporarily disabled: BLE HID path is mid-rework for issue #44 and
+        // must not be entered from the UI until the Gamebrick decoder lands
+        // and a volunteer has verified pairing on real hardware. The row is
+        // still visible with a strikethrough so users see the feature is
+        // upcoming; confirm presses are ignored here.
         break;
       }
       case SettingAction::KOReaderSync:
@@ -636,11 +629,25 @@ void SettingsActivity::render(Activity::RenderLock&&) {
     const int chipH = textH + kChipPad * 2;
     const int chipY = rowY + (rowHeight - chipH) / 2;
 
+    const bool isDisabledAction = (setting.type == SettingType::ACTION &&
+                                   setting.action == SettingAction::BluetoothHID);
+
     if (isSelected) {
       const int nameWidth = renderer.getTextWidth(rowFont, settingName);
       renderer.fillRect(metrics.contentSidePadding - kChipPad, chipY, nameWidth + kChipPad * 2, chipH, true);
     }
     renderer.drawText(rowFont, metrics.contentSidePadding, rowY, settingName, !isSelected);
+
+    if (isDisabledAction) {
+      // Strike-through indicates "upcoming but disabled for now". Inverted
+      // foreground color when the row is selected (highlight draws the
+      // background black, so the line must be drawn white to remain visible).
+      const int strikeWidth = renderer.getTextWidth(rowFont, settingName);
+      const int strikeY = rowY + textH / 2;
+      renderer.drawLine(metrics.contentSidePadding, strikeY,
+                        metrics.contentSidePadding + strikeWidth, strikeY,
+                        !isSelected);
+    }
 
     std::string valueText;
     if (setting.type == SettingType::TOGGLE && setting.valuePtr != nullptr) {


### PR DESCRIPTION
## Summary

Two small user-facing changes bundled together; both verified on-device (Xteink X4, flash `bfc81f0`):

1. **Reader menu pagination.** Menu items that overflow the visible area split into pages sized to `contentHeight / lineHeight`. Bottom-right shows a `1/N`-style counter when pagination is active; hidden when all items fit on one page.

2. **"Bluetooth Controller" settings entry temporarily disabled.** BLE HID path is mid-rework (issue #44, decoder in PR #51). Until that lands and a volunteer confirms Gamebrick on real hardware, entering the BLE flow from the UI is off the table — last attempt bricked an issue reporter's SD state. The row stays visible (so users see the feature is upcoming) with a horizontal strike-through line across its name, and Confirm press is a no-op.

## Test plan
- [x] Pagination: reader menu with many items shows `1/N` counter, flips by page as selection crosses boundary.
- [x] Pagination: reader menu with few items shows no counter, renders unchanged.
- [x] Strikethrough: Settings → Controls → "Bluetooth Controller" row shows strike-through line across text.
- [x] Strikethrough: row is still highlightable by up/down navigation.
- [x] Confirm press on disabled row: nothing happens, screen stays on settings.
- [x] Neighbouring Controls entries (Remap Front Buttons) still work normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)