### PR TITLE
chore: bump version to v1.1.2 and align enum formatting

### DIFF
--- a/lib/I18n/I18nKeys.h
+++ b/lib/I18n/I18nKeys.h
@@ -9,7 +9,10 @@ extern const char* const STRINGS_EN[];
 }  // namespace i18n_strings
 
 // Language enum
-enum class Language : uint8_t { ENGLISH = 0, _COUNT };
+enum class Language : uint8_t {
+  ENGLISH = 0,
+  _COUNT
+};
 
 // Language display names (defined in I18nStrings.cpp)
 extern const char* const LANGUAGE_NAMES[];

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,7 +2,7 @@
 default_envs = default
 
 [crosspoint]
-version = v1.1.1
+version = v1.1.2
 
 [base]
 platform = espressif32 @ 6.12.0
@@ -172,4 +172,3 @@ build_flags =
   -Isrc
 build_unflags =
   -std=gnu++11
-


### PR DESCRIPTION
## Summary
- Bumps `crosspoint.version` in `platformio.ini` from `v1.1.1` → `v1.1.2` for the next release cut.
- Expands `Language` enum in `lib/I18n/I18nKeys.h` across multiple lines to match clang-format-21 output. No semantic change.
- Trailing blank line trimmed from `platformio.ini`.

## Test plan
- [ ] `pio run -e default` — build passes, binary reports v1.1.2 on boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)