### PR TITLE
chore: rip V1 fallbacks behind PERSIST/LIFECYCLE/WEBSERVER/SLEEP_V2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -38,10 +38,6 @@ build_flags =
   ; LIFECYCLE_V2 routes Home → Settings through lifecycle::ActivityRouter (#23).
   ; Promoted to base for v1.1.0 — V1 code path kept as gate-flag fallback.
   -DLIFECYCLE_V2=1
-  ; WEBSERVER_V2 routes WS upload + settings POST through the new modules
-  ; (WsUploadSession + SettingsGateway). See RFC #24.
-  ; Promoted to base for v1.1.0 — V1 code path kept as gate-flag fallback.
-  -DWEBSERVER_V2=1
   ; SLEEP_V2 routes sleep wallpaper playlist through sleep::WallpaperPlaylist
   ; (RFC #22). Promoted to base for v1.1.0 — V1 code path kept as gate-flag fallback.
   -DSLEEP_V2=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,9 +32,6 @@ build_flags =
 # https://libexpat.github.io/doc/api/latest/#XML_GE
   -DXML_GE=0
   -DXML_CONTEXT_BYTES=1024
-  ; PERSIST_V2 routes CrossPointState through persist::AppStateStore (RFC #20).
-  ; Promoted to base after debug smoke (PR #35); applies to all envs.
-  -DPERSIST_V2=1
   -std=gnu++2a
 # Enable UTF-8 long file names in SdFat
   -DUSE_UTF8_LONG_NAMES=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,9 +38,6 @@ build_flags =
   ; LIFECYCLE_V2 routes Home → Settings through lifecycle::ActivityRouter (#23).
   ; Promoted to base for v1.1.0 — V1 code path kept as gate-flag fallback.
   -DLIFECYCLE_V2=1
-  ; SLEEP_V2 routes sleep wallpaper playlist through sleep::WallpaperPlaylist
-  ; (RFC #22). Promoted to base for v1.1.0 — V1 code path kept as gate-flag fallback.
-  -DSLEEP_V2=1
   -std=gnu++2a
 # Enable UTF-8 long file names in SdFat
   -DUSE_UTF8_LONG_NAMES=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,9 +35,6 @@ build_flags =
   ; PERSIST_V2 routes CrossPointState through persist::AppStateStore (RFC #20).
   ; Promoted to base after debug smoke (PR #35); applies to all envs.
   -DPERSIST_V2=1
-  ; LIFECYCLE_V2 routes Home → Settings through lifecycle::ActivityRouter (#23).
-  ; Promoted to base for v1.1.0 — V1 code path kept as gate-flag fallback.
-  -DLIFECYCLE_V2=1
   -std=gnu++2a
 # Enable UTF-8 long file names in SdFat
   -DUSE_UTF8_LONG_NAMES=1

--- a/src/CrossPointState.cpp
+++ b/src/CrossPointState.cpp
@@ -1,15 +1,11 @@
 #include "CrossPointState.h"
 
 #include <HalStorage.h>
-#include <JsonSettingsIO.h>
 #include <Logging.h>
 #include <Serialization.h>
 
 #include "Paths.h"
-
-#ifdef PERSIST_V2
 #include "persist/AppStateStore.h"
-#endif
 
 namespace {
 constexpr uint8_t STATE_FILE_VERSION = 5;
@@ -18,75 +14,40 @@ constexpr char STATE_FILE_JSON[] = "/.crosspoint/state.json";
 constexpr char STATE_FILE_BAK[] = "/.crosspoint/state.bin.bak";
 }  // namespace
 
-#ifndef PERSIST_V2
-CrossPointState CrossPointState::instance;
-
-CrossPointState& CrossPointState::getInstance() { return instance; }
-#else
 CrossPointState& CrossPointState::getInstance() { return crosspoint::persist::appStateStore().unsafeMut(); }
-#endif
 
 bool CrossPointState::saveToFile() const {
   Storage.mkdir(Paths::kDataDir);
-#ifdef PERSIST_V2
   // Debounced: mark dirty now, coalesce with any subsequent saveToFile() in
   // the same tick window into a single write. PersistManager::flushAll() at
   // activity-transition chokepoints + main-loop tickPersist drain the queue.
   crosspoint::persist::appStateStore().flushSoon();
   return true;
-#else
-  return JsonSettingsIO::saveState(*this, STATE_FILE_JSON);
-#endif
 }
 
 bool CrossPointState::loadFromFile() {
-#ifdef PERSIST_V2
   // Route through PersistentStore — IFileIO.safeRead already handles the
   // real → .bak → .tmp fallback chain.
   auto report = crosspoint::persist::appStateStore().load();
   if (report.status == crosspoint::persist::LoadReport::kOk ||
       report.status == crosspoint::persist::LoadReport::kRecoveredFromBak) {
-    LOG_DBG("CPS", "V2 load: %s (%s)", report.name, report.detail);
+    LOG_DBG("CPS", "load: %s (%s)", report.name, report.detail);
     return true;
   }
-  // JSON missing or corrupt → try legacy binary migration, same as V1.
+  // JSON missing or corrupt → try legacy binary migration from pre-RFC-#20 builds.
   if (Storage.exists(STATE_FILE_BIN) && loadFromBinaryFile()) {
     if (saveToFile()) {
-      // V2 saveToFile is debounced; force an immediate flush so migration
+      // saveToFile() is debounced; force an immediate flush so migration
       // persists before the .bin file is renamed.
       crosspoint::persist::appStateStore().flushNow();
       Storage.rename(STATE_FILE_BIN, STATE_FILE_BAK);
-      LOG_DBG("CPS", "Migrated state.bin to state.json (V2)");
+      LOG_DBG("CPS", "Migrated state.bin to state.json");
       return true;
     }
-    LOG_ERR("CPS", "Failed to save state during V2 migration");
+    LOG_ERR("CPS", "Failed to save state during migration");
     return false;
   }
   return false;
-#else
-  // V1: try JSON first, then binary migration.
-  if (!Storage.exists(STATE_FILE_JSON)) return false;
-
-  String json = JsonSettingsIO::safeReadFile(STATE_FILE_JSON);
-  if (!json.isEmpty()) {
-    return JsonSettingsIO::loadState(*this, json.c_str());
-  }
-
-  if (Storage.exists(STATE_FILE_BIN)) {
-    if (loadFromBinaryFile()) {
-      if (saveToFile()) {
-        Storage.rename(STATE_FILE_BIN, STATE_FILE_BAK);
-        LOG_DBG("CPS", "Migrated state.bin to state.json");
-        return true;
-      } else {
-        LOG_ERR("CPS", "Failed to save state during migration");
-        return false;
-      }
-    }
-  }
-
-  return false;
-#endif
 }
 
 bool CrossPointState::loadFromBinaryFile() {

--- a/src/CrossPointState.h
+++ b/src/CrossPointState.h
@@ -17,11 +17,6 @@
 #include <vector>
 
 class CrossPointState {
-#ifndef PERSIST_V2
-  // V1: static singleton lives in-class. V2: owned by PersistentStore instead.
-  static CrossPointState instance;
-#endif
-
  public:
   // Collections larger than this threshold are handled without a full in-memory
   // playlist; only the last-shown filename is persisted in that case.
@@ -40,9 +35,9 @@ class CrossPointState {
   bool lastSleepWasQuotes = false;
   ~CrossPointState() = default;
 
-  // Singleton — V1 returns the in-class static, V2 returns the data inside
-  // the PersistentStore wrapper. All 24 APP_STATE.x mutations + saveToFile()
-  // call sites work identically under either gate.
+  // Singleton — returns the data owned by persist::AppStateStore
+  // (RFC #20). All 24 APP_STATE.x mutations + saveToFile() call sites
+  // go through this accessor transparently, gaining debounce coalescing.
   static CrossPointState& getInstance();
 
   bool saveToFile() const;

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -8,7 +8,6 @@
 #include <cstring>
 
 #include "CrossPointSettings.h"
-#include "CrossPointState.h"
 #include "KOReaderCredentialStore.h"
 #include "ReadingThemeStore.h"
 #include "RecentBooksStore.h"
@@ -342,79 +341,6 @@ String JsonSettingsIO::safeReadFile(const char* path) {
   }
 
   return "";
-}
-
-// ---- CrossPointState ----
-
-bool JsonSettingsIO::saveState(const CrossPointState& s, const char* path) {
-  JsonDocument doc;
-  doc["openEpubPath"] = s.openEpubPath;
-  doc["lastSleepImage"] = s.lastSleepImage;
-  doc["lastShownSleepFilename"] = s.lastShownSleepFilename;
-  doc["lastSleepWallpaperPath"] = s.lastSleepWallpaperPath;
-  doc["readerActivityLoadCount"] = s.readerActivityLoadCount;
-  doc["sessionPagesRead"] = s.sessionPagesRead;
-  doc["lastSleepFromReader"] = s.lastSleepFromReader;
-  doc["wallpaperRotationPaused"] = s.wallpaperRotationPaused;
-  doc["lastSleepWasQuotes"] = s.lastSleepWasQuotes;
-  // Only persist the playlist for small collections. Large collections track
-  // position by filename alone to avoid heap exhaustion and huge state files.
-  if (s.sleepImagePlaylist.size() <= CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST) {
-    JsonArray sleepImagePlaylist = doc["sleepImagePlaylist"].to<JsonArray>();
-    for (const auto& entry : s.sleepImagePlaylist) {
-      sleepImagePlaylist.add(entry);
-    }
-  }
-  JsonArray favoriteBmpPaths = doc["favoriteBmpPaths"].to<JsonArray>();
-  for (const auto& entry : s.favoriteBmpPaths) {
-    favoriteBmpPaths.add(entry);
-  }
-
-  String json;
-  serializeJson(doc, json);
-  return safeWriteFile(path, json);
-}
-
-bool JsonSettingsIO::loadState(CrossPointState& s, const char* json) {
-  JsonDocument doc;
-  auto error = deserializeJson(doc, json);
-  if (error) {
-    LOG_ERR("CPS", "JSON parse error: %s", error.c_str());
-    return false;
-  }
-
-  s.openEpubPath = doc["openEpubPath"] | std::string("");
-  s.lastSleepImage = doc["lastSleepImage"] | (uint8_t)UINT8_MAX;
-  s.lastShownSleepFilename = doc["lastShownSleepFilename"] | std::string("");
-  s.lastSleepWallpaperPath = doc["lastSleepWallpaperPath"] | std::string("");
-  s.readerActivityLoadCount = doc["readerActivityLoadCount"] | (uint8_t)0;
-  s.sessionPagesRead = doc["sessionPagesRead"] | (uint32_t)0;
-  s.lastSleepFromReader = doc["lastSleepFromReader"] | false;
-  s.wallpaperRotationPaused = doc["wallpaperRotationPaused"] | false;
-  s.lastSleepWasQuotes = doc["lastSleepWasQuotes"] | false;
-  s.sleepImagePlaylist.clear();
-  if (doc["sleepImagePlaylist"].is<JsonArray>()) {
-    for (const JsonVariant value : doc["sleepImagePlaylist"].as<JsonArray>()) {
-      const char* entry = value.as<const char*>();
-      if (entry != nullptr && entry[0] != '\0') {
-        s.sleepImagePlaylist.emplace_back(entry);
-        // Cap on load to protect against legacy large playlists causing OOM.
-        if (s.sleepImagePlaylist.size() >= CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST) {
-          break;
-        }
-      }
-    }
-  }
-  s.favoriteBmpPaths.clear();
-  if (doc["favoriteBmpPaths"].is<JsonArray>()) {
-    for (const JsonVariant value : doc["favoriteBmpPaths"].as<JsonArray>()) {
-      const char* entry = value.as<const char*>();
-      if (entry != nullptr && entry[0] != '\0') {
-        s.favoriteBmpPaths.emplace_back(entry);
-      }
-    }
-  }
-  return true;
 }
 
 // ---- CrossPointSettings ----

--- a/src/JsonSettingsIO.h
+++ b/src/JsonSettingsIO.h
@@ -13,7 +13,6 @@
 #include <WString.h>
 
 class CrossPointSettings;
-class CrossPointState;
 class WifiCredentialStore;
 class KOReaderCredentialStore;
 class RecentBooksStore;
@@ -28,10 +27,6 @@ String safeReadFile(const char* path);
 // CrossPointSettings
 bool saveSettings(const CrossPointSettings& s, const char* path);
 bool loadSettings(CrossPointSettings& s, const char* json, bool* needsResave = nullptr);
-
-// CrossPointState
-bool saveState(const CrossPointState& s, const char* path);
-bool loadState(CrossPointState& s, const char* json);
 
 // WifiCredentialStore
 bool saveWifi(const WifiCredentialStore& store, const char* path);

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -16,24 +16,20 @@
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"
 #include "persist/BackupMirror.h"
+#include "persist/PersistManager.h"
+#include "sleep/WallpaperPlaylist.h"
 #include "util/FavoriteBmp.h"
 #include "util/StringUtils.h"
-#ifdef PERSIST_V2
-#include "persist/PersistManager.h"
-#endif
-#include "sleep/WallpaperPlaylist.h"
 
 namespace {
 // Sleep rendering runs inside SleepActivity::onEnter, called AFTER
 // enterDeepSleep's persistAppState flushAll and milliseconds before the CPU
-// enters deep sleep. Under PERSIST_V2 saveToFile() is debounced — the next
-// main-loop tick never fires, so any state write would be lost. Force a sync
-// flush so triage state survives the deep-sleep boundary.
+// enters deep sleep. saveToFile() is debounced — the next main-loop tick
+// never fires, so any state write would be lost. Force a sync flush so
+// triage state survives the deep-sleep boundary.
 void flushStateSync() {
   APP_STATE.saveToFile();
-#ifdef PERSIST_V2
   crosspoint::persist::PersistManager().flushAll();
-#endif
 }
 
 void clearLastSleepWallpaperPath() {

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -8,7 +8,6 @@
 #include <Xtc.h>
 
 #include <algorithm>
-#include <cstring>
 
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
@@ -18,14 +17,11 @@
 #include "fontIds.h"
 #include "persist/BackupMirror.h"
 #include "util/FavoriteBmp.h"
-#include "util/StatusPopup.h"
 #include "util/StringUtils.h"
 #ifdef PERSIST_V2
 #include "persist/PersistManager.h"
 #endif
-#if SLEEP_V2
 #include "sleep/WallpaperPlaylist.h"
-#endif
 
 namespace {
 // Sleep rendering runs inside SleepActivity::onEnter, called AFTER
@@ -60,167 +56,6 @@ void rememberLastRenderedSleepBitmap(const std::string& path, const std::string&
   if (changed) {
     flushStateSync();
   }
-}
-
-// Returns all .bmp filenames from /sleep in sorted order.
-// Does NOT open/validate each file — invalid BMPs are skipped at render time.
-std::vector<std::string> getValidSleepBitmaps() {
-  std::vector<std::string> files;
-  auto dir = Storage.open("/sleep");
-  if (!dir || !dir.isDirectory()) {
-    if (dir) dir.close();
-    return files;
-  }
-
-  char name[256];
-  for (auto file = dir.openNextFile(); file; file = dir.openNextFile()) {
-    if (file.isDirectory()) {
-      file.close();
-      continue;
-    }
-
-    file.getName(name, sizeof(name));
-    std::string filename(name);
-    if (filename.empty() || filename[0] == '.') {
-      file.close();
-      continue;
-    }
-
-    if (filename.size() >= 4 && filename.substr(filename.size() - 4) == ".bmp") {
-      files.emplace_back(std::move(filename));
-    }
-    file.close();
-    if (files.size() >= CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST) break;
-  }
-  dir.close();
-
-  std::sort(files.begin(), files.end());
-  return files;
-}
-
-void shuffleSleepPlaylist(std::vector<std::string>& files) {
-  if (files.size() <= 1) return;
-  for (size_t i = files.size() - 1; i > 0; --i) {
-    const auto j = static_cast<size_t>(random(i + 1));
-    std::swap(files[i], files[j]);
-  }
-}
-
-void syncSleepPlaylistWithFiles(const std::vector<std::string>& files, bool forceReshuffle,
-                                size_t maxEntries = CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST) {
-  auto& playlist = APP_STATE.sleepImagePlaylist;
-  bool changed = false;
-
-  if (files.empty()) {
-    if (!playlist.empty()) {
-      playlist.clear();
-      APP_STATE.saveToFile();
-    }
-    return;
-  }
-
-  if (forceReshuffle) {
-    playlist = files;
-    shuffleSleepPlaylist(playlist);
-    APP_STATE.lastSleepImage = 0;
-    APP_STATE.saveToFile();
-    return;
-  }
-
-  if (playlist.empty()) {
-    // Default behavior: follow stable filename order from /sleep directory.
-    playlist = files;
-    APP_STATE.lastSleepImage = 0;
-    APP_STATE.saveToFile();
-    return;
-  }
-
-  // files is already sorted; use binary_search for O(log n) membership checks
-  // without copying any strings.
-
-  // Remove entries that no longer exist on disk.
-  const auto oldSize = playlist.size();
-  playlist.erase(
-      std::remove_if(playlist.begin(), playlist.end(),
-                     [&files](const std::string& e) { return !std::binary_search(files.begin(), files.end(), e); }),
-      playlist.end());
-  if (playlist.size() != oldSize) {
-    changed = true;
-  }
-
-  // Find newly-added files not yet in the playlist.
-  // Sort a temporary copy of playlist pointers for O(log n) lookup without
-  // allocating a separate string_view vector (saves ~1.6 KB for 200 entries).
-  // We sort const char* pointers and compare via strcmp — no string copies.
-  std::vector<const char*> sortedPtrs;
-  sortedPtrs.reserve(playlist.size());
-  for (const auto& e : playlist) sortedPtrs.push_back(e.c_str());
-  std::sort(sortedPtrs.begin(), sortedPtrs.end(), [](const char* a, const char* b) { return strcmp(a, b) < 0; });
-
-  std::vector<std::string> newFiles;
-  std::copy_if(files.begin(), files.end(), std::back_inserter(newFiles), [&sortedPtrs](const std::string& file) {
-    return !std::binary_search(sortedPtrs.begin(), sortedPtrs.end(), file.c_str(),
-                               [](const char* a, const char* b) { return strcmp(a, b) < 0; });
-  });
-
-  // Insert new files right after the current head so they show immediately.
-  // When lastSleepImage == 0 nothing has been shown yet, so insert at 0.
-  // When lastSleepImage == 1 the head (playlist[0]) is the last-shown image
-  // and will be rotated to the back before the next render, so insert at 1.
-  if (!newFiles.empty()) {
-    const size_t insertPos = (APP_STATE.lastSleepImage == 0) ? 0 : std::min<size_t>(1, playlist.size());
-    playlist.insert(playlist.begin() + insertPos, newFiles.begin(), newFiles.end());
-    changed = true;
-  }
-
-  // Final safety: strictly cap playlist size to avoid serialization OOM.
-  if (maxEntries > 0 && playlist.size() > maxEntries) {
-    playlist.erase(playlist.begin() + maxEntries, playlist.end());
-    changed = true;
-  }
-
-  if (playlist.empty()) {
-    playlist = files;
-    APP_STATE.lastSleepImage = 0;
-    changed = true;
-  }
-
-  if (changed) {
-    APP_STATE.saveToFile();
-  }
-}
-
-// For large collections (> SLEEP_PLAYLIST_MAX_PERSIST) we do not maintain the
-// full playlist in memory. Instead we find the next file after the last-shown
-// one using a binary search on the already-sorted files list.
-std::string nextSleepImageLargeCollection(const std::vector<std::string>& files) {
-  if (files.empty()) {
-    return "";
-  }
-
-  const auto& last = APP_STATE.lastShownSleepFilename;
-  std::string next;
-
-  if (last.empty()) {
-    // No prior context: start from the beginning.
-    next = files.front();
-  } else if (APP_STATE.lastSleepImage == 0) {
-    // randomizeSleepImagePlaylist() set a starting file but nothing rendered
-    // yet — show it now without advancing past it.
-    next = last;
-  } else {
-    // Find the last-shown file and advance to the next one, wrapping around.
-    auto it = std::lower_bound(files.begin(), files.end(), last);
-    if (it != files.end() && *it == last) {
-      ++it;
-    }
-    next = (it != files.end()) ? *it : files.front();
-  }
-
-  APP_STATE.lastShownSleepFilename = next;
-  APP_STATE.lastSleepImage = 1;
-  APP_STATE.saveToFile();
-  return next;
 }
 
 void drawSleepFilenameLabel(const GfxRenderer& renderer, const char* filename) {
@@ -325,41 +160,7 @@ void SleepActivity::renderCustomSleepScreen() const {
   std::string selectedImage;
   bool rendered = false;
   for (int attempt = 0; attempt < kMaxParseRetries && !rendered; ++attempt) {
-#if SLEEP_V2
     selectedImage = crosspoint::sleep::WallpaperPlaylist::instance().advance();
-#else
-    selectedImage.clear();
-    {
-      const auto files = getValidSleepBitmaps();
-      if (!files.empty()) {
-        if (files.size() > CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST) {
-          selectedImage = nextSleepImageLargeCollection(files);
-        } else {
-          syncSleepPlaylistWithFiles(files, false);
-          auto& playlist = APP_STATE.sleepImagePlaylist;
-          if (!playlist.empty()) {
-            bool changed = false;
-            // Rotate head to tail on every pass: first attempt honors the
-            // post-render rotation (lastSleepImage != 0); subsequent attempts
-            // are explicit skips of the bad file we just tried.
-            const bool rotate = (attempt > 0) || (APP_STATE.lastSleepImage != 0 && playlist.size() > 1);
-            if (rotate && playlist.size() > 1) {
-              const auto first = playlist.front();
-              playlist.erase(playlist.begin());
-              playlist.push_back(first);
-              changed = true;
-            }
-            selectedImage = playlist.front();
-            if (APP_STATE.lastSleepImage != 1) {
-              APP_STATE.lastSleepImage = 1;
-              changed = true;
-            }
-            if (changed) APP_STATE.saveToFile();
-          }
-        }
-      }
-    }
-#endif
     if (selectedImage.empty()) break;
     const auto filename = "/sleep/" + selectedImage;
     FsFile file;
@@ -408,183 +209,16 @@ void SleepActivity::renderCustomSleepScreen() const {
 }
 
 bool SleepActivity::randomizeSleepImagePlaylist() {
-#if SLEEP_V2
   return crosspoint::sleep::WallpaperPlaylist::instance().reshuffle();
-#else
-  const auto files = getValidSleepBitmaps();
-  if (files.empty()) {
-    if (!APP_STATE.sleepImagePlaylist.empty()) {
-      APP_STATE.sleepImagePlaylist.clear();
-      APP_STATE.saveToFile();
-    }
-    return false;
-  }
-
-  if (files.size() > CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST) {
-    // Large collection: pick a random starting file; sequential advance
-    // resumes from there on the next sleep.
-    const auto idx = static_cast<size_t>(random(static_cast<long>(files.size())));
-    APP_STATE.sleepImagePlaylist.clear();
-    APP_STATE.lastShownSleepFilename = files[idx];
-    APP_STATE.lastSleepImage = 0;
-    APP_STATE.saveToFile();
-    return true;
-  }
-
-  syncSleepPlaylistWithFiles(files, true);
-  return true;
-#endif
 }
 
-static size_t s_cachedSleepFavoriteCount = 0;
-
 size_t SleepActivity::cachedSleepFavoriteCount() {
-#if SLEEP_V2
   return crosspoint::sleep::WallpaperPlaylist::instance().cachedFavoriteCount();
-#else
-  return s_cachedSleepFavoriteCount;
-#endif
 }
 
 void SleepActivity::trimSleepFolderToLimit(GfxRenderer* popupRenderer) {
-#if SLEEP_V2
   (void)popupRenderer;  // No caller passes a non-null renderer today.
   crosspoint::sleep::WallpaperPlaylist::instance().trimToLimit();
-  return;
-#else
-  const size_t kLimit = CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST;
-  const size_t kScanCap = kLimit + 500;  // Hard cap on scanning to avoid OOM
-
-  // Count .bmp files in /sleep first to avoid allocating the vector if not needed.
-  // Also count favorites so callers can use cachedSleepFavoriteCount() without
-  // a separate directory scan.
-  size_t count = 0;
-  size_t scannedFavorites = 0;
-  auto dir = Storage.open("/sleep");
-  if (!dir || !dir.isDirectory()) {
-    if (dir) dir.close();
-    s_cachedSleepFavoriteCount = 0;
-    return;
-  }
-  char name[256];  // Reduced from 500 to save stack
-  for (auto file = dir.openNextFile(); file; file = dir.openNextFile()) {
-    if (file.isDirectory()) {
-      file.close();
-      continue;
-    }
-    file.getName(name, sizeof(name));
-    std::string filename(name);
-    if (!filename.empty() && filename[0] != '.' && filename.size() >= 4 &&
-        filename.substr(filename.size() - 4) == ".bmp") {
-      count++;
-      if (FavoriteBmp::isFavoritePath("/sleep/" + filename)) {
-        scannedFavorites++;
-      }
-      if (count > kScanCap) break;  // Optimization: we already know we're over limit
-    }
-    file.close();
-  }
-  dir.rewindDirectory();
-
-  if (count <= kLimit) {
-    s_cachedSleepFavoriteCount = scannedFavorites;
-    dir.close();
-    return;  // Under limit — nothing to do.
-  }
-
-  LOG_INF("SLP", "Trim: /sleep has %zu images (limit %zu), starting prune...", count, kLimit);
-
-  // Now scan and collect files up to cap
-  std::vector<std::string> allFiles;
-  allFiles.reserve(std::min(count, kScanCap));
-  for (auto file = dir.openNextFile(); file; file = dir.openNextFile()) {
-    if (file.isDirectory()) {
-      file.close();
-      continue;
-    }
-    file.getName(name, sizeof(name));
-    std::string filename(name);
-    if (!filename.empty() && filename[0] != '.' && filename.size() >= 4 &&
-        filename.substr(filename.size() - 4) == ".bmp") {
-      allFiles.emplace_back(std::move(filename));
-      if (allFiles.size() >= kScanCap) {
-        file.close();
-        break;
-      }
-    }
-    file.close();
-  }
-  dir.close();
-
-  std::sort(allFiles.begin(), allFiles.end());
-
-  // Sync the playlist against on-disk files: new files are inserted at the
-  // front (shown first), deleted files are pruned. Do not cap yet; trim picks
-  // the protected favorites to keep first.
-  syncSleepPlaylistWithFiles(allFiles, false, 0);
-
-  auto& playlist = APP_STATE.sleepImagePlaylist;
-  if (playlist.size() <= kLimit) {
-    return;
-  }
-
-  const size_t favoriteCount = std::count_if(playlist.begin(), playlist.end(), [](const std::string& filename) {
-    return FavoriteBmp::isFavoritePath("/sleep/" + filename);
-  });
-  s_cachedSleepFavoriteCount = favoriteCount;
-  if (favoriteCount > kLimit) {
-    LOG_ERR("SLP", "Trim: %zu favorites in /sleep exceed limit %zu", favoriteCount, kLimit);
-    return;
-  }
-
-  const size_t nonFavoriteBudget = kLimit - favoriteCount;
-  size_t keptNonFavorites = 0;
-  std::vector<std::string> keep;
-  std::vector<std::string> overflow;
-  keep.reserve(kLimit);
-  overflow.reserve(playlist.size() - kLimit);
-
-  for (const std::string& filename : playlist) {
-    const bool isFavorite = FavoriteBmp::isFavoritePath("/sleep/" + filename);
-    if (isFavorite) {
-      keep.push_back(filename);
-      continue;
-    }
-    if (keptNonFavorites < nonFavoriteBudget) {
-      keep.push_back(filename);
-      ++keptNonFavorites;
-    } else {
-      overflow.push_back(filename);
-    }
-  }
-
-  if (overflow.empty()) {
-    if (keep.size() < playlist.size()) {
-      playlist = keep;
-      APP_STATE.saveToFile();
-    }
-    return;
-  }
-
-  playlist = keep;
-
-  if (popupRenderer) {
-    StatusPopup::showBlocking(*popupRenderer, "Moving wallpapers");
-  }
-
-  Storage.mkdir("/sleep pause");
-  for (const auto& filename : overflow) {
-    const std::string src = std::string("/sleep/") + filename;
-    const std::string dst = std::string("/sleep pause/") + filename;
-    if (!Storage.rename(src.c_str(), dst.c_str())) {
-      LOG_ERR("SLP", "Trim: failed to move %s to sleep pause", filename.c_str());
-    } else {
-      FavoriteBmp::replacePathReferences(src, dst);
-      LOG_INF("SLP", "Trim: moved %s to /sleep pause", filename.c_str());
-    }
-  }
-  APP_STATE.saveToFile();
-#endif
 }
 
 void SleepActivity::renderDefaultSleepScreen() const {

--- a/src/lifecycle/ActivityRouter.cpp
+++ b/src/lifecycle/ActivityRouter.cpp
@@ -71,8 +71,7 @@ void ActivityRouter::enterDeepSleep(bool fromReader) {
 // Lambda synthesizers — return std::function callbacks bound to router.request.
 // Activities continue to receive the callbacks they have always received;
 // these let a caller (production main.cpp, or a host test) swap out the source
-// without touching every activity constructor. main.cpp still passes its own
-// free functions for the legacy LIFECYCLE_V2=0 path.
+// without touching every activity constructor.
 std::function<void(const std::string&)> ActivityRouter::makeGoToReader() const {
   return [](const std::string& p) { instance().request({RouteId::Reader, p}); };
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,11 +54,9 @@
 #if LIFECYCLE_V2
 #include "lifecycle/ActivityRouter.h"
 #endif
-#if SLEEP_V2
 #include "sleep/SdFatSleepFs.h"
 #include "sleep/WallpaperPlaylist.h"
 #include "util/FavoriteBmp.h"
-#endif
 #ifdef PERSIST_V2
 #include "persist/AppStateStore.h"
 #include "persist/PersistManager.h"
@@ -196,7 +194,7 @@ bool persistAppState(const char* context) {
 #endif
 }
 
-static void trimSleepFolderIfDirty();  // fwd decl — defined with sleepFolderDirty below
+static void trimSleepFolderIfDirty();  // fwd decl — defined below
 
 // Verify power button press duration on wake-up from deep sleep
 // Pre-condition: isWakeupByPowerButton() == true
@@ -276,13 +274,10 @@ void onGoHome();
 void onGoToMyLibraryWithPath(const std::string& path);
 void onGoToRecentBooks();
 
-// When true the /sleep folder may have changed since the last trim, so the
-// Home route policy will re-scan. Set to false after a successful trim and to
-// true before entering activities that can modify /sleep (e.g. file transfer).
-// V2 (SLEEP_V2): state lives in crosspoint::sleep::WallpaperPlaylist — this flag unused.
-static bool sleepFolderDirty = true;
+// Folder-dirty state lives in crosspoint::sleep::WallpaperPlaylist; it is
+// marked dirty before entering activities that can modify /sleep (e.g. file
+// transfer) and reconciled by trimSleepFolderIfDirty() on the Home route.
 
-#if SLEEP_V2
 static crosspoint::sleep::SdFatSleepFs s_sleepFs;
 
 static void wireWallpaperPlaylist() {
@@ -313,18 +308,10 @@ static void wireWallpaperPlaylist() {
   deps.onBeforeTrimMove = []() {};  // no popup in current call sites
   crosspoint::sleep::WallpaperPlaylist::instance().setDeps(deps);
 }
-#endif
 
 static void trimSleepFolderIfDirty() {
-#if SLEEP_V2
   auto& wp = crosspoint::sleep::WallpaperPlaylist::instance();
   if (wp.dirty()) wp.reconcile();
-#else
-  if (sleepFolderDirty) {
-    SleepActivity::trimSleepFolderToLimit();
-    sleepFolderDirty = false;
-  }
-#endif
 }
 
 // Inline Reader activity construction. Used by both the V2 factory and the
@@ -347,11 +334,7 @@ void onGoToReader(const std::string& initialEpubPath) {
 
 static void openFileTransferInline() {
   TransitionFeedback::show(renderer, "Starting server...");
-#if SLEEP_V2
   crosspoint::sleep::WallpaperPlaylist::instance().markFolderDirty();
-#else
-  sleepFolderDirty = true;  // Files may be uploaded to /sleep during transfer
-#endif
   exitActivity();
   enterNewActivity(new CrossPointWebServerActivity(renderer, mappedInputManager, onGoHome));
 }
@@ -633,12 +616,10 @@ void setup() {
 #endif
   APP_STATE.loadFromFile();
 
-#if SLEEP_V2
   // Wire crosspoint::sleep::WallpaperPlaylist deps now that APP_STATE is populated — all
   // subsequent sleep paths (trimSleepFolderIfDirty, SleepActivity) read through
   // the module.
   wireWallpaperPlaylist();
-#endif
 
   LOG_INF("MAIN", "Booting complete, checking initial activity");
 
@@ -683,14 +664,9 @@ void setup() {
   // Defer sleep cache trimming until home screen is actually needed.
   if (goHome) {
     bootActivity->setProgress(60, "Refreshing sleep cache");
-#if SLEEP_V2
     auto& wp = crosspoint::sleep::WallpaperPlaylist::instance();
     wp.markFolderDirty();
     wp.reconcile();
-#else
-    SleepActivity::trimSleepFolderToLimit();
-    sleepFolderDirty = false;
-#endif
   }
   bootActivity->setProgress(80, goHome ? "Preparing home" : "Resuming book");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,12 +55,10 @@
 #include "sleep/SdFatSleepFs.h"
 #include "sleep/WallpaperPlaylist.h"
 #include "util/FavoriteBmp.h"
-#ifdef PERSIST_V2
 #include "persist/AppStateStore.h"
 #include "persist/PersistManager.h"
 #include "persist/SdFatFileIO.h"
 #include "persist/Trash.h"
-#endif
 
 HalDisplay display;
 HalGPIO gpio;
@@ -176,20 +174,13 @@ void enterNewActivity(Activity* activity) {
 }
 
 bool persistAppState(const char* context) {
-#ifdef PERSIST_V2
-  // V2: force sync flush of all dirty stores (not just APP_STATE). Activity
-  // transitions are the crash-safety boundary — debounce only coalesces
-  // within an activity, never across one.
+  // Force sync flush of all dirty stores. Activity transitions are the
+  // crash-safety boundary — debounce only coalesces within an activity,
+  // never across one.
+  (void)context;
   const size_t flushed = crosspoint::persist::PersistManager().flushAll();
   (void)flushed;
   return true;
-#else
-  if (!APP_STATE.saveToFile()) {
-    LOG_ERR("MAIN", "Failed to save app state (%s)", context);
-    return false;
-  }
-  return true;
-#endif
 }
 
 static void trimSleepFolderIfDirty();  // fwd decl — defined below
@@ -267,15 +258,13 @@ static void wireWallpaperPlaylist() {
   deps.lastRenderedPath = &APP_STATE.lastSleepWallpaperPath;
   // WallpaperPlaylist::advance() runs inside SleepActivity::onEnter, AFTER
   // enterDeepSleep's persistAppState flush and milliseconds before the CPU
-  // enters deep sleep. Under PERSIST_V2 saveToFile() is debounced — the
-  // debounce window never fires, so the new lastShownSleepFilename is lost
-  // and the next boot loads the stale value (same wallpaper every wake).
-  // Force a sync flush so rotation survives the deep-sleep boundary.
+  // enters deep sleep. saveToFile() is debounced — the debounce window
+  // never fires, so the new lastShownSleepFilename is lost and the next
+  // boot loads the stale value (same wallpaper every wake). Force a sync
+  // flush so rotation survives the deep-sleep boundary.
   deps.saveState = []() {
     const bool ok = APP_STATE.saveToFile();
-#ifdef PERSIST_V2
     crosspoint::persist::PersistManager().flushAll();
-#endif
     return ok;
   };
   deps.randomFn = [](long mod) -> long { return ::random(mod); };
@@ -540,7 +529,6 @@ void setup() {
   enterNewActivity(bootActivity);
 
   bootActivity->setProgress(32, "Restoring state");
-#ifdef PERSIST_V2
   {
     // Touch the store so it registers with PersistManager before the sidecar
     // backup runs (backup iterates registered store paths).
@@ -550,7 +538,6 @@ void setup() {
       LOG_INF("MAIN", "First boot of %s — SD sidecar backup written", CROSSPOINT_VERSION);
     }
   }
-#endif
   APP_STATE.loadFromFile();
 
   // Wire crosspoint::sleep::WallpaperPlaylist deps now that APP_STATE is populated — all
@@ -671,11 +658,9 @@ void loop() {
 
   gpio.update();
 
-#ifdef PERSIST_V2
   // Drain any coalesced dirty writes. Stores flush only when debounce
   // window has elapsed since the last markDirty; most ticks are no-ops.
   crosspoint::persist::PersistManager().tick(static_cast<uint32_t>(loopStartTime));
-#endif
 
   // Only update fading fix when it changes (avoid calling every loop iteration)
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,9 +51,7 @@
 #include "fontIds.h"
 #include "util/ButtonNavigator.h"
 #include "util/TransitionFeedback.h"
-#if LIFECYCLE_V2
 #include "lifecycle/ActivityRouter.h"
-#endif
 #include "sleep/SdFatSleepFs.h"
 #include "sleep/WallpaperPlaylist.h"
 #include "util/FavoriteBmp.h"
@@ -250,26 +248,6 @@ void waitForPowerRelease() {
   }
 }
 
-// Enter deep sleep mode
-void enterDeepSleep() {
-  // Shut down BLE before sleep to free resources
-  if (BLE_HID.isInitialized()) {
-    BLE_HID.disconnect();
-    BLE_HID.deinit();
-  }
-
-  APP_STATE.lastSleepFromReader = currentActivity && currentActivity->isReaderActivity();
-  persistAppState("enter deep sleep");
-  exitActivity();
-  enterNewActivity(new SleepActivity(renderer, mappedInputManager));
-
-  display.deepSleep();
-  LOG_DBG("MAIN", "Power button press calibration value: %lu ms", t2 - t1);
-  LOG_DBG("MAIN", "Entering deep sleep");
-
-  powerManager.startDeepSleep(gpio);
-}
-
 void onGoHome();
 void onGoToMyLibraryWithPath(const std::string& path);
 void onGoToRecentBooks();
@@ -325,11 +303,7 @@ static void openReaderInline(const std::string& initialEpubPath) {
 }
 
 void onGoToReader(const std::string& initialEpubPath) {
-#if LIFECYCLE_V2
   lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::Reader, initialEpubPath});
-#else
-  openReaderInline(initialEpubPath);
-#endif
 }
 
 static void openFileTransferInline() {
@@ -340,26 +314,14 @@ static void openFileTransferInline() {
 }
 
 void onGoToFileTransfer() {
-#if LIFECYCLE_V2
   lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::FileTransfer, ""});
-#else
-  openFileTransferInline();
-#endif
 }
 
 void onGoToSettings() {
-#if LIFECYCLE_V2
   lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::Settings, ""});
-#else
-  TransitionFeedback::show(renderer, "Loading settings...");
-  exitActivity();
-  enterNewActivity(new SettingsActivity(renderer, mappedInputManager, onGoHome));
-#endif
 }
 
-// V2 path: ActivityRouter applies persist policy before calling this factory.
-// Legacy path: the #else branch in onGoToMyLibrary / onGoToMyLibraryWithPath
-// explicitly persists before calling this helper.
+// ActivityRouter applies persist policy before calling this factory (RFC #23).
 static void openMyLibraryInline(const std::string& path) {
   TransitionFeedback::show(renderer, "Loading library...");
   exitActivity();
@@ -371,12 +333,7 @@ static void openMyLibraryInline(const std::string& path) {
 }
 
 void onGoToMyLibrary() {
-#if LIFECYCLE_V2
   lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::MyLibrary, ""});
-#else
-  persistAppState("go to library");
-  openMyLibraryInline("");
-#endif
 }
 
 static void openRecentBooksInline() {
@@ -386,21 +343,11 @@ static void openRecentBooksInline() {
 }
 
 void onGoToRecentBooks() {
-#if LIFECYCLE_V2
   lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::RecentBooks, ""});
-#else
-  persistAppState("go to recents");
-  openRecentBooksInline();
-#endif
 }
 
 void onGoToMyLibraryWithPath(const std::string& path) {
-#if LIFECYCLE_V2
   lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::MyLibraryAt, path});
-#else
-  persistAppState("go to library path");
-  openMyLibraryInline(path);
-#endif
 }
 
 static void openBrowserInline() {
@@ -410,11 +357,7 @@ static void openBrowserInline() {
 }
 
 void onGoToBrowser() {
-#if LIFECYCLE_V2
   lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::Browser, ""});
-#else
-  openBrowserInline();
-#endif
 }
 
 static void openHomeInline() {
@@ -425,13 +368,7 @@ static void openHomeInline() {
 }
 
 void onGoHome() {
-#if LIFECYCLE_V2
   lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::Home, ""});
-#else
-  trimSleepFolderIfDirty();
-  persistAppState("go home");
-  openHomeInline();
-#endif
 }
 
 void setupDisplayAndFonts() {
@@ -670,11 +607,10 @@ void setup() {
   }
   bootActivity->setProgress(80, goHome ? "Preparing home" : "Resuming book");
 
-#if LIFECYCLE_V2
-  // Wire ActivityRouter with Deps + route factories (#23). All transitions on
-  // the V2 path flow through the router: per-route persist/trim policy is
-  // applied before the factory runs, and deep-sleep entry follows the fixed
-  // hook sequence in ActivityRouter::enterDeepSleep.
+  // Wire ActivityRouter with Deps + route factories (RFC #23). All transitions
+  // flow through the router: per-route persist/trim policy is applied before
+  // the factory runs, and deep-sleep entry follows the fixed hook sequence in
+  // ActivityRouter::enterDeepSleep.
   {
     auto& router = lifecycle::ActivityRouter::instance();
 
@@ -715,22 +651,13 @@ void setup() {
     router.setRouteFactory(lifecycle::RouteId::Browser, [](const std::string& /*payload*/) { openBrowserInline(); });
     router.setRouteFactory(lifecycle::RouteId::Home, [](const std::string& /*payload*/) { openHomeInline(); });
   }
-#endif
 
   if (goHome) {
     bootActivity->setProgress(100, "Opening home");
-#if LIFECYCLE_V2
     lifecycle::ActivityRouter::instance().begin({lifecycle::RouteId::Home, ""});
-#else
-    onGoHome();
-#endif
   } else {
     bootActivity->setProgress(100, "Opening book");
-#if LIFECYCLE_V2
     lifecycle::ActivityRouter::instance().begin({lifecycle::RouteId::Reader, readerPath});
-#else
-    onGoToReader(readerPath);
-#endif
   }
 
   // Ensure we're not still holding the power button before leaving setup
@@ -798,12 +725,8 @@ void loop() {
   }
 
   auto triggerDeepSleep = []() {
-#if LIFECYCLE_V2
     const bool fromReader = currentActivity && currentActivity->isReaderActivity();
     lifecycle::ActivityRouter::instance().enterDeepSleep(fromReader);
-#else
-    enterDeepSleep();
-#endif
   };
 
   const unsigned long sleepTimeoutMs = SETTINGS.getSleepTimeoutMs();
@@ -831,11 +754,9 @@ void loop() {
     currentActivity->loop();
   }
 
-#if LIFECYCLE_V2
   // Drain any transition requested during currentActivity->loop() at a safe
   // boundary (after the activity has returned from its tick).
   lifecycle::ActivityRouter::instance().applyIfPending();
-#endif
 
   const unsigned long loopDuration = millis() - loopStartTime;
   if (loopDuration > maxLoopDuration) {

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -30,10 +30,8 @@
 #include "html/js/jszip_minJs.generated.h"
 #include "util/StringUtils.h"
 
-#if WEBSERVER_V2
 #include "network/SettingsGateway.h"
 #include "network/ws/WsUploadSession.h"
-#endif
 
 namespace {
 // Folders/files to hide from the web interface file browser
@@ -67,14 +65,11 @@ String wsLastCompleteName;
 size_t wsLastCompleteSize = 0;
 unsigned long wsLastCompleteAt = 0;
 
-#if WEBSERVER_V2
-// V2 globals (RFC #24). Session owns the WS upload state machine; gateway
-// owns the settings POST orchestration. Both created in begin(), destroyed
-// in stop(). Kept at file scope rather than class members so the V1 path
-// stays byte-identical when WEBSERVER_V2 is off.
+// RFC #24 globals. Session owns the WS upload state machine; gateway owns
+// the settings POST orchestration. Both created in begin(), destroyed in
+// stop().
 std::unique_ptr<crosspoint::ws::WsUploadSession> g_wsUploadSession;
 std::unique_ptr<crosspoint::network::SettingsGateway> g_settingsGateway;
-#endif
 
 // Compute the cache directory path for a book file (returns empty if not a book).
 // Uses content-based fingerprint so the path is stable across file moves.
@@ -281,11 +276,9 @@ void CrossPointWebServer::begin() {
   udpActive = udp.begin(LOCAL_UDP_PORT);
   LOG_DBG("WEB", "Discovery UDP %s on port %d", udpActive ? "enabled" : "failed", LOCAL_UDP_PORT);
 
-#if WEBSERVER_V2
-  // WsUploadSession deps bind the existing file-scope upload state so the V1
-  // ownership semantics (wsUploadFile, wsUploadFileName, wsUploadPath,
-  // wsUploadSize, wsLastCompleteName/Size/At) are preserved exactly. V1 code
-  // paths continue to read these for status endpoints.
+  // WsUploadSession deps bind the file-scope upload state (wsUploadFile,
+  // wsUploadFileName, wsUploadPath, wsUploadSize, wsLastCompleteName/Size/At)
+  // so the HTTP status endpoints continue to read them.
   crosspoint::ws::WsUploadDeps wsDeps;
   wsDeps.beginWrite = [](const std::string& path, const std::string& name) {
     wsUploadPath = path.c_str();
@@ -408,7 +401,6 @@ void CrossPointWebServer::begin() {
         return applied;
       },
       [] { return SETTINGS.saveToFile(); }));
-#endif
 
   running = true;
 
@@ -497,24 +489,16 @@ void CrossPointWebServer::stop() {
   LOG_DBG("WEB", "[MEM] Free heap before stop: %d bytes", ESP.getFreeHeap());
 
   // Close any in-progress WebSocket upload and remove partial file
-#if WEBSERVER_V2
   if (g_wsUploadSession) g_wsUploadSession->abort("server stopping");
-#else
-  if (wsUploadInProgress && wsUploadFile) {
-    abortWsUpload("WEB");
-  }
-#endif
   if (wsDownloadInProgress && wsDownloadFile) {
     wsDownloadFile.close();
     wsDownloadInProgress = false;
   }
 
-#if WEBSERVER_V2
-  // Release V2 state before the WS server goes away, so any pending callbacks
-  // have no session to delegate to (checked at dispatch).
+  // Release session + gateway before the WS server goes away, so any pending
+  // callbacks have no session to delegate to (checked at dispatch).
   g_wsUploadSession.reset();
   g_settingsGateway.reset();
-#endif
 
   // Stop WebSocket server
   if (wsServer) {
@@ -577,11 +561,9 @@ void CrossPointWebServer::handleClient() {
 
   pumpWsDownload();
 
-#if WEBSERVER_V2
   // Enforce the idle timeout on WS uploads. If a client dies without sending
   // TCP FIN the session would otherwise wedge until reboot.
   if (g_wsUploadSession) g_wsUploadSession->tick(static_cast<uint32_t>(millis()));
-#endif
 
   // Respond to discovery broadcasts
   if (udpActive) {
@@ -1576,95 +1558,20 @@ void CrossPointWebServer::handlePostSettings() {
     return;
   }
 
-#if WEBSERVER_V2
   if (!g_settingsGateway) {
     server->send(500, "text/plain", "Settings gateway not initialized");
     return;
   }
   const auto r = g_settingsGateway->applyJson(doc);
   if (!r.persisted) {
-    // 500 is the bug fix: V1 returned 200 even on disk error, so the browser
-    // UI reported "saved" while settings reverted on the next boot.
+    // Return 500 on disk error so the browser UI doesn't falsely report
+    // "saved" while settings silently revert on the next boot.
     LOG_ERR("WEB", "Settings save failed: %s", r.error.c_str());
     server->send(500, "text/plain", String("Applied but not saved: ") + r.error.c_str());
     return;
   }
   LOG_DBG("WEB", "Applied %d setting(s)", r.applied);
   server->send(200, "text/plain", String("Applied ") + String(r.applied) + " setting(s)");
-  return;
-#else
-  auto settings = getSettingsList();
-  int applied = 0;
-
-  for (auto& s : settings) {
-    if (!s.key) continue;
-    if (!doc[s.key].is<JsonVariant>()) continue;
-
-    switch (s.type) {
-      case SettingType::TOGGLE: {
-        const int val = doc[s.key].as<int>() ? 1 : 0;
-        if (s.valuePtr) {
-          SETTINGS.*(s.valuePtr) = val;
-        }
-        applied++;
-        break;
-      }
-      case SettingType::ENUM: {
-        const int val = doc[s.key].as<int>();
-        const int maxEnumValue = (s.valuePtr == &CrossPointSettings::fontSize)
-                                     ? static_cast<int>(CrossPointSettings::fontSizeOptionCount(SETTINGS.fontFamily))
-                                     : static_cast<int>(s.enumValues.size());
-        if (val >= 0 && val < maxEnumValue) {
-          if (s.valuePtr) {
-            if (s.valuePtr == &CrossPointSettings::fontSize) {
-              SETTINGS.fontSize =
-                  CrossPointSettings::displayIndexToFontSize(SETTINGS.fontFamily, static_cast<uint8_t>(val));
-            } else if (s.valuePtr == &CrossPointSettings::fontFamily) {
-              SETTINGS.fontFamily = CrossPointSettings::displayIndexToFontFamily(static_cast<uint8_t>(val));
-              SETTINGS.fontSize =
-                  CrossPointSettings::normalizeFontSizeForFamily(SETTINGS.fontFamily, SETTINGS.fontSize);
-              SETTINGS.lineSpacingPercent = 90;  // Reset to default on font change
-            } else {
-              SETTINGS.*(s.valuePtr) = static_cast<uint8_t>(val);
-            }
-          } else if (s.valueSetter) {
-            s.valueSetter(static_cast<uint8_t>(val));
-          }
-          applied++;
-        }
-        break;
-      }
-      case SettingType::VALUE: {
-        const int val = doc[s.key].as<int>();
-        if (val >= s.valueRange.min && val <= s.valueRange.max) {
-          if (s.valuePtr) {
-            SETTINGS.*(s.valuePtr) = static_cast<uint8_t>(val);
-          }
-          applied++;
-        }
-        break;
-      }
-      case SettingType::STRING: {
-        const std::string val = doc[s.key].as<std::string>();
-        if (s.stringSetter) {
-          s.stringSetter(val);
-        } else if (s.stringPtr && s.stringMaxLen > 0) {
-          strncpy(s.stringPtr, val.c_str(), s.stringMaxLen - 1);
-          s.stringPtr[s.stringMaxLen - 1] = '\0';
-        }
-        applied++;
-        break;
-      }
-      default:
-        break;
-    }
-  }
-
-  SETTINGS.saveToFile();
-
-  LOG_DBG("WEB", "Applied %d setting(s)", applied);
-  server->send(200, "text/plain", String("Applied ") + String(applied) + " setting(s)");
-#endif  // WEBSERVER_V2
 }
 
 // WebSocket callback trampoline — check both pointer and running flag.
@@ -1688,16 +1595,7 @@ void CrossPointWebServer::onWebSocketEvent(uint8_t num, WStype_t type, uint8_t* 
   switch (type) {
     case WStype_DISCONNECTED:
       LOG_DBG("WS", "Client %u disconnected", num);
-#if WEBSERVER_V2
       if (g_wsUploadSession) g_wsUploadSession->onDisconnect(num);
-#else
-      // Only clean up if this is the client that owns the active upload.
-      // A new client may have already started a fresh upload before this
-      // DISCONNECTED event fires (race condition on quick cancel + retry).
-      if (num == wsUploadClientNum && wsUploadInProgress && wsUploadFile) {
-        abortWsUpload("WS");
-      }
-#endif
       // Clean up any in-progress download
       if (wsDownloadInProgress && wsDownloadClientNum == num) {
         wsDownloadFile.close();
@@ -1718,21 +1616,13 @@ void CrossPointWebServer::onWebSocketEvent(uint8_t num, WStype_t type, uint8_t* 
       if (msg.startsWith("DOWNLOAD:")) {
         handleWsDownloadRequest(num, msg);
       } else if (msg.startsWith("START:")) {
-#if WEBSERVER_V2
         if (g_wsUploadSession) g_wsUploadSession->onStart(num, std::string(msg.c_str()));
-#else
-        handleWsUploadStart(num, msg);
-#endif
       }
       break;
     }
 
     case WStype_BIN: {
-#if WEBSERVER_V2
       if (g_wsUploadSession) g_wsUploadSession->onBinary(num, payload, length);
-#else
-      handleWsUploadData(num, payload, length);
-#endif
       break;
     }
 

--- a/src/persist/AppStateStore.cpp
+++ b/src/persist/AppStateStore.cpp
@@ -1,5 +1,3 @@
-#ifdef PERSIST_V2
-
 #include "AppStateStore.h"
 
 #include "../CrossPointState.h"
@@ -41,5 +39,3 @@ PersistentStore<CrossPointState>& appStateStore() {
 
 }  // namespace persist
 }  // namespace crosspoint
-
-#endif  // PERSIST_V2

--- a/src/persist/AppStateStore.h
+++ b/src/persist/AppStateStore.h
@@ -1,16 +1,13 @@
 /**
  * @file AppStateStore.h
- * @brief V2 PersistentStore<CrossPointState> singleton accessor.
+ * @brief PersistentStore<CrossPointState> singleton accessor (RFC #20).
  *
- * Under PERSIST_V2, CrossPointState::getInstance() is backed by this
- * store's internal data, and saveToFile()/loadFromFile() delegate to
- * flushSoon()/load(). Caller API on APP_STATE is unchanged — all 24
- * call sites keep working without caller changes, gaining debounce
- * coalescing transparently.
+ * CrossPointState::getInstance() is backed by this store's internal
+ * data, and saveToFile()/loadFromFile() delegate to flushSoon()/load().
+ * Caller API on APP_STATE is unchanged — all 24 call sites keep working
+ * without caller changes, gaining debounce coalescing transparently.
  */
 #pragma once
-
-#ifdef PERSIST_V2
 
 #include "CrossPointStateJson.h"
 #include "PersistentStore.h"
@@ -26,5 +23,3 @@ PersistentStore<CrossPointState>& appStateStore();
 
 }  // namespace persist
 }  // namespace crosspoint
-
-#endif  // PERSIST_V2

--- a/src/persist/CrossPointStateJson.h
+++ b/src/persist/CrossPointStateJson.h
@@ -2,10 +2,10 @@
  * @file CrossPointStateJson.h
  * @brief Free toJson/fromJson pair for CrossPointState.
  *
- * Byte-identical to JsonSettingsIO::saveState/loadState. Extracted so
- * PersistentStore<CrossPointState> can own the store without reaching
- * into the 1045-LOC god-marshaller. Under PERSIST_V2 this is the
- * serializer plugged into the template.
+ * PersistentStore<CrossPointState> plugs these into the template as
+ * its serializer pair (RFC #20). Streaming variant writes straight to
+ * a JsonSink so a populated sleep playlist doesn't peak as a ~15 KB
+ * std::string on the heap (see issue #43 postmortem).
  */
 #pragma once
 

--- a/src/persist/PersistManager.h
+++ b/src/persist/PersistManager.h
@@ -2,9 +2,9 @@
  * @file PersistManager.h
  * @brief Coordinates multi-store tick/flush and first-boot SD sidecar backup.
  *
- * Under PERSIST_V2 this replaces persistAppState() in main.cpp with a
- * single flushAll() call at activity-transition chokepoints. Stores
- * register themselves via registerStore<T>().
+ * Backs persistAppState() in main.cpp: a single flushAll() call at
+ * activity-transition chokepoints (RFC #20). Stores register themselves
+ * via registerStore<T>().
  */
 #pragma once
 

--- a/src/sleep/WallpaperPlaylist.h
+++ b/src/sleep/WallpaperPlaylist.h
@@ -6,8 +6,6 @@
  * playlist advance, reshuffle, and trim-to-limit. State lives in APP_STATE
  * (pointers injected via Deps — zero state.json schema change). All SD and
  * persistence calls are injected, enabling host-side unit tests.
- *
- * Call sites migrate under #if SLEEP_V2 (debug env only until soak-tested).
  */
 #pragma once
 
@@ -69,7 +67,7 @@ class WallpaperPlaylist {
   void setDeps(const Deps&);
   const Deps& deps() const { return deps_; }
 
-  // Replaces global sleepFolderDirty flag.
+  // Marks /sleep as needing a reconcile on next policy tick.
   void markFolderDirty() { dirty_ = true; }
   bool dirty() const { return dirty_; }
 


### PR DESCRIPTION
## Summary

All four V2 refactor flags (RFC #20 PERSIST, RFC #22 SLEEP, RFC #23 LIFECYCLE, RFC #24 WEBSERVER) shipped to base in v1.1.0 (2026-04-19). Soaked through v1.1.2 + v1.2.0-rc1 — no regressions reported. Delete the V1 fallback paths, drop the build flags, and unwrap file-level `#ifdef` guards.

**Four commits, one per cluster, for clean bisect:**

| Cluster | Commit | Net LOC |
|---|---|---|
| WEBSERVER_V2 | fcf3145 | -120 |
| SLEEP_V2 + orphan helpers | 3165396 | -395 |
| LIFECYCLE_V2 | ed14105 | -83 |
| PERSIST_V2 | ee1f0dd | -154 |
| **Total** | | **-752** |

### Orphans deleted (had zero callers after gate rip)
- `getValidSleepBitmaps`, `syncSleepPlaylistWithFiles`, `nextSleepImageLargeCollection`, `shuffleSleepPlaylist`, `sleepFolderDirty` global, `s_cachedSleepFavoriteCount`
- Legacy `enterDeepSleep()` free function in main.cpp (router method replaces it)
- `JsonSettingsIO::saveState` / `loadState` (~71 lines — only reachable from V1 CrossPointState marshalling)
- `CrossPointState::instance` static + V1 `getInstance/saveToFile/loadFromFile` overloads

### Retained on purpose
- `loadFromBinaryFile` — still needed for V2 migration of pre-RFC-#20 `state.bin` files.
- All `onGoTo*` callbacks, route factories, `persistAppState`, `trimSleepFolderIfDirty` — wired as router deps.

### Build impact (`pio run -e default`)
- SUCCESS in 59 s
- Flash: **4,975,698 bytes** (75.9% of 6.25 MB OTA slot) — **-63 KB** vs v1.1.2 baseline
- RAM: 33.6%

## Test plan

- [ ] Flash `firmware.bin` from this branch to a test device
- [ ] Boot → verify home screen renders, no crash on `CrossPointState::getInstance()`
- [ ] Open a book, exit, verify `persistAppState` debounce still works (bookmark saves)
- [ ] Enter + wake from sleep at least twice → wallpaper playlist advances correctly
- [ ] WS upload a file via web UI → file lands, progress UI works, 500-on-error path intact
- [ ] POST a settings change via web UI → settings persist, browser gets success/failure correctly
- [ ] Navigate Home → Settings → back → Home → verify ActivityRouter lifecycle is clean
- [ ] Power-button deep-sleep → state persists, boots back clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)