### PR TITLE
feat(reader): make Bold Swap a per-book preference

### DIFF
--- a/src/CrossPointSettings.cpp
+++ b/src/CrossPointSettings.cpp
@@ -373,7 +373,13 @@ bool CrossPointSettings::loadFromBinaryFile() {
     }
     statusBarGranularRead = true;
     if (++settingsRead >= fileSettingsCount) break;
-    serialization::readPod(inputFile, readerBoldSwap);
+    {
+      // Legacy global readerBoldSwap: the preference is now stored per book in
+      // RecentBooksStore, so read and discard to keep binary offsets aligned
+      // for any remaining fields below.
+      uint8_t legacyReaderBoldSwap = 0;
+      serialization::readPod(inputFile, legacyReaderBoldSwap);
+    }
     if (++settingsRead >= fileSettingsCount) break;
     serialization::readPod(inputFile, debugBorders);
     if (++settingsRead >= fileSettingsCount) break;

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -309,8 +309,6 @@ class CrossPointSettings {
   // Reader line spacing percentage (35..150)
   uint8_t lineSpacingPercent = 110;
   uint8_t paragraphAlignment = JUSTIFIED;
-  // Reader-only style swap: Regular <-> Bold (italics unchanged)
-  uint8_t readerBoldSwap = 0;
   // Auto-sleep timeout setting (default 10 minutes)
   uint8_t sleepTimeout = SLEEP_10_MIN;
   // Show hidden files/directories (starting with '.') in file browser

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -406,7 +406,6 @@ bool JsonSettingsIO::saveSettings(const CrossPointSettings& s, const char* path)
   doc["hideBatteryPercentage"] = s.hideBatteryPercentage;
   doc["longPressChapterSkip"] = s.longPressChapterSkip;
   doc["hyphenationEnabled"] = s.hyphenationEnabled;
-  doc["readerBoldSwap"] = s.readerBoldSwap;
   doc["fadingFix"] = s.fadingFix;
   doc["embeddedStyle"] = s.readerStyleMode == CrossPointSettings::READER_STYLE_HYBRID;
   doc["debugBorders"] = s.debugBorders;
@@ -694,7 +693,6 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
       clampEnum(doc["hideBatteryPercentage"] | (uint8_t)S::HIDE_NEVER, S::HIDE_BATTERY_PERCENTAGE_COUNT, S::HIDE_NEVER);
   s.longPressChapterSkip = doc["longPressChapterSkip"] | (uint8_t)1;
   s.hyphenationEnabled = doc["hyphenationEnabled"] | (uint8_t)0;
-  s.readerBoldSwap = doc["readerBoldSwap"] | (uint8_t)0;
   s.fadingFix = doc["fadingFix"] | (uint8_t)0;
   s.embeddedStyle = s.readerStyleMode == S::READER_STYLE_HYBRID ? (uint8_t)1 : (uint8_t)0;
   s.debugBorders = doc["debugBorders"] | (uint8_t)0;
@@ -843,6 +841,7 @@ bool JsonSettingsIO::saveRecentBooks(const RecentBooksStore& store, const char* 
     obj["title"] = book.title;
     obj["author"] = book.author;
     obj["coverBmpPath"] = book.coverBmpPath;
+    obj["boldSwap"] = book.boldSwap;
   }
 
   String json;
@@ -867,6 +866,8 @@ bool JsonSettingsIO::loadRecentBooks(RecentBooksStore& store, const char* json) 
     book.title = obj["title"] | std::string("");
     book.author = obj["author"] | std::string("");
     book.coverBmpPath = obj["coverBmpPath"] | std::string("");
+    // Missing field (older recent.json) -> default OFF.
+    book.boldSwap = (obj["boldSwap"] | (uint8_t)0) != 0 ? 1 : 0;
     store.recentBooks.push_back(book);
   }
 

--- a/src/RecentBooksStore.cpp
+++ b/src/RecentBooksStore.cpp
@@ -85,9 +85,15 @@ void RecentBooksStore::addBook(const std::string& path, const std::string& title
     return;
   }
 
+  // Preserve per-book preferences (e.g. Bold Swap) when the book is re-added:
+  // addBook is called every time a book is opened, and erasing-then-reinserting
+  // would otherwise reset any per-book toggles the user set earlier.
+  uint8_t preservedBoldSwap = 0;
+
   // Remove existing entry if present
   for (auto it = recentBooks.begin(); it != recentBooks.end();) {
     if (makeRecentPathKey(it->path) == normalizedKey) {
+      preservedBoldSwap = it->boldSwap;
       it = recentBooks.erase(it);
     } else {
       ++it;
@@ -95,7 +101,9 @@ void RecentBooksStore::addBook(const std::string& path, const std::string& title
   }
 
   // Add to front
-  recentBooks.insert(recentBooks.begin(), {normalizedPath, title, author, coverBmpPath});
+  RecentBook entry{normalizedPath, title, author, coverBmpPath};
+  entry.boldSwap = preservedBoldSwap;
+  recentBooks.insert(recentBooks.begin(), entry);
 
   dedupeRecentBooks(recentBooks);
 
@@ -212,6 +220,47 @@ bool RecentBooksStore::saveToFile() const {
     LOG_ERR("RBS", "Failed to save recent books to %s", RECENT_BOOKS_FILE_JSON);
   }
   return ok;
+}
+
+bool RecentBooksStore::getBoldSwap(const std::string& path) const {
+  const std::string normalizedKey = makeRecentPathKey(normalizeRecentPath(path));
+  if (normalizedKey.empty()) {
+    return false;
+  }
+  for (const auto& book : recentBooks) {
+    if (makeRecentPathKey(book.path) == normalizedKey) {
+      return book.boldSwap != 0;
+    }
+  }
+  return false;
+}
+
+void RecentBooksStore::setBoldSwap(const std::string& path, bool enabled) {
+  const std::string normalizedPath = normalizeRecentPath(path);
+  const std::string normalizedKey = makeRecentPathKey(normalizedPath);
+  if (normalizedPath.empty()) {
+    return;
+  }
+  const uint8_t newValue = enabled ? 1 : 0;
+  for (auto& book : recentBooks) {
+    if (makeRecentPathKey(book.path) == normalizedKey) {
+      if (book.boldSwap == newValue) {
+        return;
+      }
+      book.boldSwap = newValue;
+      saveToFile();
+      return;
+    }
+  }
+
+  // Book not yet registered: create a minimal entry so the preference
+  // persists. Titles/author/cover fill in when the reader calls addBook().
+  RecentBook entry;
+  entry.path = normalizedPath;
+  entry.boldSwap = newValue;
+  recentBooks.insert(recentBooks.begin(), entry);
+  dedupeRecentBooks(recentBooks);
+  saveToFile();
 }
 
 RecentBook RecentBooksStore::getDataFromBook(std::string path) const {

--- a/src/RecentBooksStore.h
+++ b/src/RecentBooksStore.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -7,6 +8,10 @@ struct RecentBook {
   std::string title;
   std::string author;
   std::string coverBmpPath;
+  // Per-book reader Bold Swap preference (0 = off, 1 = on). Persisted alongside
+  // the rest of the recent-books record so it survives reboots and only
+  // affects the book it was toggled on.
+  uint8_t boldSwap = 0;
 
   bool operator==(const RecentBook& other) const { return path == other.path; }
 };
@@ -52,6 +57,13 @@ class RecentBooksStore {
   int getCount() const { return static_cast<int>(recentBooks.size()); }
 
   bool saveToFile() const;
+
+  // Per-book Bold Swap preference. Lookup is by book path; unknown paths
+  // return false so first-time opens always start with bold swap OFF.
+  // setBoldSwap creates the entry if missing (title/author/cover empty) so the
+  // preference can still be persisted before the book's metadata is registered.
+  bool getBoldSwap(const std::string& path) const;
+  void setBoldSwap(const std::string& path, bool enabled);
 
   bool loadFromFile();
   RecentBook getDataFromBook(std::string path) const;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -113,7 +113,7 @@ void EpubReaderActivity::onEnter() {
   // Configure screen orientation based on settings
   // NOTE: This affects layout math and must be applied before any render calls.
   ReaderCommon::applyReaderOrientation(renderer, SETTINGS.orientation);
-  EpdFontFamily::setReaderBoldSwapEnabled(SETTINGS.readerBoldSwap != 0);
+  EpdFontFamily::setReaderBoldSwapEnabled(RECENT_BOOKS.getBoldSwap(epub->getPath()));
   ImageBlock::setDitherMode(SETTINGS.imageDither);
 
   epub->setupCacheDir();
@@ -648,11 +648,11 @@ void EpubReaderActivity::openReaderMenu() {
   const int bmCount = bookmarkStore.count();
   const std::string quotesPath = getQuotesFilePath();
   const bool hasQuotes = !quotesPath.empty() && Storage.exists(quotesPath.c_str());
-  boldSwapAtMenuOpen = SETTINGS.readerBoldSwap != 0;
+  boldSwapAtMenuOpen = RECENT_BOOKS.getBoldSwap(epub->getPath());
   exitActivity();
   enterNewActivity(new EpubReaderMenuActivity(
-      this->renderer, this->mappedInput, epub->getTitle(), currentPage, totalPages, bookProgressPercent,
-      SETTINGS.orientation, !currentPageFootnotes.empty(), isBookmarked, bmCount, hasQuotes,
+      this->renderer, this->mappedInput, epub->getTitle(), epub->getPath(), currentPage, totalPages,
+      bookProgressPercent, SETTINGS.orientation, !currentPageFootnotes.empty(), isBookmarked, bmCount, hasQuotes,
       [this](const uint8_t orientation) { onReaderMenuBack(orientation); },
       [this](EpubReaderMenuActivity::MenuAction action) { onReaderMenuConfirm(action); }));
 }
@@ -706,7 +706,7 @@ void EpubReaderActivity::onReaderMenuBack(const uint8_t orientation) {
   // cached layout no longer matches the new glyph advances (Regular and
   // Bold have different widths). Re-lay out the page with the same flow
   // used for theme changes.
-  const bool boldSwapNow = SETTINGS.readerBoldSwap != 0;
+  const bool boldSwapNow = RECENT_BOOKS.getBoldSwap(epub->getPath());
   if (boldSwapNow != boldSwapAtMenuOpen) {
     boldSwapAtMenuOpen = boldSwapNow;
     reloadCurrentSectionForDisplaySettings();
@@ -1235,12 +1235,13 @@ bool EpubReaderActivity::ensureSectionLoaded(const uint16_t viewportWidth, const
   clearPageCache();
 
   const uint8_t sectionTextRenderMode = SETTINGS.textRenderMode;
+  const bool boldSwapEnabled = RECENT_BOOKS.getBoldSwap(epub->getPath());
 
   if (!section->loadSectionFile(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
                                 SETTINGS.extraParagraphSpacingLevel, SETTINGS.paragraphAlignment, viewportWidth,
                                 viewportHeight, SETTINGS.hyphenationEnabled != 0, SETTINGS.wordSpacingPercent,
                                 SETTINGS.firstLineIndentMode, SETTINGS.readerStyleMode, sectionTextRenderMode,
-                                SETTINGS.readerBoldSwap != 0)) {
+                                boldSwapEnabled)) {
     LOG_DBG("ERS", "Cache not found, building...");
 
     // Free font caches to reclaim contiguous heap for ZIP decompression (needs a 32 KB
@@ -1256,7 +1257,7 @@ bool EpubReaderActivity::ensureSectionLoaded(const uint16_t viewportWidth, const
                                     SETTINGS.extraParagraphSpacingLevel, SETTINGS.paragraphAlignment, viewportWidth,
                                     viewportHeight, SETTINGS.hyphenationEnabled != 0, SETTINGS.wordSpacingPercent,
                                     SETTINGS.firstLineIndentMode, SETTINGS.readerStyleMode, sectionTextRenderMode,
-                                    SETTINGS.readerBoldSwap != 0, layoutProgressTick)) {
+                                    boldSwapEnabled, layoutProgressTick)) {
       LOG_ERR("ERS", "Failed to persist page data to SD");
       clearPageCache();
       section.reset();
@@ -1515,13 +1516,14 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
   }
 
   const uint8_t sectionTextRenderMode = SETTINGS.textRenderMode;
+  const bool boldSwapEnabled = RECENT_BOOKS.getBoldSwap(epub->getPath());
 
   Section nextSection(epub, nextSpineIndex, renderer);
   if (nextSection.loadSectionFile(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
                                   SETTINGS.extraParagraphSpacingLevel, SETTINGS.paragraphAlignment, viewportWidth,
                                   viewportHeight, SETTINGS.hyphenationEnabled != 0, SETTINGS.wordSpacingPercent,
                                   SETTINGS.firstLineIndentMode, SETTINGS.readerStyleMode, sectionTextRenderMode,
-                                  SETTINGS.readerBoldSwap != 0)) {
+                                  boldSwapEnabled)) {
     return;  // Already cached
   }
 
@@ -1530,7 +1532,7 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
                                      SETTINGS.extraParagraphSpacingLevel, SETTINGS.paragraphAlignment, viewportWidth,
                                      viewportHeight, SETTINGS.hyphenationEnabled != 0, SETTINGS.wordSpacingPercent,
                                      SETTINGS.firstLineIndentMode, SETTINGS.readerStyleMode, sectionTextRenderMode,
-                                     SETTINGS.readerBoldSwap != 0)) {
+                                     boldSwapEnabled)) {
     LOG_ERR("ERS", "Failed silent indexing for chapter: %d", nextSpineIndex);
   }
 }

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -79,9 +79,9 @@ class EpubReaderActivity final : public ActivityWithSubactivity {
   bool pendingGoLibrary = false;        // Defer go library after destructive actions
   bool pendingMenuOpen = false;
   bool pendingThemeReload = false;  // Defer settings reload after ReadingThemesActivity exits
-  // Snapshot of SETTINGS.readerBoldSwap at the moment the reader menu was
-  // opened. Compared on menu exit; if the user toggled the in-menu Bold
-  // Swap item, the current page is re-laid out to apply the change.
+  // Snapshot of the per-book Bold Swap preference at the moment the reader
+  // menu was opened. Compared on menu exit; if the user toggled the in-menu
+  // Bold Swap item, the current page is re-laid out to apply the change.
   bool boldSwapAtMenuOpen = false;
   unsigned long lastConfirmReleaseMs = 0;
   bool confirmLongPressHandled = false;

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -9,12 +9,14 @@
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
 #include "MappedInputManager.h"
+#include "RecentBooksStore.h"
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"
 #include "util/FavoriteBmp.h"
 
 EpubReaderMenuActivity::EpubReaderMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                               const std::string& title, const int currentPage, const int totalPages,
+                                               const std::string& title, const std::string& bookPath,
+                                               const int currentPage, const int totalPages,
                                                const int bookProgressPercent, const uint8_t currentOrientation,
                                                const bool hasFootnotes, const bool isPageBookmarked,
                                                const int bookmarkCount, const bool hasQuotes,
@@ -23,6 +25,7 @@ EpubReaderMenuActivity::EpubReaderMenuActivity(GfxRenderer& renderer, MappedInpu
     : ActivityWithSubactivity("EpubReaderMenu", renderer, mappedInput),
       menuItems(buildMenuItems(hasFootnotes, isPageBookmarked, bookmarkCount, hasQuotes)),
       title(title),
+      bookPath(bookPath),
       pendingOrientation(currentOrientation),
       currentPage(currentPage),
       totalPages(totalPages),
@@ -124,14 +127,15 @@ void EpubReaderMenuActivity::loop() {
       return;
     }
     if (selectedAction == MenuAction::TOGGLE_BOLD_SWAP) {
-      // Flip the swap setting, persist, and update the global EpdFontFamily
-      // state so any subsequent draws (including this menu's own labels)
-      // reflect the new mapping. The reader picks up the change on menu
-      // exit via EpubReaderActivity::onReaderMenuBack, which re-lays out
-      // the current page if the value changed while the menu was open.
-      SETTINGS.readerBoldSwap = SETTINGS.readerBoldSwap ? 0 : 1;
-      SETTINGS.saveToFile();
-      EpdFontFamily::setReaderBoldSwapEnabled(SETTINGS.readerBoldSwap != 0);
+      // Flip the per-book swap preference, persist it to RecentBooksStore,
+      // and update the global EpdFontFamily state so any subsequent draws
+      // (including this menu's own labels) reflect the new mapping. The
+      // reader picks up the change on menu exit via
+      // EpubReaderActivity::onReaderMenuBack, which re-lays out the current
+      // page if the value changed while the menu was open.
+      const bool newEnabled = !RECENT_BOOKS.getBoldSwap(bookPath);
+      RECENT_BOOKS.setBoldSwap(bookPath, newEnabled);
+      EpdFontFamily::setReaderBoldSwapEnabled(newEnabled);
       requestUpdate();
       return;
     }
@@ -229,7 +233,8 @@ void EpubReaderMenuActivity::render(Activity::RenderLock&&) {
       const auto width = renderer.getTextWidth(UI_10_FONT_ID, value);
       renderer.drawText(UI_10_FONT_ID, contentX + contentWidth - 20 - width, displayY, value, !isSelected);
     } else if (item.action == MenuAction::TOGGLE_BOLD_SWAP) {
-      const char* value = SETTINGS.readerBoldSwap ? I18N.get(StrId::STR_STATE_ON) : I18N.get(StrId::STR_STATE_OFF);
+      const char* value =
+          RECENT_BOOKS.getBoldSwap(bookPath) ? I18N.get(StrId::STR_STATE_ON) : I18N.get(StrId::STR_STATE_OFF);
       const auto width = renderer.getTextWidth(UI_10_FONT_ID, value);
       renderer.drawText(UI_10_FONT_ID, contentX + contentWidth - 20 - width, displayY, value, !isSelected);
     }

--- a/src/activities/reader/EpubReaderMenuActivity.h
+++ b/src/activities/reader/EpubReaderMenuActivity.h
@@ -38,10 +38,10 @@ class EpubReaderMenuActivity final : public ActivityWithSubactivity {
   };
 
   explicit EpubReaderMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const std::string& title,
-                                  const int currentPage, const int totalPages, const int bookProgressPercent,
-                                  const uint8_t currentOrientation, const bool hasFootnotes,
-                                  const bool isPageBookmarked, const int bookmarkCount, const bool hasQuotes,
-                                  const std::function<void(uint8_t)>& onBack,
+                                  const std::string& bookPath, const int currentPage, const int totalPages,
+                                  const int bookProgressPercent, const uint8_t currentOrientation,
+                                  const bool hasFootnotes, const bool isPageBookmarked, const int bookmarkCount,
+                                  const bool hasQuotes, const std::function<void(uint8_t)>& onBack,
                                   const std::function<void(MenuAction)>& onAction);
 
   void onEnter() override;
@@ -67,6 +67,9 @@ class EpubReaderMenuActivity final : public ActivityWithSubactivity {
 
   ButtonNavigator buttonNavigator;
   std::string title = "Reader Menu";
+  // Path of the book currently open in the reader. Used as the key for the
+  // per-book Bold Swap preference stored in RecentBooksStore.
+  std::string bookPath;
   uint8_t pendingOrientation = 0;
   const std::vector<StrId> orientationLabels = {StrId::STR_PORTRAIT, StrId::STR_LANDSCAPE_CW, StrId::STR_INVERTED,
                                                 StrId::STR_LANDSCAPE_CCW};

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -71,7 +71,7 @@ void TxtReaderActivity::onEnter() {
 
   // Configure screen orientation based on settings
   ReaderCommon::applyReaderOrientation(renderer, SETTINGS.orientation);
-  EpdFontFamily::setReaderBoldSwapEnabled(SETTINGS.readerBoldSwap != 0);
+  EpdFontFamily::setReaderBoldSwapEnabled(RECENT_BOOKS.getBoldSwap(txt->getPath()));
 
   txt->setupCacheDir();
 

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -48,7 +48,7 @@ void XtcReaderActivity::onEnter() {
   // if ghost artifacts appear.
   renderer.requestHalfRefresh();
 
-  EpdFontFamily::setReaderBoldSwapEnabled(SETTINGS.readerBoldSwap != 0);
+  EpdFontFamily::setReaderBoldSwapEnabled(RECENT_BOOKS.getBoldSwap(xtc->getPath()));
   xtc->setupCacheDir();
 
   // Load saved progress


### PR DESCRIPTION
## Summary

Makes the reader Bold Swap toggle a per-book setting instead of a global one.
Each book remembers its own value; unknown books start OFF.

### Changes
- `RecentBook` gains a `boldSwap` field, persisted in `recent.json` (defaults to 0 for older files).
- `RecentBooksStore::{getBoldSwap,setBoldSwap}` keyed by book path. `setBoldSwap` creates a minimal entry if the book is not yet registered.
- `addBook` preserves the existing `boldSwap` when a book is re-added (reopening a book no longer resets the toggle).
- `SETTINGS.readerBoldSwap` removed from `CrossPointSettings` + `JsonSettingsIO`. The legacy binary-settings reader discards the old field to keep offsets aligned; no binary writer referenced it.
- `EpubReaderMenuActivity` now takes the current book path; the TOGGLE/label read and write via `RECENT_BOOKS`.
- `EpubReaderActivity`, `TxtReaderActivity`, `XtcReaderActivity` query `RECENT_BOOKS.getBoldSwap(path)` on enter and pass it into section load/create.

### Notes
- The `readerBoldSwap` parameter in `lib/Epub/Section*` is unchanged — it's a per-section cache key; it now receives the per-book value instead of the global one.
- I could not run `pio run` in this environment (no PlatformIO installed), so this hasn't been compiled here. Please run the build before merging.

## Test plan
- [ ] Toggle Bold Swap on Book A in the in-reader menu; close and reopen — still ON for A.
- [ ] Open Book B — starts OFF (not inheriting A's value).
- [ ] Toggle Bold Swap on B, reboot device — A stays ON, B stays ON independently.
- [ ] Fresh device / first open of a brand-new book — defaults to OFF.
- [ ] Load a pre-existing `recent.json` written by an older build (no `boldSwap` field) — migrates cleanly to OFF, no parse errors.
- [ ] Toggling Bold Swap in the menu immediately re-lays out the current page on exit (`onReaderMenuBack`).
- [ ] TXT and XTC readers pick up the per-book value on open.