### PR TITLE
chore(reader): code review cleanups + clang-format sweep

### DIFF
--- a/lib/I18n/I18nKeys.h
+++ b/lib/I18n/I18nKeys.h
@@ -9,10 +9,7 @@ extern const char* const STRINGS_EN[];
 }  // namespace i18n_strings
 
 // Language enum
-enum class Language : uint8_t {
-  ENGLISH = 0,
-  _COUNT
-};
+enum class Language : uint8_t { ENGLISH = 0, _COUNT };
 
 // Language display names (defined in I18nStrings.cpp)
 extern const char* const LANGUAGE_NAMES[];

--- a/src/CrossPointSettings.cpp
+++ b/src/CrossPointSettings.cpp
@@ -516,10 +516,12 @@ uint8_t CrossPointSettings::displayIndexToFontFamily(const uint8_t displayIndex)
   }
 }
 
-uint8_t CrossPointSettings::defaultLineSpacingPercentForFamily(const uint8_t family) {
-  // TT2020 is a monospaced typewriter font whose glyphs sit tight vertically;
-  // it reads better with extra leading.
-  return normalizeFontFamily(family) == TT2020 ? 120 : 100;
+uint8_t CrossPointSettings::resetLineSpacingPercentForFamily(const uint8_t family) {
+  // Value to snap lineSpacingPercent to when the user switches font family.
+  // TT2020 is a monospaced typewriter font whose glyphs sit tight vertically
+  // and needs extra leading. All other families use the historical 90 so
+  // upgrades don't change layout for users who never touch spacing.
+  return normalizeFontFamily(family) == TT2020 ? 120 : 90;
 }
 
 uint8_t CrossPointSettings::normalizeFontSizeForFamily(const uint8_t family, const uint8_t fontSize) {

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -375,7 +375,7 @@ class CrossPointSettings {
   static uint8_t fontFamilyToDisplayIndex(uint8_t family);
   static uint8_t displayIndexToFontFamily(uint8_t displayIndex);
   static uint8_t normalizeFontSizeForFamily(uint8_t family, uint8_t fontSize);
-  static uint8_t defaultLineSpacingPercentForFamily(uint8_t family);
+  static uint8_t resetLineSpacingPercentForFamily(uint8_t family);
   static uint8_t nextFontSize(uint8_t family, uint8_t fontSize);
   static uint8_t fontSizeToPointSize(uint8_t family, uint8_t fontSize);
   static uint8_t fontSizeOptionCount(uint8_t family);

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -89,12 +89,12 @@ void readReadingThemeObject(JsonObject obj, ReadingTheme& theme) {
   theme.extraParagraphSpacingLevel =
       clampEnum(obj["extraParagraphSpacingLevel"] | (uint8_t)CrossPointSettings::EXTRA_SPACING_M,
                 CrossPointSettings::EXTRA_PARAGRAPH_SPACING_COUNT, CrossPointSettings::EXTRA_SPACING_M);
-  theme.wordSpacingPercent = clampEnum(obj["wordSpacingPercent"] | (uint8_t)CrossPointSettings::WORD_SPACING_NORMAL,
-                                       CrossPointSettings::WORD_SPACING_MODE_COUNT,
-                                       CrossPointSettings::WORD_SPACING_NORMAL);
-  theme.firstLineIndentMode = clampEnum(obj["firstLineIndentMode"] | (uint8_t)CrossPointSettings::INDENT_BOOK,
-                                        CrossPointSettings::FIRST_LINE_INDENT_MODE_COUNT,
-                                        CrossPointSettings::INDENT_BOOK);
+  theme.wordSpacingPercent =
+      clampEnum(obj["wordSpacingPercent"] | (uint8_t)CrossPointSettings::WORD_SPACING_NORMAL,
+                CrossPointSettings::WORD_SPACING_MODE_COUNT, CrossPointSettings::WORD_SPACING_NORMAL);
+  theme.firstLineIndentMode =
+      clampEnum(obj["firstLineIndentMode"] | (uint8_t)CrossPointSettings::INDENT_BOOK,
+                CrossPointSettings::FIRST_LINE_INDENT_MODE_COUNT, CrossPointSettings::INDENT_BOOK);
   {
     const uint8_t raw = obj["readerStyleMode"] |
                         (obj["embeddedStyle"].isNull()
@@ -400,7 +400,9 @@ bool JsonSettingsIO::saveSettings(const CrossPointSettings& s, const char* path)
   doc["refreshFrequency"] = s.refreshFrequency;
   doc["screenMargin"] = s.screenMargin;
   doc["uniformMargins"] = s.uniformMargins;
-  doc["dynamicMargins"] = s.dynamicMargins;
+  // Defensive clamp: field is 0/1/2 in the UI, but a bad in-memory value
+  // would otherwise hit disk and force a reset on load.
+  doc["dynamicMargins"] = static_cast<uint8_t>(s.dynamicMargins > 2 ? 0 : s.dynamicMargins);
   doc["screenMarginHorizontal"] = s.screenMarginHorizontal;
   doc["screenMarginTop"] = s.screenMarginTop;
   doc["screenMarginBottom"] = s.screenMarginBottom;
@@ -492,7 +494,7 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
       }
     } else {
       s.statusBarBatteryPosition = clampEnum(doc["statusBarBatteryPosition"] | (uint8_t)S::STATUS_TEXT_BOTTOM_LEFT,
-                                         S::STATUS_BAR_TEXT_POSITION_COUNT, S::STATUS_TEXT_BOTTOM_LEFT);
+                                             S::STATUS_BAR_TEXT_POSITION_COUNT, S::STATUS_TEXT_BOTTOM_LEFT);
     }
     if (doc["statusBarProgressTextPosition"].isNull()) {
       s.statusBarProgressTextPosition = (uint8_t)S::STATUS_AT_BOTTOM;
@@ -501,7 +503,7 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
       }
     } else {
       s.statusBarProgressTextPosition = clampEnum(doc["statusBarProgressTextPosition"] | (uint8_t)S::STATUS_AT_BOTTOM,
-                                              S::STATUS_BAR_ITEM_POSITION_COUNT, S::STATUS_AT_BOTTOM);
+                                                  S::STATUS_BAR_ITEM_POSITION_COUNT, S::STATUS_AT_BOTTOM);
     }
     const uint8_t fallbackProgressTextPosition = s.statusBarProgressTextPosition == S::STATUS_AT_TOP
                                                      ? (uint8_t)S::STATUS_TEXT_TOP_CENTER
@@ -514,7 +516,7 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
     } else {
       s.statusBarPageCounterPosition =
           clampEnum(doc["statusBarPageCounterPosition"] | (uint8_t)S::STATUS_TEXT_BOTTOM_CENTER,
-                S::STATUS_BAR_TEXT_POSITION_COUNT, S::STATUS_TEXT_BOTTOM_CENTER);
+                    S::STATUS_BAR_TEXT_POSITION_COUNT, S::STATUS_TEXT_BOTTOM_CENTER);
     }
     if (doc["statusBarBookPercentagePosition"].isNull()) {
       s.statusBarBookPercentagePosition = fallbackProgressTextPosition;
@@ -524,7 +526,7 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
     } else {
       s.statusBarBookPercentagePosition =
           clampEnum(doc["statusBarBookPercentagePosition"] | (uint8_t)S::STATUS_TEXT_BOTTOM_CENTER,
-                S::STATUS_BAR_TEXT_POSITION_COUNT, S::STATUS_TEXT_BOTTOM_CENTER);
+                    S::STATUS_BAR_TEXT_POSITION_COUNT, S::STATUS_TEXT_BOTTOM_CENTER);
     }
     if (doc["statusBarChapterPercentagePosition"].isNull()) {
       s.statusBarChapterPercentagePosition = fallbackProgressTextPosition;
@@ -534,7 +536,7 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
     } else {
       s.statusBarChapterPercentagePosition =
           clampEnum(doc["statusBarChapterPercentagePosition"] | (uint8_t)S::STATUS_TEXT_BOTTOM_CENTER,
-                S::STATUS_BAR_TEXT_POSITION_COUNT, S::STATUS_TEXT_BOTTOM_CENTER);
+                    S::STATUS_BAR_TEXT_POSITION_COUNT, S::STATUS_TEXT_BOTTOM_CENTER);
     }
     if (doc["statusBarBookBarPosition"].isNull()) {
       s.statusBarBookBarPosition = (uint8_t)S::STATUS_AT_BOTTOM;
@@ -543,7 +545,7 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
       }
     } else {
       s.statusBarBookBarPosition = clampEnum(doc["statusBarBookBarPosition"] | (uint8_t)S::STATUS_AT_BOTTOM,
-                                         S::STATUS_BAR_ITEM_POSITION_COUNT, S::STATUS_AT_BOTTOM);
+                                             S::STATUS_BAR_ITEM_POSITION_COUNT, S::STATUS_AT_BOTTOM);
     }
     if (doc["statusBarChapterBarPosition"].isNull()) {
       s.statusBarChapterBarPosition = (uint8_t)S::STATUS_AT_BOTTOM;
@@ -552,7 +554,7 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
       }
     } else {
       s.statusBarChapterBarPosition = clampEnum(doc["statusBarChapterBarPosition"] | (uint8_t)S::STATUS_AT_BOTTOM,
-                                            S::STATUS_BAR_ITEM_POSITION_COUNT, S::STATUS_AT_BOTTOM);
+                                                S::STATUS_BAR_ITEM_POSITION_COUNT, S::STATUS_AT_BOTTOM);
     }
     if (doc["statusBarTitlePosition"].isNull()) {
       s.statusBarTitlePosition = (uint8_t)S::STATUS_AT_BOTTOM;
@@ -561,23 +563,23 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
       }
     } else {
       s.statusBarTitlePosition = clampEnum(doc["statusBarTitlePosition"] | (uint8_t)S::STATUS_AT_BOTTOM,
-                                       S::STATUS_BAR_ITEM_POSITION_COUNT, S::STATUS_AT_BOTTOM);
+                                           S::STATUS_BAR_ITEM_POSITION_COUNT, S::STATUS_AT_BOTTOM);
     }
     s.statusBarTextAlignment = clampEnum(doc["statusBarTextAlignment"] | (uint8_t)S::STATUS_TEXT_RIGHT,
-                                     S::STATUS_TEXT_ALIGNMENT_COUNT, S::STATUS_TEXT_RIGHT);
+                                         S::STATUS_TEXT_ALIGNMENT_COUNT, S::STATUS_TEXT_RIGHT);
     s.statusBarProgressStyle = clampEnum(doc["statusBarProgressStyle"] | (uint8_t)S::STATUS_BAR_THICK,
-                                     S::STATUS_BAR_PROGRESS_STYLE_COUNT, S::STATUS_BAR_THICK);
-    s.statusBarFontSize = clampEnum(doc["statusBarFontSize"] | (uint8_t)S::STATUS_FONT_SMALL, S::STATUS_BAR_FONT_SIZE_COUNT,
-                                S::STATUS_FONT_SMALL);
+                                         S::STATUS_BAR_PROGRESS_STYLE_COUNT, S::STATUS_BAR_THICK);
+    s.statusBarFontSize = clampEnum(doc["statusBarFontSize"] | (uint8_t)S::STATUS_FONT_SMALL,
+                                    S::STATUS_BAR_FONT_SIZE_COUNT, S::STATUS_FONT_SMALL);
     s.statusBarBarThickness = clampEnum(doc["statusBarBarThickness"] | (uint8_t)S::STATUS_BAR_THICKNESS_NORMAL,
-                                    S::STATUS_BAR_BAR_THICKNESS_COUNT, S::STATUS_BAR_THICKNESS_NORMAL);
+                                        S::STATUS_BAR_BAR_THICKNESS_COUNT, S::STATUS_BAR_THICKNESS_NORMAL);
   } else {
     migrateLegacyStatusBarMode(s);
     if (needsResave) *needsResave = true;
   }
   if (!doc["extraParagraphSpacingLevel"].isNull()) {
     s.extraParagraphSpacingLevel = clampEnum(doc["extraParagraphSpacingLevel"] | (uint8_t)S::EXTRA_SPACING_M,
-                                         S::EXTRA_PARAGRAPH_SPACING_COUNT, S::EXTRA_SPACING_M);
+                                             S::EXTRA_PARAGRAPH_SPACING_COUNT, S::EXTRA_SPACING_M);
   } else {
     const uint8_t legacyExtraSpacing = doc["extraParagraphSpacing"] | (uint8_t)1;
     s.extraParagraphSpacingLevel = legacyExtraSpacing ? (uint8_t)S::EXTRA_SPACING_M : (uint8_t)S::EXTRA_SPACING_OFF;
@@ -603,8 +605,8 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
       *needsResave = true;
     }
   } else {
-    s.readerStyleMode =
-        clampEnum(doc["readerStyleMode"] | (uint8_t)S::READER_STYLE_USER, S::READER_STYLE_MODE_COUNT, S::READER_STYLE_USER);
+    s.readerStyleMode = clampEnum(doc["readerStyleMode"] | (uint8_t)S::READER_STYLE_USER, S::READER_STYLE_MODE_COUNT,
+                                  S::READER_STYLE_USER);
   }
   if (doc["textRenderMode"].isNull()) {
     s.textRenderMode = (uint8_t)S::TEXT_RENDER_CRISP;
@@ -633,12 +635,12 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
       clampEnum(doc["sideButtonLayout"] | (uint8_t)S::PREV_NEXT, S::SIDE_BUTTON_LAYOUT_COUNT, S::PREV_NEXT);
   s.frontButtonBack =
       clampEnum(doc["frontButtonBack"] | (uint8_t)S::FRONT_HW_BACK, S::FRONT_BUTTON_HARDWARE_COUNT, S::FRONT_HW_BACK);
-  s.frontButtonConfirm = clampEnum(doc["frontButtonConfirm"] | (uint8_t)S::FRONT_HW_CONFIRM, S::FRONT_BUTTON_HARDWARE_COUNT,
-                               S::FRONT_HW_CONFIRM);
+  s.frontButtonConfirm = clampEnum(doc["frontButtonConfirm"] | (uint8_t)S::FRONT_HW_CONFIRM,
+                                   S::FRONT_BUTTON_HARDWARE_COUNT, S::FRONT_HW_CONFIRM);
   s.frontButtonLeft =
       clampEnum(doc["frontButtonLeft"] | (uint8_t)S::FRONT_HW_LEFT, S::FRONT_BUTTON_HARDWARE_COUNT, S::FRONT_HW_LEFT);
-  s.frontButtonRight =
-      clampEnum(doc["frontButtonRight"] | (uint8_t)S::FRONT_HW_RIGHT, S::FRONT_BUTTON_HARDWARE_COUNT, S::FRONT_HW_RIGHT);
+  s.frontButtonRight = clampEnum(doc["frontButtonRight"] | (uint8_t)S::FRONT_HW_RIGHT, S::FRONT_BUTTON_HARDWARE_COUNT,
+                                 S::FRONT_HW_RIGHT);
   CrossPointSettings::validateFrontButtonMapping(s);
   s.fontFamily = clampEnum(doc["fontFamily"] | (uint8_t)S::CHAREINK, S::FONT_FAMILY_COUNT, S::CHAREINK);
   s.fontFamily = S::normalizeFontFamily(s.fontFamily);

--- a/src/ReadingThemeStore.cpp
+++ b/src/ReadingThemeStore.cpp
@@ -241,8 +241,7 @@ bool ReadingThemeStore::matchesCurrent(const ReadingTheme& theme) const {
          current.wordSpacingPercent == theme.wordSpacingPercent &&
          current.firstLineIndentMode == theme.firstLineIndentMode && current.readerStyleMode == theme.readerStyleMode &&
          current.textRenderMode == theme.textRenderMode && current.orientation == theme.orientation &&
-         current.hyphenationEnabled == theme.hyphenationEnabled &&
-         current.statusBarEnabled == theme.statusBarEnabled &&
+         current.hyphenationEnabled == theme.hyphenationEnabled && current.statusBarEnabled == theme.statusBarEnabled &&
          current.statusBarShowBattery == theme.statusBarShowBattery &&
          current.statusBarShowPageCounter == theme.statusBarShowPageCounter &&
          current.statusBarPageCounterMode == theme.statusBarPageCounterMode &&

--- a/src/RecentBooksStore.cpp
+++ b/src/RecentBooksStore.cpp
@@ -253,14 +253,11 @@ void RecentBooksStore::setBoldSwap(const std::string& path, bool enabled) {
     }
   }
 
-  // Book not yet registered: create a minimal entry so the preference
-  // persists. Titles/author/cover fill in when the reader calls addBook().
-  RecentBook entry;
-  entry.path = normalizedPath;
-  entry.boldSwap = newValue;
-  recentBooks.insert(recentBooks.begin(), entry);
-  dedupeRecentBooks(recentBooks);
-  saveToFile();
+  // In normal flow the reader always calls addBook() before the user can
+  // reach the toggle, so setBoldSwap on an unknown path indicates a caller
+  // bug. Refuse rather than spawning a ghost recents entry with empty
+  // title/author/cover that would leak into the library list.
+  LOG_ERR("RBS", "setBoldSwap on unregistered book, ignoring: %s", normalizedPath.c_str());
 }
 
 RecentBook RecentBooksStore::getDataFromBook(std::string path) const {

--- a/src/RecentBooksStore.h
+++ b/src/RecentBooksStore.h
@@ -60,8 +60,9 @@ class RecentBooksStore {
 
   // Per-book Bold Swap preference. Lookup is by book path; unknown paths
   // return false so first-time opens always start with bold swap OFF.
-  // setBoldSwap creates the entry if missing (title/author/cover empty) so the
-  // preference can still be persisted before the book's metadata is registered.
+  // setBoldSwap is a no-op on unknown paths (logs an error) — callers must
+  // register the book via addBook() first, which the reader always does on
+  // open before the menu that exposes this toggle is reachable.
   bool getBoldSwap(const std::string& path) const;
   void setBoldSwap(const std::string& path, bool enabled);
 

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -51,8 +51,8 @@ inline std::vector<SettingInfo> getSettingsList() {
 
   // --- Reader ---
   s.push_back(SettingInfo::Enum(StrId::STR_FONT_FAMILY, &CrossPointSettings::fontFamily,
-                                {StrId::STR_CHAREINK, StrId::STR_BOOKERLY, StrId::STR_VOLLKORN,
-                                 StrId::STR_GALMURI, StrId::STR_TT2020, StrId::STR_BITTER},
+                                {StrId::STR_CHAREINK, StrId::STR_BOOKERLY, StrId::STR_VOLLKORN, StrId::STR_GALMURI,
+                                 StrId::STR_TT2020, StrId::STR_BITTER},
                                 "fontFamily", StrId::STR_CAT_READER));
   s.push_back(SettingInfo::Enum(StrId::STR_FONT_SIZE, &CrossPointSettings::fontSize,
                                 {StrId::STR_SMALL, StrId::STR_MEDIUM, StrId::STR_LARGE}, "fontSize",

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -357,8 +357,8 @@ EpubReaderActivity::StatusBarLayout EpubReaderActivity::buildStatusBarLayout(con
       (section->pageCount > 0) ? (static_cast<float>(section->currentPage + 1) / section->pageCount) * 100.0f : 0.0f;
 
   if (SETTINGS.statusBarShowPageCounter) {
-    layout.pageCounterText = ReaderCommon::formatPageCounterText(
-        SETTINGS.statusBarPageCounterMode, section->currentPage, section->pageCount);
+    layout.pageCounterText = ReaderCommon::formatPageCounterText(SETTINGS.statusBarPageCounterMode,
+                                                                 section->currentPage, section->pageCount);
     layout.pageCounterTextWidth = renderer.getTextWidth(SETTINGS.getStatusBarFontId(), layout.pageCounterText.c_str());
   }
   if (SETTINGS.statusBarShowBookPercentage) {
@@ -402,8 +402,7 @@ void EpubReaderActivity::populateBookPageCounterText(StatusBarLayout& layout) co
   // than prose, so the estimated total can fluctuate as the reader moves between chapter types.
   // We accept that drift rather than pre-indexing every chapter (which would block first-open).
   const size_t bookSize = epub->getBookSize();
-  const size_t prevChapterSize =
-      (currentSpineIndex >= 1) ? epub->getCumulativeSpineItemSize(currentSpineIndex - 1) : 0;
+  const size_t prevChapterSize = (currentSpineIndex >= 1) ? epub->getCumulativeSpineItemSize(currentSpineIndex - 1) : 0;
   const size_t curChapterSize = epub->getCumulativeSpineItemSize(currentSpineIndex) - prevChapterSize;
   if (curChapterSize == 0 || bookSize == 0) {
     return;
@@ -1291,8 +1290,7 @@ bool EpubReaderActivity::ensureSectionLoaded(const uint16_t viewportWidth, const
   // doesn't jump to a random page after a settings change.
   if (cachedChapterTotalPageCount > 0) {
     if (currentSpineIndex == cachedSpineIndex && section->pageCount != cachedChapterTotalPageCount) {
-      const float progress =
-          static_cast<float>(section->currentPage) / static_cast<float>(cachedChapterTotalPageCount);
+      const float progress = static_cast<float>(section->currentPage) / static_cast<float>(cachedChapterTotalPageCount);
       section->currentPage = static_cast<int>(progress * section->pageCount);
     }
     cachedChapterTotalPageCount = 0;  // One-shot: don't re-apply on subsequent renders.

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -87,7 +87,7 @@ class EpubReaderActivity final : public ActivityWithSubactivity {
   bool confirmLongPressHandled = false;
   crosspoint::reader::EpubProgressSink progressSink_{"", 0};
   crosspoint::reader::ReaderProgressTracker progress_{progressSink_};
-  int pageLoadFailCount = 0;         // Tracks consecutive page load failures to prevent infinite retry loops
+  int pageLoadFailCount = 0;  // Tracks consecutive page load failures to prevent infinite retry loops
   // Cross-task handoff: render runs on the display task, but tearing down `section` must happen on
   // the loop task — its destructor closes file handles and frees page-layout storage that the
   // render task may still be iterating. Setting this flag asks the loop to call section.reset()

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -1,10 +1,9 @@
 #include "EpubReaderMenuActivity.h"
 
+#include <EpdFontFamily.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <I18n.h>
-
-#include <EpdFontFamily.h>
 
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
@@ -14,14 +13,11 @@
 #include "fontIds.h"
 #include "util/FavoriteBmp.h"
 
-EpubReaderMenuActivity::EpubReaderMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                               const std::string& title, const std::string& bookPath,
-                                               const int currentPage, const int totalPages,
-                                               const int bookProgressPercent, const uint8_t currentOrientation,
-                                               const bool hasFootnotes, const bool isPageBookmarked,
-                                               const int bookmarkCount, const bool hasQuotes,
-                                               const std::function<void(uint8_t)>& onBack,
-                                               const std::function<void(MenuAction)>& onAction)
+EpubReaderMenuActivity::EpubReaderMenuActivity(
+    GfxRenderer& renderer, MappedInputManager& mappedInput, const std::string& title, const std::string& bookPath,
+    const int currentPage, const int totalPages, const int bookProgressPercent, const uint8_t currentOrientation,
+    const bool hasFootnotes, const bool isPageBookmarked, const int bookmarkCount, const bool hasQuotes,
+    const std::function<void(uint8_t)>& onBack, const std::function<void(MenuAction)>& onAction)
     : ActivityWithSubactivity("EpubReaderMenu", renderer, mappedInput),
       menuItems(buildMenuItems(hasFootnotes, isPageBookmarked, bookmarkCount, hasQuotes)),
       title(title),

--- a/src/activities/reader/ReaderCommon.cpp
+++ b/src/activities/reader/ReaderCommon.cpp
@@ -8,7 +8,6 @@
 
 namespace ReaderCommon {
 
-
 std::string formatPageCounterText(const uint8_t mode, const int currentPage, const int totalPages) {
   const int safeTotalPages = std::max(totalPages, 0);
   const int safeCurrentPage = std::max(currentPage, 0);

--- a/src/activities/reader/ReaderSettingsActivity.cpp
+++ b/src/activities/reader/ReaderSettingsActivity.cpp
@@ -292,8 +292,8 @@ void ReaderSettingsActivity::buildSettingsList() {
 
   // --- Build reader settings directly (no intermediate vector) ---
   pushReader(ReaderSettingInfo::Enum(StrId::STR_FONT_FAMILY, &CrossPointSettings::fontFamily,
-                                     {StrId::STR_CHAREINK, StrId::STR_BOOKERLY, StrId::STR_VOLLKORN,
-                                      StrId::STR_GALMURI, StrId::STR_TT2020, StrId::STR_BITTER}));
+                                     {StrId::STR_CHAREINK, StrId::STR_BOOKERLY, StrId::STR_VOLLKORN, StrId::STR_GALMURI,
+                                      StrId::STR_TT2020, StrId::STR_BITTER}));
   pushReader(ReaderSettingInfo::Enum(StrId::STR_FONT_SIZE, &CrossPointSettings::fontSize,
                                      {StrId::STR_SMALL, StrId::STR_MEDIUM, StrId::STR_LARGE}));
   pushReader(ReaderSettingInfo::Value(StrId::STR_LINE_SPACING, &CrossPointSettings::lineSpacingPercent, {35, 150, 5}));
@@ -453,7 +453,7 @@ void ReaderSettingsActivity::toggleCurrentSetting() {
           (currentIndex + 1) % static_cast<uint8_t>(setting.enumValues.size()));
       SETTINGS.fontFamily = CrossPointSettings::normalizeFontFamily(SETTINGS.fontFamily);
       SETTINGS.fontSize = CrossPointSettings::normalizeFontSizeForFamily(SETTINGS.fontFamily, SETTINGS.fontSize);
-      SETTINGS.lineSpacingPercent = CrossPointSettings::defaultLineSpacingPercentForFamily(SETTINGS.fontFamily);
+      SETTINGS.lineSpacingPercent = CrossPointSettings::resetLineSpacingPercentForFamily(SETTINGS.fontFamily);
       buildSettingsList();
       selectedRowIndex = std::min(selectedRowIndex, static_cast<int>(flatRows.size()) - 1);
     } else {

--- a/src/activities/reader/ReaderStatusBar.cpp
+++ b/src/activities/reader/ReaderStatusBar.cpp
@@ -102,7 +102,7 @@ void renderStatusBar(GfxRenderer& renderer, const StatusBarLayout& statusBarLayo
 
   // Status bar chrome always renders crisp, regardless of the book's textRenderMode.
   const uint8_t previousTextRenderStyle = renderer.getTextRenderStyle();
-  renderer.setTextRenderStyle(0);
+  renderer.setTextRenderStyle(CrossPointSettings::TEXT_RENDER_CRISP);
 
   const bool showBattery = SETTINGS.statusBarShowBattery;
   const bool showBatteryPercentage =

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -376,8 +376,8 @@ void XtcReaderActivity::renderPage() {
   // malformed XTC header reporting garbage dimensions.
   constexpr size_t XTC_MAX_PAGE_BUF = 512u * 1024;
   if (pageBufferSize == 0 || pageBufferSize > XTC_MAX_PAGE_BUF) {
-    LOG_ERR("XTR", "Invalid page buffer size %lu (max %u) — corrupt XTC header?",
-            (unsigned long)pageBufferSize, (unsigned)XTC_MAX_PAGE_BUF);
+    LOG_ERR("XTR", "Invalid page buffer size %lu (max %u) — corrupt XTC header?", (unsigned long)pageBufferSize,
+            (unsigned)XTC_MAX_PAGE_BUF);
     renderer.clearScreen();
     renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_PAGE_LOAD_ERROR), true, EpdFontFamily::REGULAR);
     renderer.displayBuffer();

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -493,7 +493,7 @@ void SettingsActivity::toggleCurrentSetting() {
     if (setting.valuePtr == &CrossPointSettings::fontFamily) {
       SETTINGS.fontFamily = CrossPointSettings::normalizeFontFamily(SETTINGS.fontFamily);
       SETTINGS.fontSize = CrossPointSettings::normalizeFontSizeForFamily(SETTINGS.fontFamily, SETTINGS.fontSize);
-      SETTINGS.lineSpacingPercent = CrossPointSettings::defaultLineSpacingPercentForFamily(SETTINGS.fontFamily);
+      SETTINGS.lineSpacingPercent = CrossPointSettings::resetLineSpacingPercentForFamily(SETTINGS.fontFamily);
       buildSettingsList();
       selectedRowIndex = std::min(selectedRowIndex, static_cast<int>(flatRows.size()) - 1);
     }

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -1099,8 +1099,7 @@ void BaseTheme::drawHomeInfoStatsPopup(const GfxRenderer& renderer) const {
   };
 
   const uint64_t usedBytes = stats.totalBytes > stats.freeBytes ? stats.totalBytes - stats.freeBytes : 0;
-  const uint32_t usedPct =
-      stats.totalBytes > 0 ? static_cast<uint32_t>((usedBytes * 100ull) / stats.totalBytes) : 0;
+  const uint32_t usedPct = stats.totalBytes > 0 ? static_cast<uint32_t>((usedBytes * 100ull) / stats.totalBytes) : 0;
 
   // Right-aligned value layout so numbers line up in a column.
   auto drawRow = [&](const int y, const char* labelText, const std::string& valueText) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,16 +49,16 @@
 #include "activities/util/FullScreenMessageActivity.h"
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"
-#include "util/ButtonNavigator.h"
-#include "util/TransitionFeedback.h"
 #include "lifecycle/ActivityRouter.h"
-#include "sleep/SdFatSleepFs.h"
-#include "sleep/WallpaperPlaylist.h"
-#include "util/FavoriteBmp.h"
 #include "persist/AppStateStore.h"
 #include "persist/PersistManager.h"
 #include "persist/SdFatFileIO.h"
 #include "persist/Trash.h"
+#include "sleep/SdFatSleepFs.h"
+#include "sleep/WallpaperPlaylist.h"
+#include "util/ButtonNavigator.h"
+#include "util/FavoriteBmp.h"
+#include "util/TransitionFeedback.h"
 
 HalDisplay display;
 HalGPIO gpio;
@@ -355,13 +355,9 @@ static void openFileTransferInline() {
   enterNewActivity(new CrossPointWebServerActivity(renderer, mappedInputManager, onGoHome));
 }
 
-void onGoToFileTransfer() {
-  lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::FileTransfer, ""});
-}
+void onGoToFileTransfer() { lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::FileTransfer, ""}); }
 
-void onGoToSettings() {
-  lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::Settings, ""});
-}
+void onGoToSettings() { lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::Settings, ""}); }
 
 // ActivityRouter applies persist policy before calling this factory (RFC #23).
 static void openMyLibraryInline(const std::string& path) {
@@ -374,9 +370,7 @@ static void openMyLibraryInline(const std::string& path) {
   }
 }
 
-void onGoToMyLibrary() {
-  lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::MyLibrary, ""});
-}
+void onGoToMyLibrary() { lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::MyLibrary, ""}); }
 
 static void openRecentBooksInline() {
   TransitionFeedback::show(renderer, "Loading recents...");
@@ -384,9 +378,7 @@ static void openRecentBooksInline() {
   enterNewActivity(new RecentBooksActivity(renderer, mappedInputManager, onGoHome, onGoToReader));
 }
 
-void onGoToRecentBooks() {
-  lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::RecentBooks, ""});
-}
+void onGoToRecentBooks() { lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::RecentBooks, ""}); }
 
 void onGoToMyLibraryWithPath(const std::string& path) {
   lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::MyLibraryAt, path});
@@ -398,9 +390,7 @@ static void openBrowserInline() {
   enterNewActivity(new OpdsBookBrowserActivity(renderer, mappedInputManager, onGoHome));
 }
 
-void onGoToBrowser() {
-  lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::Browser, ""});
-}
+void onGoToBrowser() { lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::Browser, ""}); }
 
 static void openHomeInline() {
   TransitionFeedback::show(renderer, "Loading home...");
@@ -409,9 +399,7 @@ static void openHomeInline() {
                                     onGoToSettings, onGoToFileTransfer, onGoToBrowser));
 }
 
-void onGoHome() {
-  lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::Home, ""});
-}
+void onGoHome() { lifecycle::ActivityRouter::instance().request({lifecycle::RouteId::Home, ""}); }
 
 void setupDisplayAndFonts() {
   display.begin();
@@ -771,6 +759,9 @@ void loop() {
   }
 
   auto triggerDeepSleep = []() {
+    // Shown on both auto-sleep (inactivity timeout) and power-button-hold paths
+    // so the device never blanks silently. renderer is a file-scope global.
+    TransitionFeedback::show(renderer, "Going to sleep...");
     const bool fromReader = currentActivity && currentActivity->isReaderActivity();
     lifecycle::ActivityRouter::instance().enterDeepSleep(fromReader);
   };
@@ -784,7 +775,6 @@ void loop() {
   }
 
   if (gpio.isPressed(HalGPIO::BTN_POWER) && gpio.getHeldTime() > SETTINGS.getPowerButtonDuration()) {
-    TransitionFeedback::show(renderer, "Going to sleep...");
     triggerDeepSleep();
     // This should never be hit as enterDeepSleep calls esp_deep_sleep_start
     return;

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -28,10 +28,9 @@
 #include "html/HomePageHtml.generated.h"
 #include "html/SettingsPageHtml.generated.h"
 #include "html/js/jszip_minJs.generated.h"
-#include "util/StringUtils.h"
-
 #include "network/SettingsGateway.h"
 #include "network/ws/WsUploadSession.h"
+#include "util/StringUtils.h"
 
 namespace {
 // Folders/files to hide from the web interface file browser
@@ -365,7 +364,7 @@ void CrossPointWebServer::begin() {
                     SETTINGS.fontSize =
                         CrossPointSettings::normalizeFontSizeForFamily(SETTINGS.fontFamily, SETTINGS.fontSize);
                     SETTINGS.lineSpacingPercent =
-                        CrossPointSettings::defaultLineSpacingPercentForFamily(SETTINGS.fontFamily);
+                        CrossPointSettings::resetLineSpacingPercentForFamily(SETTINGS.fontFamily);
                   } else {
                     SETTINGS.*(s.valuePtr) = static_cast<uint8_t>(val);
                   }


### PR DESCRIPTION
## Summary
Follow-up cleanups from the review of PRs #56, #60, #61, #62, #63 (all already merged). No behavior changes users will notice except #62 revert (below).

- **#63**: `ReaderStatusBar.cpp` — magic `0` → `CrossPointSettings::TEXT_RENDER_CRISP`.
- **#62**: rename `defaultLineSpacingPercentForFamily` → `resetLineSpacingPercentForFamily`. Revert non-TT2020 family-change reset from 100 back to historical **90** (TT2020 still 120). Preserves prior behavior for Charis/Bookerly/Vollkorn/Galmuri/Bitter users who swap font families.
- **#61**: `JsonSettingsIO::saveSettings` — clamp `dynamicMargins` on write (`>2 → 0`). Loader already clamps; this prevents a bad in-memory value from ever hitting disk.
- **#60**: `RecentBooksStore::setBoldSwap` — on unknown book path, `LOG_ERR` and return instead of creating a minimal recents entry with empty title/author/cover. Unreachable in current flow but prevents a future footgun.
- **#56**: `main.cpp` — move `TransitionFeedback::show(renderer, "Going to sleep...")` into `triggerDeepSleep` lambda so the auto-sleep (inactivity timeout) path also shows the toast, not just the power-button-hold path.
- `clang-format` sweep on touched files to clear the CI formatting failures carried over from the above PRs.

## Test plan
- [ ] Build passes (`pio run -e default`)
- [ ] clang-format CI check green
- [ ] Flash + open a book, verify status bar renders crisp when textRenderMode=Dark or Bionic (#63)
- [ ] Change font family in reader settings, verify line spacing resets to 90 (not 100) except TT2020 which resets to 120 (#62)
- [ ] Set Dynamic Margins = 20, reboot, verify setting persists (regression check for #61 fix still works)
- [ ] Toggle Bold Swap in reader menu, verify per-book persistence still works (#60)
- [ ] Let device auto-sleep from inactivity, verify "Going to sleep..." toast shows before blank (#56)
- [ ] Hold power for 1s, verify toast still shows on button-sleep path (#56)

🤖 Generated with [Claude Code](https://claude.com/claude-code)