### PR TITLE
fix(reader): preserve Dynamic Margins = 20 across reloads

### DIFF
--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -40,6 +40,7 @@ void writeReadingThemeObject(JsonObject obj, const ReadingTheme& theme) {
   obj["readerStyleMode"] = theme.readerStyleMode;
   obj["textRenderMode"] = theme.textRenderMode;
   obj["textRenderModeV2"] = true;
+  obj["orientation"] = theme.orientation;
   obj["embeddedStyle"] = theme.readerStyleMode == CrossPointSettings::READER_STYLE_HYBRID;
   obj["hyphenationEnabled"] = theme.hyphenationEnabled;
   obj["statusBarEnabled"] = theme.statusBarEnabled;
@@ -119,6 +120,8 @@ void readReadingThemeObject(JsonObject obj, ReadingTheme& theme) {
     }
   }
   theme.hyphenationEnabled = obj["hyphenationEnabled"] | (uint8_t)0;
+  theme.orientation = clampEnum(obj["orientation"] | (uint8_t)CrossPointSettings::PORTRAIT,
+                                CrossPointSettings::ORIENTATION_COUNT, CrossPointSettings::PORTRAIT);
   theme.statusBarEnabled = obj["statusBarEnabled"] | (uint8_t)1;
   theme.statusBarShowBattery = obj["statusBarShowBattery"] | (uint8_t)1;
   theme.statusBarShowPageCounter = obj["statusBarShowPageCounter"] | (uint8_t)0;

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -397,6 +397,7 @@ bool JsonSettingsIO::saveSettings(const CrossPointSettings& s, const char* path)
   doc["refreshFrequency"] = s.refreshFrequency;
   doc["screenMargin"] = s.screenMargin;
   doc["uniformMargins"] = s.uniformMargins;
+  doc["dynamicMargins"] = s.dynamicMargins;
   doc["screenMarginHorizontal"] = s.screenMarginHorizontal;
   doc["screenMarginTop"] = s.screenMarginTop;
   doc["screenMarginBottom"] = s.screenMarginBottom;
@@ -678,6 +679,8 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
   s.screenMargin = doc["screenMargin"] | (uint8_t)5;
   s.uniformMargins = doc["uniformMargins"] | (uint8_t)0;
   if (s.uniformMargins > 1) s.uniformMargins = 0;
+  s.dynamicMargins = doc["dynamicMargins"] | (uint8_t)0;
+  if (s.dynamicMargins > 2) s.dynamicMargins = 0;
   const bool hasSplitMargins = !doc["screenMarginHorizontal"].isNull() && !doc["screenMarginTop"].isNull() &&
                                !doc["screenMarginBottom"].isNull();
   if (hasSplitMargins) {

--- a/src/ReadingThemeStore.cpp
+++ b/src/ReadingThemeStore.cpp
@@ -500,7 +500,7 @@ ReadingTheme ReadingThemeStore::normalizeTheme(const ReadingTheme& theme) {
   normalized.fontSize = CrossPointSettings::normalizeFontSizeForFamily(normalized.fontFamily, theme.fontSize);
   normalized.lineSpacingPercent = clampRange(theme.lineSpacingPercent, 35, 150, 110);
   normalized.uniformMargins = theme.uniformMargins ? 1 : 0;
-  normalized.dynamicMargins = theme.dynamicMargins ? 1 : 0;
+  normalized.dynamicMargins = (theme.dynamicMargins > 2) ? 0 : theme.dynamicMargins;
   normalized.screenMarginHorizontal = clampRange(theme.screenMarginHorizontal, 0, 55, 20);
   normalized.screenMarginTop = clampRange(theme.screenMarginTop, 0, 55, 20);
   normalized.screenMarginBottom = clampRange(theme.screenMarginBottom, 0, 55, 20);

--- a/src/ReadingThemeStore.cpp
+++ b/src/ReadingThemeStore.cpp
@@ -117,6 +117,7 @@ ReadingTheme ReadingThemeStore::fromSettings(const std::string& name, const Cros
   theme.firstLineIndentMode = settings.firstLineIndentMode;
   theme.readerStyleMode = settings.readerStyleMode;
   theme.textRenderMode = settings.textRenderMode;
+  theme.orientation = settings.orientation;
   theme.hyphenationEnabled = settings.hyphenationEnabled;
   theme.statusBarEnabled = settings.statusBarEnabled;
   theme.statusBarShowBattery = settings.statusBarShowBattery;
@@ -170,6 +171,8 @@ void ReadingThemeStore::applyThemeToSettings(const ReadingTheme& theme, CrossPoi
                                         CrossPointSettings::READER_STYLE_USER);
   settings.textRenderMode = clampRange(theme.textRenderMode, 0, CrossPointSettings::TEXT_RENDER_MODE_COUNT - 1,
                                        CrossPointSettings::TEXT_RENDER_CRISP);
+  settings.orientation =
+      clampRange(theme.orientation, 0, CrossPointSettings::ORIENTATION_COUNT - 1, CrossPointSettings::PORTRAIT);
   settings.embeddedStyle = settings.readerStyleMode == CrossPointSettings::READER_STYLE_HYBRID ? 1 : 0;
   settings.textAntiAliasing = 0;
   settings.hyphenationEnabled = theme.hyphenationEnabled ? 1 : 0;
@@ -237,7 +240,8 @@ bool ReadingThemeStore::matchesCurrent(const ReadingTheme& theme) const {
          current.extraParagraphSpacingLevel == theme.extraParagraphSpacingLevel &&
          current.wordSpacingPercent == theme.wordSpacingPercent &&
          current.firstLineIndentMode == theme.firstLineIndentMode && current.readerStyleMode == theme.readerStyleMode &&
-         current.textRenderMode == theme.textRenderMode && current.hyphenationEnabled == theme.hyphenationEnabled &&
+         current.textRenderMode == theme.textRenderMode && current.orientation == theme.orientation &&
+         current.hyphenationEnabled == theme.hyphenationEnabled &&
          current.statusBarEnabled == theme.statusBarEnabled &&
          current.statusBarShowBattery == theme.statusBarShowBattery &&
          current.statusBarShowPageCounter == theme.statusBarShowPageCounter &&
@@ -519,6 +523,8 @@ ReadingTheme ReadingThemeStore::normalizeTheme(const ReadingTheme& theme) {
                                           CrossPointSettings::READER_STYLE_USER);
   normalized.textRenderMode = clampRange(theme.textRenderMode, 0, CrossPointSettings::TEXT_RENDER_MODE_COUNT - 1,
                                          CrossPointSettings::TEXT_RENDER_CRISP);
+  normalized.orientation =
+      clampRange(theme.orientation, 0, CrossPointSettings::ORIENTATION_COUNT - 1, CrossPointSettings::PORTRAIT);
   normalized.hyphenationEnabled = theme.hyphenationEnabled ? 1 : 0;
   normalized.statusBarEnabled = theme.statusBarEnabled ? 1 : 0;
   normalized.statusBarShowBattery = theme.statusBarShowBattery ? 1 : 0;

--- a/src/ReadingThemeStore.h
+++ b/src/ReadingThemeStore.h
@@ -23,6 +23,7 @@ struct ReadingTheme {
   uint8_t firstLineIndentMode = CrossPointSettings::INDENT_BOOK;
   uint8_t readerStyleMode = CrossPointSettings::READER_STYLE_USER;
   uint8_t textRenderMode = CrossPointSettings::TEXT_RENDER_CRISP;
+  uint8_t orientation = CrossPointSettings::PORTRAIT;
   uint8_t hyphenationEnabled = 0;
   uint8_t statusBarEnabled = 1;
   uint8_t statusBarShowBattery = 1;


### PR DESCRIPTION
## Summary

Per-book Dynamic Margins set to **20** silently reverted to **10** after closing and reopening a book (e.g. "Shadow Slave"). The on-disk `reader_settings.json` stored the correct value (`"dynamicMargins": 2`); the bug was on the read path.

`ReadingThemeStore::normalizeTheme()` treated `dynamicMargins` as a boolean:

```cpp
normalized.dynamicMargins = theme.dynamicMargins ? 1 : 0;  // collapses 2 → 1
```

But `dynamicMargins` is a 3-valued enum (`0 = Off`, `1 = 10`, `2 = 20`; see `ReaderSettingsActivity.cpp:301-302`). `normalizeTheme` is invoked at the end of every `readReadingThemeObject` call (`JsonSettingsIO.cpp:162`), so the loaded value `2` was always clobbered to `1` before `applyThemeToSettings` ran. Exactly matches the reported "20 reverts to 10" symptom.

Fix: clamp instead of cast to bool — same shape already used in `applyThemeToSettings` (line 155) and `readReadingThemeObject` (lines 81-82).

Also persist `dynamicMargins` in the global settings JSON. `saveSettings` / `loadSettings` in `JsonSettingsIO.cpp` were missing the field entirely, so the global default hard-reset to `0` on every reboot regardless of user choice. Same class of bug — enum forgotten or treated as boolean in persistence.

- `src/ReadingThemeStore.cpp:503` — clamp `dynamicMargins` to `{0, 1, 2}`
- `src/JsonSettingsIO.cpp` — add `dynamicMargins` to `saveSettings` (~L400) and `loadSettings` (~L680)

## Test plan

- [ ] Build and flash firmware
- [ ] Open "Shadow Slave". Reader Settings → Dynamic Margins → **20**. Exit settings; book renders with 20.
- [ ] Close the book, reopen from the library. Reader Settings shows **20** (regression case; was 10 before).
- [ ] Inspect SD: book's cache dir `reader_settings.json` contains `"dynamicMargins": 2`.
- [ ] Lock the device, wake, reopen the book — value stays **20**.
- [ ] Power cycle, reopen the book — value stays **20**.
- [ ] Regression: set to **Off** → reopen; **10** → reopen; both persist.
- [ ] Global path: set Dynamic Margins to **20** in main Settings activity, reboot, open a book with no per-book override — picks up **20** from global.

## Out of scope (noted for follow-up)

- `ReaderSettingsActivity::persistSettings` (lines 114-130) swallows save failures — only logs, doesn't surface to UI.
- Several in-book code sites call `SETTINGS.saveToFile()` while SETTINGS still holds per-book overrides (`EpubReaderActivity.cpp:664`, `:1182`; `EpubReaderMenuActivity.cpp:122`, `:133`; TXT/XTC equivalents). Pollutes the global settings file but unrelated to this regression.