### PR TITLE
feat(power): 1s hold for sleep + toast feedback

### DIFF
--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -357,7 +357,7 @@ class CrossPointSettings {
   static CrossPointSettings& getInstance() { return instance; }
 
   uint16_t getPowerButtonDuration() const {
-    return (shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::SLEEP) ? 10 : 400;
+    return (shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::SLEEP) ? 10 : 1000;
   }
   static uint8_t normalizeFontFamily(uint8_t family);
   static uint8_t fontFamilyToDisplayIndex(uint8_t family);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -839,6 +839,7 @@ void loop() {
   }
 
   if (gpio.isPressed(HalGPIO::BTN_POWER) && gpio.getHeldTime() > SETTINGS.getPowerButtonDuration()) {
+    TransitionFeedback::show(renderer, "Going to sleep...");
     triggerDeepSleep();
     // This should never be hit as enterDeepSleep calls esp_deep_sleep_start
     return;


### PR DESCRIPTION
## Summary
- Bump non-SLEEP power-button hold threshold `400ms` → `1000ms` ([src/CrossPointSettings.h:360](src/CrossPointSettings.h#L360))
- Flash `"Going to sleep..."` toast immediately at threshold cross, before BLE deinit / persist flush / wallpaper render ([src/main.cpp:849](src/main.cpp#L849))
- Quick-sleep mode (`SHORT_PWRBTN::SLEEP`) unchanged at 10ms
- Auto-sleep (inactivity) stays silent — user not watching

## Why
Previous 400ms hold gave no visual feedback — device looked unresponsive for ~1s while sleep path ran. New 1s deliberate hold + instant toast gives clear signal the device heard the press.

## Test plan
- [x] Build + flash to hardware (default env)
- [ ] Hold power <1s → no sleep, no toast
- [ ] Hold power ≥1s → toast flashes, wallpaper replaces, device sleeps
- [ ] `shortPwrBtn == SLEEP` setting: tap power → still instant sleep (10ms)
- [ ] Auto-sleep via inactivity timeout → no toast, silent sleep

🤖 Generated with [Claude Code](https://claude.com/claude-code)