### PR TITLE
chore(format): restore single-line Language enum (unblocks CI)

### DIFF
--- a/lib/I18n/I18nKeys.h
+++ b/lib/I18n/I18nKeys.h
@@ -9,10 +9,7 @@ extern const char* const STRINGS_EN[];
 }  // namespace i18n_strings
 
 // Language enum
-enum class Language : uint8_t {
-  ENGLISH = 0,
-  _COUNT
-};
+enum class Language : uint8_t { ENGLISH = 0, _COUNT };
 
 // Language display names (defined in I18nStrings.cpp)
 extern const char* const LANGUAGE_NAMES[];


### PR DESCRIPTION
## Summary
Revert \`lib/I18n/I18nKeys.h\` \`Language\` enum to its generator-written single-line form. **Unblocks clang-format CI on every open PR.**

## Why this is urgent
I landed PR #54 which mis-committed a stale working-tree copy of this auto-generated header. The copy had the enum expanded to 4 lines by a non-CI formatter. The CI check runs \`clang-format-21\` + \`git diff --exit-code\` — clang-format-21 normalises this enum back to a single line, so every PR (including #52, #53, #51) fails CI until main is corrected.

## Scope
- One file, 3-line-delta.
- \`scripts/gen_i18n.py\` (the generator) unchanged — its output already produces the single-line form.
- My mistake in #54; this is the straight revert of that specific hunk.

## Test plan
- [x] \`git diff main\` shows only the single enum revert.
- [ ] CI clang-format passes on this branch.
- [ ] After merge, PRs #52 / #53 / #51 CI passes on next run (may need branch refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)