### PR TITLE
fix(reader): always render status bar text crisp

### DIFF
--- a/src/activities/reader/ReaderStatusBar.cpp
+++ b/src/activities/reader/ReaderStatusBar.cpp
@@ -99,6 +99,11 @@ void renderStatusBar(GfxRenderer& renderer, const StatusBarLayout& statusBarLayo
   if (!SETTINGS.statusBarEnabled) {
     return;
   }
+
+  // Status bar chrome always renders crisp, regardless of the book's textRenderMode.
+  const uint8_t previousTextRenderStyle = renderer.getTextRenderStyle();
+  renderer.setTextRenderStyle(0);
+
   const bool showBattery = SETTINGS.statusBarShowBattery;
   const bool showBatteryPercentage =
       SETTINGS.hideBatteryPercentage == CrossPointSettings::HIDE_BATTERY_PERCENTAGE::HIDE_NEVER;
@@ -326,6 +331,8 @@ void renderStatusBar(GfxRenderer& renderer, const StatusBarLayout& statusBarLayo
   renderBand(statusTopInset, statusBarLayout.topReservedHeight, true);
   renderBand(screenHeight - statusBottomInset - statusBarLayout.bottomReservedHeight,
              statusBarLayout.bottomReservedHeight, false);
+
+  renderer.setTextRenderStyle(previousTextRenderStyle);
 }
 
 }  // namespace ReaderStatusBar


### PR DESCRIPTION
## Summary
- Status bar chrome (chapter title, battery %, page counter, book/chapter %) was inheriting the reader's `textRenderMode`, so DARK/BIONIC book settings were smearing or bionic-bolding the chrome.
- Save/restore the renderer's text render style around `ReaderStatusBar::renderStatusBar` and force it to `CRISP (0)` for the duration of the draw.
- Encapsulated in the shared `ReaderStatusBar` module so both EPUB and TXT readers benefit without each caller needing to know about the invariant.

## Test plan
- [ ] Open an EPUB with `Text render mode = Dark`: book text renders dark/bold, status bar stays crisp.
- [ ] Open an EPUB with `Text render mode = Bionic`: book text has bionic emphasis, status bar stays crisp.
- [ ] Open an EPUB with `Text render mode = Crisp`: both book and status bar are crisp (no regression).
- [ ] Repeat the three cases on a TXT book.
- [ ] Move status items to the top band and to each horizontal slot (left/center/right); confirm crispness everywhere, including chapter title.
- [ ] Hit the empty-chapter path in `EpubReaderActivity` (chapter with no pages) and confirm the status bar still renders correctly.

https://claude.ai/code/session_016ogPPxsrfZ6PrDDUoVXybe