### PR TITLE
feat(fonts): BDF custom-font Phase 1 + WS upload timeout fix

### DIFF
--- a/lib/BdfFont/BdfFilename.cpp
+++ b/lib/BdfFont/BdfFilename.cpp
@@ -1,0 +1,70 @@
+#include "BdfFilename.h"
+
+#include <cctype>
+#include <cstring>
+
+namespace crosspoint {
+namespace bdf {
+
+namespace {
+
+bool isNameChar(const char c) {
+  return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-';
+}
+
+// Case-insensitive extension match against ".bdf". Returns end-of-name index
+// (length minus 4) on match, -1 otherwise.
+int stripBdfExtension(const char* basename) {
+  const size_t len = std::strlen(basename);
+  if (len < 5) return -1;  // need at least "x.bdf"
+  const size_t extStart = len - 4;
+  if (basename[extStart] != '.') return -1;
+  const char e1 = static_cast<char>(std::tolower(static_cast<unsigned char>(basename[extStart + 1])));
+  const char e2 = static_cast<char>(std::tolower(static_cast<unsigned char>(basename[extStart + 2])));
+  const char e3 = static_cast<char>(std::tolower(static_cast<unsigned char>(basename[extStart + 3])));
+  if (e1 != 'b' || e2 != 'd' || e3 != 'f') return -1;
+  return static_cast<int>(extStart);
+}
+
+}  // namespace
+
+std::optional<BdfFilenameInfo> parseBdfFilename(const char* basename) {
+  if (!basename) return std::nullopt;
+
+  const int extPos = stripBdfExtension(basename);
+  if (extPos <= 0) return std::nullopt;
+
+  // Find the last underscore before the extension.
+  int underscorePos = -1;
+  for (int i = extPos - 1; i >= 0; --i) {
+    if (basename[i] == '_') {
+      underscorePos = i;
+      break;
+    }
+  }
+  if (underscorePos <= 0) return std::nullopt;          // no underscore, or empty name
+  if (underscorePos == extPos - 1) return std::nullopt;  // "_.bdf" or "foo_.bdf"
+
+  // Validate name chars in [0, underscorePos).
+  for (int i = 0; i < underscorePos; ++i) {
+    if (!isNameChar(basename[i])) return std::nullopt;
+  }
+
+  // Parse size digits in [underscorePos+1, extPos).
+  uint32_t size = 0;
+  for (int i = underscorePos + 1; i < extPos; ++i) {
+    const char c = basename[i];
+    if (c < '0' || c > '9') return std::nullopt;
+    size = size * 10 + static_cast<uint32_t>(c - '0');
+    if (size > 255) return std::nullopt;
+  }
+  if (size < 4) return std::nullopt;
+
+  BdfFilenameInfo info;
+  info.name.assign(basename, static_cast<size_t>(underscorePos));
+  info.sizePt = static_cast<uint16_t>(size);
+  return info;
+}
+
+}  // namespace bdf
+}  // namespace crosspoint

--- a/lib/BdfFont/BdfFilename.h
+++ b/lib/BdfFont/BdfFilename.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace crosspoint {
+namespace bdf {
+
+struct BdfFilenameInfo {
+  std::string name;
+  uint16_t sizePt;
+};
+
+// Parses "<name>_<size>.bdf" (extension case-insensitive).
+//   name chars: [A-Za-z0-9-]+
+//   size:       4..255 inclusive (decimal digits only)
+// Returns nullopt if the basename does not match.
+//
+// Examples:
+//   "unifont_16.bdf"   -> {"unifont", 16}
+//   "Unifont_16.BDF"   -> {"Unifont", 16}
+//   "my-font_24.bdf"   -> {"my-font", 24}
+//   "unifont.bdf"      -> nullopt  (no _<digits>)
+//   "_16.bdf"          -> nullopt  (empty name)
+//   "foo_3.bdf"        -> nullopt  (size < 4)
+//   "foo_300.bdf"      -> nullopt  (size > 255)
+std::optional<BdfFilenameInfo> parseBdfFilename(const char* basename);
+
+}  // namespace bdf
+}  // namespace crosspoint

--- a/lib/BdfFont/BdfParser.cpp
+++ b/lib/BdfFont/BdfParser.cpp
@@ -1,0 +1,168 @@
+#include "BdfParser.h"
+
+#include <Arduino.h>
+#include <esp_task_wdt.h>
+
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+
+namespace crosspoint {
+namespace bdf {
+
+namespace {
+
+constexpr size_t kLineBuf = 192;
+
+// Reads a single line from `in` into `buf` (NUL-terminated, trimmed of CR).
+// Lines longer than the buffer are truncated; the remainder is discarded so
+// the next call still starts at a line boundary. Returns the number of bytes
+// stored, or -1 on EOF before any byte was read.
+int readLine(HalFile& in, char* buf, size_t bufSize) {
+  if (bufSize == 0) return -1;
+  size_t len = 0;
+  bool sawAny = false;
+  while (true) {
+    const int c = in.read();
+    if (c < 0) {
+      // EOF. If we already collected bytes, return what we have.
+      if (!sawAny) return -1;
+      break;
+    }
+    sawAny = true;
+    if (c == '\n') break;
+    if (c == '\r') continue;
+    if (len + 1 < bufSize) {
+      buf[len++] = static_cast<char>(c);
+    }
+    // else: silently drop overflow; we still want to land on the next \n.
+  }
+  buf[len] = '\0';
+  return static_cast<int>(len);
+}
+
+// Returns true when `line` starts with `token` AND the next char is a space
+// or end-of-string (so "STARTCHAR" does not match "STARTFONT").
+bool startsWithToken(const char* line, const char* token) {
+  const size_t tlen = std::strlen(token);
+  if (std::strncmp(line, token, tlen) != 0) return false;
+  const char next = line[tlen];
+  return next == '\0' || next == ' ' || next == '\t';
+}
+
+// Skips whitespace, then parses a signed decimal int from `*p`. Advances `*p`
+// past the parsed digits. Returns false if no digits were found.
+bool parseInt(const char** p, long* out) {
+  while (**p == ' ' || **p == '\t') ++(*p);
+  char* end = nullptr;
+  const long v = std::strtol(*p, &end, 10);
+  if (end == *p) return false;
+  *p = end;
+  *out = v;
+  return true;
+}
+
+}  // namespace
+
+BdfHeader BdfParser::readHeader(HalFile& in, const size_t wdtTickEvery) {
+  BdfHeader h;
+  char line[kLineBuf];
+
+  bool sawStartFont = false;
+  bool sawCharsCount = false;
+  size_t lineNum = 0;
+
+  while (true) {
+    const int n = readLine(in, line, sizeof(line));
+    if (n < 0) {
+      // EOF before STARTCHAR. Header is complete only if we got the bare
+      // minimum (STARTFONT + CHARS N) — otherwise the file is malformed.
+      if (sawStartFont && sawCharsCount) {
+        h.ok = true;
+      } else {
+        h.error = "unexpected EOF in header";
+      }
+      return h;
+    }
+
+    if (++lineNum % wdtTickEvery == 0) {
+      esp_task_wdt_reset();
+      yield();
+    }
+
+    if (n == 0) continue;  // blank line
+
+    if (startsWithToken(line, "STARTFONT")) {
+      sawStartFont = true;
+      continue;
+    }
+    if (!sawStartFont) {
+      h.error = "missing STARTFONT";
+      return h;
+    }
+
+    if (startsWithToken(line, "STARTCHAR")) {
+      // First glyph reached. Header parse is complete iff CHARS was seen.
+      if (!sawCharsCount) {
+        h.error = "missing CHARS before first STARTCHAR";
+        return h;
+      }
+      h.ok = true;
+      return h;
+    }
+
+    if (startsWithToken(line, "CHARS")) {
+      const char* p = line + std::strlen("CHARS");
+      long v = 0;
+      if (!parseInt(&p, &v) || v < 0) {
+        h.error = "bad CHARS count";
+        return h;
+      }
+      h.glyphCount = static_cast<uint32_t>(v);
+      sawCharsCount = true;
+      continue;
+    }
+
+    if (startsWithToken(line, "FONTBOUNDINGBOX")) {
+      const char* p = line + std::strlen("FONTBOUNDINGBOX");
+      long w = 0, ht = 0, ox = 0, oy = 0;
+      if (!parseInt(&p, &w) || !parseInt(&p, &ht) || !parseInt(&p, &ox) || !parseInt(&p, &oy)) {
+        h.error = "bad FONTBOUNDINGBOX";
+        return h;
+      }
+      h.bbxW = static_cast<int16_t>(w);
+      h.bbxH = static_cast<int16_t>(ht);
+      h.bbxOffX = static_cast<int16_t>(ox);
+      h.bbxOffY = static_cast<int16_t>(oy);
+      continue;
+    }
+
+    if (startsWithToken(line, "SIZE")) {
+      const char* p = line + std::strlen("SIZE");
+      long pt = 0;
+      if (parseInt(&p, &pt) && pt > 0 && pt < 65536) {
+        h.pointSize = static_cast<uint16_t>(pt);
+      }
+      continue;
+    }
+
+    if (startsWithToken(line, "FONT_ASCENT")) {
+      const char* p = line + std::strlen("FONT_ASCENT");
+      long v = 0;
+      if (parseInt(&p, &v)) h.ascent = static_cast<int16_t>(v);
+      continue;
+    }
+
+    if (startsWithToken(line, "FONT_DESCENT")) {
+      const char* p = line + std::strlen("FONT_DESCENT");
+      long v = 0;
+      if (parseInt(&p, &v)) h.descent = static_cast<int16_t>(v);
+      continue;
+    }
+    // All other lines (COMMENT, FONT, STARTPROPERTIES, ENDPROPERTIES, ...)
+    // are ignored.
+  }
+}
+
+}  // namespace bdf
+}  // namespace crosspoint

--- a/lib/BdfFont/BdfParser.h
+++ b/lib/BdfFont/BdfParser.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <HalStorage.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace crosspoint {
+namespace bdf {
+
+struct BdfHeader {
+  uint32_t glyphCount = 0;
+  int16_t bbxW = 0;
+  int16_t bbxH = 0;
+  int16_t bbxOffX = 0;
+  int16_t bbxOffY = 0;
+  int16_t ascent = 0;
+  int16_t descent = 0;
+  uint16_t pointSize = 0;
+  bool ok = false;
+  // Static string literal — never owned, never freed.
+  const char* error = nullptr;
+};
+
+class BdfParser {
+ public:
+  // Reads the BDF header (STARTFONT...CHARS N), then stops at the first
+  // STARTCHAR. Does NOT enumerate glyphs (that is Phase 2).
+  //
+  // The parser yields and resets the watchdog every `wdtTickEvery` lines so
+  // a 9 MB Unifont scan does not trip the task watchdog.
+  static BdfHeader readHeader(HalFile& in, size_t wdtTickEvery = 256);
+};
+
+}  // namespace bdf
+}  // namespace crosspoint

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,6 +35,10 @@ build_flags =
   -std=gnu++2a
 # Enable UTF-8 long file names in SdFat
   -DUSE_UTF8_LONG_NAMES=1
+# WebSockets lib: default TCP send/recv timeout is 5 s, which causes the WS
+# server to drop the connection during multi-MB uploads when SD writes block
+# longer than that. 30 s gives slow-SD writes plenty of headroom.
+  -DWEBSOCKETS_TCP_TIMEOUT=30000
 # NimBLE: central + observer only, 1 connection, save RAM
   -DCONFIG_BT_NIMBLE_ROLE_CENTRAL=1
   -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL=0

--- a/src/CrossPointState.h
+++ b/src/CrossPointState.h
@@ -28,6 +28,12 @@ class CrossPointState {
   std::string lastShownSleepFilename;
   std::string lastSleepWallpaperPath;
   std::vector<std::string> favoriteBmpPaths;
+  // Phase 1 BDF custom-font tracking. Filenames (basename only, e.g.
+  // "unifont_16.bdf") of custom fonts the user has acknowledged via the
+  // boot prompt. seen = "Install" tapped (Phase 1 = log-only). skipped =
+  // "Skip forever" tapped (never prompt again).
+  std::vector<std::string> seenCustomFonts;
+  std::vector<std::string> skippedCustomFonts;
   uint8_t readerActivityLoadCount = 0;
   uint32_t sessionPagesRead = 0;
   bool lastSleepFromReader = false;

--- a/src/activities/util/CustomFontPromptActivity.cpp
+++ b/src/activities/util/CustomFontPromptActivity.cpp
@@ -1,0 +1,104 @@
+#include "CustomFontPromptActivity.h"
+
+#include <GfxRenderer.h>
+#include <I18n.h>
+
+#include <string>
+#include <vector>
+
+#include "components/themes/BaseTheme.h"
+#include "fontIds.h"
+
+namespace {
+constexpr int kOptionCount = 3;
+}
+
+void CustomFontPromptActivity::onEnter() {
+  Activity::onEnter();
+  selectedOptionIndex = 1;  // Skip
+  requestUpdate();
+}
+
+void CustomFontPromptActivity::loop() {
+  if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+    auto cb = std::move(onSkip);
+    if (cb) cb();
+    return;
+  }
+
+  buttonNavigator.onNextRelease([this] {
+    selectedOptionIndex = (selectedOptionIndex + 1) % kOptionCount;
+    requestUpdate();
+  });
+  buttonNavigator.onPreviousRelease([this] {
+    selectedOptionIndex = (selectedOptionIndex + kOptionCount - 1) % kOptionCount;
+    requestUpdate();
+  });
+
+  if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+    if (selectedOptionIndex == 0) {
+      auto cb = std::move(onInstall);
+      if (cb) cb();
+    } else if (selectedOptionIndex == 1) {
+      auto cb = std::move(onSkip);
+      if (cb) cb();
+    } else {
+      auto cb = std::move(onSkipForever);
+      if (cb) cb();
+    }
+  }
+}
+
+void CustomFontPromptActivity::render(Activity::RenderLock&&) {
+  renderer.clearScreen();
+
+  const int pageWidth = renderer.getScreenWidth();
+  const int pageHeight = renderer.getScreenHeight();
+  const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
+  GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+
+  // Phase 1: literal English. i18n in Phase 5.
+  const char* options[] = {"Install", "Skip", "Skip forever"};
+  constexpr int rowH = 28;
+  const int popupW = pageWidth - 48;
+
+  const int textMaxW = popupW - 24;
+  const int lineH = renderer.getLineHeight(UI_10_FONT_ID);
+  std::vector<std::string> msgLines;
+  {
+    size_t start = 0;
+    while (start <= message.size()) {
+      auto nl = message.find('\n', start);
+      if (nl == std::string::npos) nl = message.size();
+      std::string line = message.substr(start, nl - start);
+      msgLines.push_back(renderer.truncatedText(UI_10_FONT_ID, line.c_str(), textMaxW));
+      start = nl + 1;
+    }
+  }
+  const int textH = static_cast<int>(msgLines.size()) * (lineH + 2);
+
+  const int popupH = 20 + textH + 16 + kOptionCount * rowH;
+  const int popupX = (pageWidth - popupW) / 2;
+  const int popupY = (pageHeight - popupH) / 2;
+
+  renderer.fillRect(popupX - 2, popupY - 2, popupW + 4, popupH + 4, true);
+  renderer.fillRect(popupX, popupY, popupW, popupH, false);
+
+  int msgY = popupY + 10;
+  for (const auto& line : msgLines) {
+    renderer.drawText(UI_10_FONT_ID, popupX + 12, msgY, line.c_str(), true);
+    msgY += lineH + 2;
+  }
+
+  const int optionsStartY = popupY + 20 + textH + 8;
+  for (int i = 0; i < kOptionCount; i++) {
+    const int rowY = optionsStartY + i * rowH;
+    const bool selected = (i == selectedOptionIndex);
+    if (selected) {
+      renderer.fillRect(popupX + 6, rowY - 1, popupW - 12, rowH - 2, true);
+    }
+    renderer.drawText(UI_10_FONT_ID, popupX + 12, rowY, options[i], !selected);
+  }
+
+  renderer.displayBuffer();
+}

--- a/src/activities/util/CustomFontPromptActivity.h
+++ b/src/activities/util/CustomFontPromptActivity.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <functional>
+#include <string>
+
+#include "activities/Activity.h"
+#include "util/ButtonNavigator.h"
+
+// Boot-time popup shown for each newly-detected /custom-font/<name>_<size>.bdf
+// file. Three options:
+//   Install      — caller persists filename in seenCustomFonts (Phase 1: log only).
+//   Skip         — caller does nothing; popup re-appears next boot.
+//   Skip forever — caller persists filename in skippedCustomFonts.
+//
+// The Back button maps to Skip (least-destructive default).
+class CustomFontPromptActivity final : public Activity {
+ public:
+  explicit CustomFontPromptActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::string message,
+                                    std::function<void()> onInstall, std::function<void()> onSkip,
+                                    std::function<void()> onSkipForever)
+      : Activity("CustomFontPrompt", renderer, mappedInput),
+        message(std::move(message)),
+        onInstall(std::move(onInstall)),
+        onSkip(std::move(onSkip)),
+        onSkipForever(std::move(onSkipForever)) {}
+
+  void onEnter() override;
+  void loop() override;
+  void render(Activity::RenderLock&&) override;
+
+ private:
+  const std::string message;
+  std::function<void()> onInstall;
+  std::function<void()> onSkip;
+  std::function<void()> onSkipForever;
+  ButtonNavigator buttonNavigator;
+  int selectedOptionIndex = 1;  // default to Skip (safe middle)
+};

--- a/src/fonts/CustomFontManager.cpp
+++ b/src/fonts/CustomFontManager.cpp
@@ -1,0 +1,204 @@
+#include "CustomFontManager.h"
+
+#include <BdfFilename.h>
+#include <BdfParser.h>
+#include <HalStorage.h>
+#include <Logging.h>
+#include <esp_task_wdt.h>
+#include <strings.h>
+
+#include <algorithm>
+#include <cstring>
+#include <utility>
+
+#include "CrossPointState.h"
+#include "activities/util/CustomFontPromptActivity.h"
+
+// Defined in main.cpp; replaces the current activity slot.
+class Activity;
+void enterNewActivity(Activity* activity);
+
+namespace crosspoint {
+namespace fonts {
+
+namespace {
+
+constexpr const char* kModule = "CFONT";
+constexpr const char* kCustomFontDir = "/custom-font";
+constexpr size_t kScanCap = 50;          // hard limit on .bdf files scanned per boot
+constexpr size_t kWdtResetInterval = 32; // reset watchdog every N dir entries
+
+bool isBdfName(const char* name) {
+  if (!name || name[0] == '\0' || name[0] == '.') return false;
+  const size_t len = std::strlen(name);
+  if (len < 5) return false;  // "x.bdf"
+  return strcasecmp(name + len - 4, ".bdf") == 0;
+}
+
+bool contains(const std::vector<std::string>& v, const std::string& needle) {
+  return std::find(v.begin(), v.end(), needle) != v.end();
+}
+
+}  // namespace
+
+CustomFontManager& CustomFontManager::instance() {
+  static CustomFontManager inst;
+  return inst;
+}
+
+void CustomFontManager::scanAndQueuePrompts() {
+  entries_.clear();
+  pendingPromptIdx_.clear();
+
+  auto dir = Storage.open(kCustomFontDir);
+  if (!dir || !dir.isDirectory()) {
+    if (dir) dir.close();
+    LOG_DBG(kModule, "%s missing or not a directory; skipping scan", kCustomFontDir);
+    return;
+  }
+
+  size_t scanned = 0;
+  size_t iter = 0;
+  size_t valid = 0;
+  char name[256];
+
+  for (auto file = dir.openNextFile(); file; file = dir.openNextFile()) {
+    if (file.isDirectory()) {
+      file.close();
+      continue;
+    }
+    file.getName(name, sizeof(name));
+    if (!isBdfName(name)) {
+      file.close();
+      if (++iter % kWdtResetInterval == 0) {
+        esp_task_wdt_reset();
+        yield();
+      }
+      continue;
+    }
+    if (++scanned > kScanCap) {
+      LOG_INF(kModule, "scan cap reached (%u files); stopping", static_cast<unsigned>(kScanCap));
+      file.close();
+      break;
+    }
+
+    const auto fname = bdf::parseBdfFilename(name);
+    if (!fname.has_value()) {
+      LOG_INF(kModule, "%s filename invalid, skipping", name);
+      file.close();
+      if (++iter % kWdtResetInterval == 0) {
+        esp_task_wdt_reset();
+        yield();
+      }
+      continue;
+    }
+
+    // file is already open at the directory entry. We need a fresh open at the
+    // full path because openNextFile() does not give us a Stream we can re-seek
+    // to position 0 (some HAL impls leave the cursor mid-file). Close + reopen.
+    file.close();
+
+    char fullPath[320];
+    snprintf(fullPath, sizeof(fullPath), "%s/%s", kCustomFontDir, name);
+    auto bdfFile = Storage.open(fullPath);
+    if (!bdfFile) {
+      LOG_INF(kModule, "%s open failed, skipping", name);
+      if (++iter % kWdtResetInterval == 0) {
+        esp_task_wdt_reset();
+        yield();
+      }
+      continue;
+    }
+
+    const auto header = bdf::BdfParser::readHeader(bdfFile);
+    bdfFile.close();
+
+    if (!header.ok) {
+      LOG_INF(kModule, "%s header error: %s", name, header.error ? header.error : "unknown");
+      if (++iter % kWdtResetInterval == 0) {
+        esp_task_wdt_reset();
+        yield();
+      }
+      continue;
+    }
+
+    CustomFontEntry entry;
+    entry.filename = name;
+    entry.fontName = fname->name;
+    entry.sizePt = fname->sizePt;
+    entry.glyphCount = header.glyphCount;
+    entry.headerOk = true;
+    entries_.push_back(std::move(entry));
+    ++valid;
+
+    LOG_INF(kModule, "%s header OK glyphs=%u bbx=%dx%d ascent=%d descent=%d", name,
+            static_cast<unsigned>(header.glyphCount), header.bbxW, header.bbxH, header.ascent, header.descent);
+
+    if (++iter % kWdtResetInterval == 0) {
+      esp_task_wdt_reset();
+      yield();
+    }
+  }
+  dir.close();
+
+  // Cross-check vs persistent state.
+  for (size_t i = 0; i < entries_.size(); ++i) {
+    const auto& fn = entries_[i].filename;
+    if (contains(APP_STATE.skippedCustomFonts, fn)) continue;
+    if (contains(APP_STATE.seenCustomFonts, fn)) continue;
+    pendingPromptIdx_.push_back(i);
+  }
+
+  LOG_INF(kModule, "scanned %u files, %u valid, %u queued", static_cast<unsigned>(scanned),
+          static_cast<unsigned>(valid), static_cast<unsigned>(pendingPromptIdx_.size()));
+}
+
+void CustomFontManager::showNextPromptIfAny(GfxRenderer& renderer, MappedInputManager& mappedInput,
+                                            std::function<void()> onAllDismissed) {
+  if (pendingPromptIdx_.empty()) {
+    if (onAllDismissed) onAllDismissed();
+    return;
+  }
+
+  const size_t idx = pendingPromptIdx_.front();
+  pendingPromptIdx_.erase(pendingPromptIdx_.begin());
+  const auto& entry = entries_[idx];
+
+  char body[160];
+  snprintf(body, sizeof(body), "Found custom font:\n%s (%upt)\n%u glyphs", entry.fontName.c_str(),
+           static_cast<unsigned>(entry.sizePt), static_cast<unsigned>(entry.glyphCount));
+
+  // All three lambdas capture `this` (singleton — stable for program lifetime),
+  // the entry filename by value, the renderer/input refs, and onAllDismissed
+  // by value so we can chain another prompt.
+  const std::string filename = entry.filename;
+
+  auto onInstall = [this, filename, &renderer, &mappedInput, onAllDismissed]() {
+    if (!std::any_of(APP_STATE.seenCustomFonts.begin(), APP_STATE.seenCustomFonts.end(),
+                     [&](const std::string& s) { return s == filename; })) {
+      APP_STATE.seenCustomFonts.push_back(filename);
+      APP_STATE.saveToFile();
+    }
+    LOG_INF(kModule, "install requested: %s", filename.c_str());
+    showNextPromptIfAny(renderer, mappedInput, onAllDismissed);
+  };
+  auto onSkip = [this, filename, &renderer, &mappedInput, onAllDismissed]() {
+    LOG_INF(kModule, "skip (this boot): %s", filename.c_str());
+    showNextPromptIfAny(renderer, mappedInput, onAllDismissed);
+  };
+  auto onSkipForever = [this, filename, &renderer, &mappedInput, onAllDismissed]() {
+    if (!std::any_of(APP_STATE.skippedCustomFonts.begin(), APP_STATE.skippedCustomFonts.end(),
+                     [&](const std::string& s) { return s == filename; })) {
+      APP_STATE.skippedCustomFonts.push_back(filename);
+      APP_STATE.saveToFile();
+    }
+    LOG_INF(kModule, "skip forever: %s", filename.c_str());
+    showNextPromptIfAny(renderer, mappedInput, onAllDismissed);
+  };
+
+  enterNewActivity(new CustomFontPromptActivity(renderer, mappedInput, body, std::move(onInstall), std::move(onSkip),
+                                                std::move(onSkipForever)));
+}
+
+}  // namespace fonts
+}  // namespace crosspoint

--- a/src/fonts/CustomFontManager.h
+++ b/src/fonts/CustomFontManager.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+class GfxRenderer;
+class MappedInputManager;
+
+namespace crosspoint {
+namespace fonts {
+
+struct CustomFontEntry {
+  std::string filename;  // "unifont_16.bdf" (basename only)
+  std::string fontName;  // "unifont"
+  uint16_t sizePt = 0;
+  uint32_t glyphCount = 0;
+  bool headerOk = false;
+};
+
+// Singleton that scans /custom-font/ at boot, parses BDF headers, and queues
+// install-prompts for any font the user has not already acknowledged (via
+// state.json seenCustomFonts / skippedCustomFonts).
+//
+// Phase 1: prompt only — "Install" logs + marks seen, no glyph extraction.
+// Phase 2 will hang real install + render integration off the same entries.
+class CustomFontManager {
+ public:
+  static CustomFontManager& instance();
+
+  // Open /custom-font/, enumerate *.bdf, parse headers. Build entries_ +
+  // pendingPromptIdx_. Safe to call when SD is missing or dir is absent
+  // (silent no-op). Caps total scan at 50 files.
+  void scanAndQueuePrompts();
+
+  // If a queued prompt exists, push CustomFontPromptActivity. The activity's
+  // callbacks chain back into showNextPromptIfAny(onAllDismissed) so all
+  // pending prompts are walked sequentially. When the queue empties (or is
+  // empty on entry) onAllDismissed() runs.
+  void showNextPromptIfAny(GfxRenderer& renderer, MappedInputManager& mappedInput,
+                           std::function<void()> onAllDismissed);
+
+  bool hasPendingPrompt() const { return !pendingPromptIdx_.empty(); }
+  const std::vector<CustomFontEntry>& entries() const { return entries_; }
+
+ private:
+  CustomFontManager() = default;
+
+  std::vector<CustomFontEntry> entries_;
+  std::vector<size_t> pendingPromptIdx_;
+};
+
+}  // namespace fonts
+}  // namespace crosspoint

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,7 @@
 #include "activities/util/FullScreenMessageActivity.h"
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"
+#include "fonts/CustomFontManager.h"
 #include "lifecycle/ActivityRouter.h"
 #include "persist/AppStateStore.h"
 #include "persist/PersistManager.h"
@@ -689,12 +690,31 @@ void setup() {
     router.setRouteFactory(lifecycle::RouteId::Home, [](const std::string& /*payload*/) { openHomeInline(); });
   }
 
-  if (goHome) {
-    bootActivity->setProgress(100, "Opening home");
-    lifecycle::ActivityRouter::instance().begin({lifecycle::RouteId::Home, ""});
+  bootActivity->setProgress(100, goHome ? "Opening home" : "Opening book");
+
+  // Phase 1 BDF custom-font scan. Runs after APP_STATE is loaded so the
+  // seen/skipped vectors are populated. If any new BDF is queued, the popup
+  // replaces BootActivity; the final dismiss callback transitions to the
+  // boot destination via ActivityRouter::begin (synchronous dispatch).
+  auto launchBootDestination = [goHome, readerPath]() {
+    if (goHome) {
+      lifecycle::ActivityRouter::instance().begin({lifecycle::RouteId::Home, ""});
+    } else {
+      lifecycle::ActivityRouter::instance().begin({lifecycle::RouteId::Reader, readerPath});
+    }
+  };
+
+  // Ensure /custom-font/ exists so the user can drop BDF files via the web
+  // server / file transfer without first creating the directory by hand.
+  // mkdir is idempotent; harmless when the dir already exists.
+  Storage.mkdir("/custom-font");
+
+  auto& customFonts = crosspoint::fonts::CustomFontManager::instance();
+  customFonts.scanAndQueuePrompts();
+  if (customFonts.hasPendingPrompt()) {
+    customFonts.showNextPromptIfAny(renderer, mappedInputManager, launchBootDestination);
   } else {
-    bootActivity->setProgress(100, "Opening book");
-    lifecycle::ActivityRouter::instance().begin({lifecycle::RouteId::Reader, readerPath});
+    launchBootDestination();
   }
 
   // Ensure we're not still holding the power button before leaving setup

--- a/src/persist/CrossPointStateJson.cpp
+++ b/src/persist/CrossPointStateJson.cpp
@@ -30,6 +30,10 @@ void populateDoc(const CrossPointState& s, JsonDocument& doc) {
   }
   JsonArray favs = doc["favoriteBmpPaths"].to<JsonArray>();
   for (const auto& entry : s.favoriteBmpPaths) favs.add(entry);
+  JsonArray seenFonts = doc["seenCustomFonts"].to<JsonArray>();
+  for (const auto& entry : s.seenCustomFonts) seenFonts.add(entry);
+  JsonArray skippedFonts = doc["skippedCustomFonts"].to<JsonArray>();
+  for (const auto& entry : s.skippedCustomFonts) skippedFonts.add(entry);
 }
 }  // namespace
 
@@ -83,6 +87,22 @@ bool deserializeCrossPointState(const std::string& json, CrossPointState& s) {
     for (const JsonVariant value : doc["favoriteBmpPaths"].as<JsonArray>()) {
       const char* entry = value.as<const char*>();
       if (entry && entry[0] != '\0') s.favoriteBmpPaths.emplace_back(entry);
+    }
+  }
+
+  s.seenCustomFonts.clear();
+  if (doc["seenCustomFonts"].is<JsonArray>()) {
+    for (const JsonVariant value : doc["seenCustomFonts"].as<JsonArray>()) {
+      const char* entry = value.as<const char*>();
+      if (entry && entry[0] != '\0') s.seenCustomFonts.emplace_back(entry);
+    }
+  }
+
+  s.skippedCustomFonts.clear();
+  if (doc["skippedCustomFonts"].is<JsonArray>()) {
+    for (const JsonVariant value : doc["skippedCustomFonts"].as<JsonArray>()) {
+      const char* entry = value.as<const char*>();
+      if (entry && entry[0] != '\0') s.skippedCustomFonts.emplace_back(entry);
     }
   }
   return true;


### PR DESCRIPTION
## Summary

- **Phase 1** of BDF custom-font loader. Drop `<name>_<size>.bdf` in `/custom-font/` on SD; firmware auto-creates the dir, scans on boot, parses each header (streaming, no full-file load), and shows a 3-button popup per new font: Install / Skip / Skip-forever. Phase 1 stops at the popup — the Install button records intent into `seenCustomFonts` for Phase 2 to act on. No glyph extraction, no font registration, no rendering yet.
- **Side fix** in [platformio.ini](platformio.ini): bumped `WEBSOCKETS_TCP_TIMEOUT` from the lib default 5s → 30s. Without this, multi-MB uploads via the file-transfer web server drop the connection mid-write because SD writes block longer than 5s. Tested on a 9.4 MB BDF.

## Architecture

- New lib `lib/BdfFont/` parallels `lib/EpdFont/`: `BdfFilename` (filename pattern parser) + `BdfParser` (line-based, streams from `HalFile`, stops at first `STARTCHAR`).
- `src/fonts/CustomFontManager` singleton owns the `/custom-font/` scan + the prompt queue.
- New `CustomFontPromptActivity` mirrors `ConfirmDialogActivity` with 3 options instead of 2 (duplicated rather than parameterized to avoid churning every existing 2-button confirm).
- Two new fields on `CrossPointState`: `seenCustomFonts` and `skippedCustomFonts`. Persisted in `state.json` via guarded read / unconditional write — backwards-compatible with old state files.

Untouched in Phase 1 (all reserved for Phase 2+):
- `lib/EpdFont/`, `lib/GfxRenderer/`, `src/fontIds.h`
- Font-family enum + `setupDisplayAndFonts()` registration
- Settings UI font picker

## Verified on device

```
[5574] [INF] [CFONT] unifont_16.bdf header OK glyphs=57086 bbx=16x16 ascent=14 descent=2
[5575] [INF] [CFONT] scanned 1 files, 1 valid, 1 queued
[9566] [INF] [CFONT] install requested: unifont_16.bdf
```

- Header parse: <1 s for 9.4 MB Unifont
- Free heap: ±56 B static delta vs main
- Flash: +7.4 KB default env (88.0% used, was 87.9%)
- Upload over WS: completes cleanly with 30s TCP timeout (failed at 53% with the old 5s default)

## Test plan

- [x] `pio run -e debug` — clean
- [x] `pio run -e default` — clean, +7.4 KB flash
- [x] Boot with empty SD `/custom-font/` — silent skip, no popup
- [x] Boot with valid BDF — popup appears, header logs match
- [x] Tap Install — log fires, `seenCustomFonts` populated, transitions to home
- [x] Upload 9.4 MB BDF over WS — completes (was failing at 53% pre-fix)
- [ ] Tap Skip-forever → reboot → confirm no popup (state persists)
- [ ] Tap Skip → reboot → confirm popup returns
- [ ] Drop malformed BDF (`broken_12.bdf` with garbage content) → confirm error log + no crash
- [ ] Drop file with invalid filename pattern (`justaname.bdf`) → confirm rejection log
- [ ] 50 valid BDFs in `/custom-font/` → confirm scan cap + watchdog OK

## Out of scope (Phase 2+)

- Real install pipeline (glyph extraction, `.idx` generation)
- `CustomFont` class + `GfxRenderer` dispatch + LRU glyph cache
- Settings UI: new font-family entry, size picker gating
- i18n strings for popup (currently literal English)

🤖 Generated with [Claude Code](https://claude.com/claude-code)