### PR TITLE
feat(reader): font-aware default line spacing

### DIFF
--- a/src/CrossPointSettings.cpp
+++ b/src/CrossPointSettings.cpp
@@ -510,6 +510,12 @@ uint8_t CrossPointSettings::displayIndexToFontFamily(const uint8_t displayIndex)
   }
 }
 
+uint8_t CrossPointSettings::defaultLineSpacingPercentForFamily(const uint8_t family) {
+  // TT2020 is a monospaced typewriter font whose glyphs sit tight vertically;
+  // it reads better with extra leading.
+  return normalizeFontFamily(family) == TT2020 ? 120 : 100;
+}
+
 uint8_t CrossPointSettings::normalizeFontSizeForFamily(const uint8_t family, const uint8_t fontSize) {
   // Galmuri is a pixel font exposed at sizes 11, 12, 14. Size 10 was
   // dropped as too small; any SIZE_10 still stored in a user's

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -377,6 +377,7 @@ class CrossPointSettings {
   static uint8_t fontFamilyToDisplayIndex(uint8_t family);
   static uint8_t displayIndexToFontFamily(uint8_t displayIndex);
   static uint8_t normalizeFontSizeForFamily(uint8_t family, uint8_t fontSize);
+  static uint8_t defaultLineSpacingPercentForFamily(uint8_t family);
   static uint8_t nextFontSize(uint8_t family, uint8_t fontSize);
   static uint8_t fontSizeToPointSize(uint8_t family, uint8_t fontSize);
   static uint8_t fontSizeOptionCount(uint8_t family);

--- a/src/activities/reader/ReaderSettingsActivity.cpp
+++ b/src/activities/reader/ReaderSettingsActivity.cpp
@@ -453,7 +453,7 @@ void ReaderSettingsActivity::toggleCurrentSetting() {
           (currentIndex + 1) % static_cast<uint8_t>(setting.enumValues.size()));
       SETTINGS.fontFamily = CrossPointSettings::normalizeFontFamily(SETTINGS.fontFamily);
       SETTINGS.fontSize = CrossPointSettings::normalizeFontSizeForFamily(SETTINGS.fontFamily, SETTINGS.fontSize);
-      SETTINGS.lineSpacingPercent = 90;  // Reset to default on font change
+      SETTINGS.lineSpacingPercent = CrossPointSettings::defaultLineSpacingPercentForFamily(SETTINGS.fontFamily);
       buildSettingsList();
       selectedRowIndex = std::min(selectedRowIndex, static_cast<int>(flatRows.size()) - 1);
     } else {

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -493,7 +493,7 @@ void SettingsActivity::toggleCurrentSetting() {
     if (setting.valuePtr == &CrossPointSettings::fontFamily) {
       SETTINGS.fontFamily = CrossPointSettings::normalizeFontFamily(SETTINGS.fontFamily);
       SETTINGS.fontSize = CrossPointSettings::normalizeFontSizeForFamily(SETTINGS.fontFamily, SETTINGS.fontSize);
-      SETTINGS.lineSpacingPercent = 90;  // Reset to default on font change
+      SETTINGS.lineSpacingPercent = CrossPointSettings::defaultLineSpacingPercentForFamily(SETTINGS.fontFamily);
       buildSettingsList();
       selectedRowIndex = std::min(selectedRowIndex, static_cast<int>(flatRows.size()) - 1);
     }

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -364,7 +364,8 @@ void CrossPointWebServer::begin() {
                     SETTINGS.fontFamily = CrossPointSettings::displayIndexToFontFamily(static_cast<uint8_t>(val));
                     SETTINGS.fontSize =
                         CrossPointSettings::normalizeFontSizeForFamily(SETTINGS.fontFamily, SETTINGS.fontSize);
-                    SETTINGS.lineSpacingPercent = 90;
+                    SETTINGS.lineSpacingPercent =
+                        CrossPointSettings::defaultLineSpacingPercentForFamily(SETTINGS.fontFamily);
                   } else {
                     SETTINGS.*(s.valuePtr) = static_cast<uint8_t>(val);
                   }


### PR DESCRIPTION
## Summary
- When the user cycles to a new reader font family, default the line spacing based on the chosen font instead of the previous flat 90% reset.
- TT2020 is a tight monospaced typewriter face that reads better with extra leading, so it now defaults to **120%**.
- All other font families default to **100%**. Users can still adjust from there as before.

## Changes
- New helper `CrossPointSettings::defaultLineSpacingPercentForFamily(uint8_t family)` centralizes the per-family default.
- Three call sites that reset `lineSpacingPercent` after a font-family change now use the helper:
  - `src/activities/reader/ReaderSettingsActivity.cpp` (in-reader settings)
  - `src/activities/settings/SettingsActivity.cpp` (global settings)
  - `src/network/CrossPointWebServer.cpp` (web UI settings push)

## Test plan
- [ ] Open reader, cycle font family to TT2020 → confirm line spacing default jumps to 120%
- [ ] Cycle to any other family (CharEInk, Bookerly, Vollkorn, Galmuri, Bitter) → confirm line spacing default is 100%
- [ ] Manually change line spacing afterwards and confirm it persists until the next font-family change
- [ ] Change font family from the global Settings screen and from the web UI → confirm same behavior

https://claude.ai/code/session_01KmLbcChrUgxSjw3hWUPvkx