### PR TITLE
feat(fonts): BDF custom-font Phase 2a — index builder + SD-backed glyph source

### DIFF
--- a/lib/BdfFont/BdfIndex.h
+++ b/lib/BdfFont/BdfIndex.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace crosspoint {
+namespace bdf {
+
+// On-disk format for the per-BDF glyph index. Lives next to the source BDF
+// as <name>_<size>.idx. Built once on Install (Phase 2 Slice 2a) and then
+// memory-mapped from SD via lookups during render.
+//
+// Layout (little-endian throughout):
+//   [0..3]   magic "CPBI"
+//   [4]      version (currently 1)
+//   [5..7]   reserved (zeroed)
+//   [8..11]  glyphCount (uint32)
+//   [12]     font-wide bbxW   (int8) — informational, from FONTBOUNDINGBOX
+//   [13]     font-wide bbxH   (int8)
+//   [14]     font-wide ascent (int8)
+//   [15]     font-wide descent(int8)
+//   [16..]   glyphCount × IndexEntry, sorted by codepoint ascending
+//
+// Sorted-codepoint invariant lets the runtime do an O(log N) binary search.
+// Unsorted BDFs are rejected at build time with an error.
+
+constexpr uint32_t kBdfIndexMagic =
+    static_cast<uint32_t>('C') | (static_cast<uint32_t>('P') << 8) | (static_cast<uint32_t>('B') << 16) |
+    (static_cast<uint32_t>('I') << 24);
+constexpr uint8_t kBdfIndexVersion = 1;
+
+struct __attribute__((packed)) IndexHeader {
+  uint32_t magic;        // kBdfIndexMagic
+  uint8_t version;       // kBdfIndexVersion
+  uint8_t reserved0;
+  uint8_t reserved1;
+  uint8_t reserved2;
+  uint32_t glyphCount;
+  int8_t fontBbxW;
+  int8_t fontBbxH;
+  int8_t fontAscent;
+  int8_t fontDescent;
+};
+static_assert(sizeof(IndexHeader) == 16, "IndexHeader must be exactly 16 bytes");
+
+struct __attribute__((packed)) IndexEntry {
+  uint32_t codepoint;     // Unicode scalar
+  uint32_t bdfOffset;     // byte offset of "STARTCHAR" in the source BDF
+  uint8_t bitmapW;        // BBX width  (BDF "BBX W H X Y" first field)
+  uint8_t bitmapH;        // BBX height
+  uint8_t advance;        // DWIDTH x (advance width in pixels). 0 if not present.
+  int8_t bbxOffX;         // BBX X offset relative to origin
+  int8_t bbxOffY;         // BBX Y offset relative to baseline
+  uint8_t reserved0;
+  uint8_t reserved1;
+  uint8_t reserved2;
+};
+static_assert(sizeof(IndexEntry) == 16, "IndexEntry must be exactly 16 bytes");
+
+}  // namespace bdf
+}  // namespace crosspoint

--- a/lib/BdfFont/BdfIndexBuilder.cpp
+++ b/lib/BdfFont/BdfIndexBuilder.cpp
@@ -1,0 +1,171 @@
+#include "BdfIndexBuilder.h"
+
+#include <Arduino.h>
+#include <HalStorage.h>
+
+#include <cstring>
+
+#include "BdfIndex.h"
+#include "BdfParser.h"
+
+namespace crosspoint {
+namespace bdf {
+
+namespace {
+
+bool writePod(HalFile& f, const void* data, size_t len) {
+  return f.write(data, len) == len;
+}
+
+void buildTmpPath(const char* finalPath, char* out, size_t outSize) {
+  // <finalPath>.tmp
+  std::snprintf(out, outSize, "%s.tmp", finalPath);
+}
+
+}  // namespace
+
+BuildIndexResult BdfIndexBuilder::buildIndex(const char* bdfPath, const char* idxPath) {
+  BuildIndexResult result;
+  if (!bdfPath || !idxPath) {
+    result.error = "null path";
+    return result;
+  }
+
+  const uint32_t startMs = millis();
+
+  HalFile bdfFile = Storage.open(bdfPath);
+  if (!bdfFile) {
+    result.error = "cannot open BDF";
+    return result;
+  }
+
+  // Parse header to populate font-wide metrics (and to position the cursor at
+  // the first STARTCHAR).
+  const BdfHeader header = BdfParser::readHeader(bdfFile);
+  if (!header.ok) {
+    bdfFile.close();
+    result.error = header.error ? header.error : "header parse failed";
+    return result;
+  }
+  // The header parser stops AT the first STARTCHAR line — meaning that line
+  // has already been consumed. Rewind to the start and re-scan past header
+  // so the glyph enumerator captures STARTCHAR offsets correctly.
+  if (!bdfFile.seekSet(0)) {
+    bdfFile.close();
+    result.error = "rewind failed";
+    return result;
+  }
+  // Re-skip header without using readHeader again (faster: just walk lines
+  // until we see STARTCHAR; the header has been validated already). But we
+  // also need the file position right BEFORE that STARTCHAR line so the
+  // enumerator can record it as the first glyph offset.
+  // Easiest: leave the cursor at 0 and let readAllGlyphs walk from there —
+  // the leading non-glyph lines (STARTFONT, FONT, ...) are no-ops in its
+  // state machine (it ignores everything before STARTCHAR).
+
+  char tmpPath[320];
+  buildTmpPath(idxPath, tmpPath, sizeof(tmpPath));
+  Storage.remove(tmpPath);  // clean any stale .tmp from a prior aborted build
+
+  HalFile idxFile;
+  if (!Storage.openFileForWrite("BIB", tmpPath, idxFile)) {
+    bdfFile.close();
+    result.error = "cannot open .idx.tmp for write";
+    return result;
+  }
+
+  // Write a placeholder header. glyphCount is fixed up at the end.
+  IndexHeader hdr{};
+  hdr.magic = kBdfIndexMagic;
+  hdr.version = kBdfIndexVersion;
+  hdr.glyphCount = 0;
+  hdr.fontBbxW = static_cast<int8_t>(header.bbxW);
+  hdr.fontBbxH = static_cast<int8_t>(header.bbxH);
+  hdr.fontAscent = static_cast<int8_t>(header.ascent);
+  hdr.fontDescent = static_cast<int8_t>(header.descent);
+  if (!writePod(idxFile, &hdr, sizeof(hdr))) {
+    idxFile.close();
+    Storage.remove(tmpPath);
+    bdfFile.close();
+    result.error = "write header failed";
+    return result;
+  }
+
+  // Enumeration callback: write one IndexEntry per glyph. Reject out-of-order
+  // codepoints (binary search in the runtime requires sorted entries).
+  uint32_t glyphsWritten = 0;
+  uint32_t lastCp = 0;
+  bool first = true;
+  const char* writeErr = nullptr;
+
+  auto cb = [&](const BdfGlyphMeta& g) -> bool {
+    if (!first && g.codepoint <= lastCp) {
+      writeErr = "BDF glyphs not sorted by codepoint";
+      return false;  // abort enumeration
+    }
+    IndexEntry e{};
+    e.codepoint = g.codepoint;
+    e.bdfOffset = g.bdfOffset;
+    e.bitmapW = g.bbxW;
+    e.bitmapH = g.bbxH;
+    e.advance = g.advance;
+    e.bbxOffX = g.bbxOffX;
+    e.bbxOffY = g.bbxOffY;
+    if (!writePod(idxFile, &e, sizeof(e))) {
+      writeErr = "write entry failed";
+      return false;
+    }
+    ++glyphsWritten;
+    lastCp = g.codepoint;
+    first = false;
+    return true;
+  };
+
+  const BdfEnumResult enumRes = BdfParser::readAllGlyphs(bdfFile, cb);
+  bdfFile.close();
+
+  if (writeErr) {
+    idxFile.close();
+    Storage.remove(tmpPath);
+    result.error = writeErr;
+    return result;
+  }
+  if (!enumRes.ok) {
+    idxFile.close();
+    Storage.remove(tmpPath);
+    result.error = enumRes.error ? enumRes.error : "glyph enum failed";
+    return result;
+  }
+
+  // Patch the header glyphCount in place.
+  if (!idxFile.seekSet(offsetof(IndexHeader, glyphCount))) {
+    idxFile.close();
+    Storage.remove(tmpPath);
+    result.error = "seek-back to header failed";
+    return result;
+  }
+  if (!writePod(idxFile, &glyphsWritten, sizeof(glyphsWritten))) {
+    idxFile.close();
+    Storage.remove(tmpPath);
+    result.error = "patch glyphCount failed";
+    return result;
+  }
+  idxFile.flush();
+  idxFile.close();
+
+  Storage.remove(idxPath);
+  if (!Storage.rename(tmpPath, idxPath)) {
+    Storage.remove(tmpPath);
+    result.error = "rename .tmp -> .idx failed";
+    return result;
+  }
+
+  result.glyphsWritten = glyphsWritten;
+  result.glyphsSkipped = enumRes.glyphsSkipped;
+  result.parseTimeMs = millis() - startMs;
+  result.ok = true;
+  return result;
+}
+
+}  // namespace bdf
+}  // namespace crosspoint

--- a/lib/BdfFont/BdfIndexBuilder.h
+++ b/lib/BdfFont/BdfIndexBuilder.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+
+namespace crosspoint {
+namespace bdf {
+
+struct BuildIndexResult {
+  uint32_t glyphsWritten = 0;
+  uint32_t glyphsSkipped = 0;
+  uint32_t parseTimeMs = 0;
+  bool ok = false;
+  // Static literal — never owned. nullptr on success.
+  const char* error = nullptr;
+};
+
+class BdfIndexBuilder {
+ public:
+  // Open the BDF at `bdfPath`, walk every glyph, and write a sorted .idx
+  // file to `idxPath`. Existing .idx is overwritten atomically (.tmp →
+  // rename). The BDF is required to have glyphs in ascending codepoint
+  // order — out-of-order entries cause the build to abort with an error.
+  static BuildIndexResult buildIndex(const char* bdfPath, const char* idxPath);
+};
+
+}  // namespace bdf
+}  // namespace crosspoint

--- a/lib/BdfFont/BdfParser.cpp
+++ b/lib/BdfFont/BdfParser.cpp
@@ -164,5 +164,146 @@ BdfHeader BdfParser::readHeader(HalFile& in, const size_t wdtTickEvery) {
   }
 }
 
+BdfEnumResult BdfParser::readAllGlyphs(HalFile& in, const BdfGlyphCallback& cb, const size_t wdtTickEvery) {
+  BdfEnumResult result;
+  char line[kLineBuf];
+  size_t lineNum = 0;
+
+  // Per-glyph mutable state, reset between STARTCHARs.
+  bool inGlyph = false;
+  bool inBitmap = false;
+  uint32_t glyphStartOffset = 0;
+  long encoding = -1;
+  long bbxW = 0, bbxH = 0, bbxOX = 0, bbxOY = 0;
+  long dwidthX = 0;
+  bool sawEncoding = false;
+  bool sawBbx = false;
+
+  auto resetGlyph = [&]() {
+    inGlyph = false;
+    inBitmap = false;
+    encoding = -1;
+    bbxW = bbxH = bbxOX = bbxOY = 0;
+    dwidthX = 0;
+    sawEncoding = false;
+    sawBbx = false;
+  };
+
+  while (true) {
+    const uint32_t lineStartOffset = static_cast<uint32_t>(in.position());
+    const int n = readLine(in, line, sizeof(line));
+    if (n < 0) {
+      // EOF. ENDFONT may or may not have been seen; either way the file is
+      // exhausted. If we were mid-glyph that is malformed.
+      if (inGlyph) {
+        result.error = "EOF inside glyph";
+        return result;
+      }
+      result.ok = true;
+      return result;
+    }
+
+    if (++lineNum % wdtTickEvery == 0) {
+      esp_task_wdt_reset();
+      yield();
+    }
+
+    if (n == 0) continue;
+
+    if (inBitmap) {
+      // Skip every line until we hit ENDCHAR. Bitmap rows are pure hex; we
+      // do not need them for index building.
+      if (startsWithToken(line, "ENDCHAR")) {
+        if (sawEncoding && sawBbx && encoding >= 0) {
+          BdfGlyphMeta meta;
+          meta.codepoint = static_cast<uint32_t>(encoding);
+          meta.bdfOffset = glyphStartOffset;
+          meta.bbxW = static_cast<uint8_t>(bbxW < 0 ? 0 : (bbxW > 255 ? 255 : bbxW));
+          meta.bbxH = static_cast<uint8_t>(bbxH < 0 ? 0 : (bbxH > 255 ? 255 : bbxH));
+          meta.bbxOffX = static_cast<int8_t>(bbxOX < -128 ? -128 : (bbxOX > 127 ? 127 : bbxOX));
+          meta.bbxOffY = static_cast<int8_t>(bbxOY < -128 ? -128 : (bbxOY > 127 ? 127 : bbxOY));
+          meta.advance = static_cast<uint8_t>(dwidthX < 0 ? 0 : (dwidthX > 255 ? 255 : dwidthX));
+          ++result.glyphsYielded;
+          if (!cb(meta)) {
+            result.ok = true;
+            return result;
+          }
+        } else {
+          ++result.glyphsSkipped;
+        }
+        resetGlyph();
+      }
+      continue;
+    }
+
+    if (startsWithToken(line, "STARTCHAR")) {
+      if (inGlyph) {
+        // Nested STARTCHAR — malformed. Treat as reset.
+        ++result.glyphsSkipped;
+        resetGlyph();
+      }
+      inGlyph = true;
+      glyphStartOffset = lineStartOffset;
+      continue;
+    }
+
+    if (!inGlyph) {
+      if (startsWithToken(line, "ENDFONT")) {
+        result.ok = true;
+        return result;
+      }
+      // Outside any glyph and not ENDFONT — skip silently (could be tail
+      // comments or whitespace).
+      continue;
+    }
+
+    if (startsWithToken(line, "ENCODING")) {
+      const char* p = line + std::strlen("ENCODING");
+      if (parseInt(&p, &encoding)) sawEncoding = true;
+      continue;
+    }
+    if (startsWithToken(line, "BBX")) {
+      const char* p = line + std::strlen("BBX");
+      if (parseInt(&p, &bbxW) && parseInt(&p, &bbxH) && parseInt(&p, &bbxOX) && parseInt(&p, &bbxOY)) {
+        sawBbx = true;
+      }
+      continue;
+    }
+    if (startsWithToken(line, "DWIDTH")) {
+      const char* p = line + std::strlen("DWIDTH");
+      parseInt(&p, &dwidthX);  // ignore Y component (vertical advance)
+      continue;
+    }
+    if (startsWithToken(line, "BITMAP")) {
+      inBitmap = true;
+      continue;
+    }
+    if (startsWithToken(line, "ENDCHAR")) {
+      // ENDCHAR without BITMAP is malformed but tolerated — treat as a
+      // bitmap-less glyph (still has metrics).
+      if (sawEncoding && sawBbx && encoding >= 0) {
+        BdfGlyphMeta meta;
+        meta.codepoint = static_cast<uint32_t>(encoding);
+        meta.bdfOffset = glyphStartOffset;
+        meta.bbxW = static_cast<uint8_t>(bbxW < 0 ? 0 : (bbxW > 255 ? 255 : bbxW));
+        meta.bbxH = static_cast<uint8_t>(bbxH < 0 ? 0 : (bbxH > 255 ? 255 : bbxH));
+        meta.bbxOffX = static_cast<int8_t>(bbxOX < -128 ? -128 : (bbxOX > 127 ? 127 : bbxOX));
+        meta.bbxOffY = static_cast<int8_t>(bbxOY < -128 ? -128 : (bbxOY > 127 ? 127 : bbxOY));
+        meta.advance = static_cast<uint8_t>(dwidthX < 0 ? 0 : (dwidthX > 255 ? 255 : dwidthX));
+        ++result.glyphsYielded;
+        if (!cb(meta)) {
+          result.ok = true;
+          return result;
+        }
+      } else {
+        ++result.glyphsSkipped;
+      }
+      resetGlyph();
+      continue;
+    }
+    // Any other lines inside a glyph (SWIDTH, etc.) are ignored.
+  }
+}
+
 }  // namespace bdf
 }  // namespace crosspoint

--- a/lib/BdfFont/BdfParser.h
+++ b/lib/BdfFont/BdfParser.h
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 
 namespace crosspoint {
 namespace bdf {
@@ -22,14 +23,49 @@ struct BdfHeader {
   const char* error = nullptr;
 };
 
+// One glyph as yielded by readAllGlyphs(). Bitmap bytes are NOT included —
+// the index builder only needs metrics + offset; runtime decode pulls the
+// bitmap on demand using bdfOffset.
+struct BdfGlyphMeta {
+  uint32_t codepoint;       // ENCODING value (skipped if < 0)
+  uint32_t bdfOffset;       // byte offset where "STARTCHAR" begins
+  uint8_t bbxW;             // BBX W
+  uint8_t bbxH;             // BBX H
+  int8_t bbxOffX;           // BBX X
+  int8_t bbxOffY;           // BBX Y
+  uint8_t advance;          // DWIDTH x; 0 if absent
+};
+
+// Per-glyph callback. Return false to abort enumeration.
+using BdfGlyphCallback = std::function<bool(const BdfGlyphMeta& g)>;
+
+struct BdfEnumResult {
+  uint32_t glyphsYielded = 0;
+  uint32_t glyphsSkipped = 0;     // missing/invalid ENCODING
+  bool ok = false;
+  const char* error = nullptr;
+};
+
 class BdfParser {
  public:
   // Reads the BDF header (STARTFONT...CHARS N), then stops at the first
-  // STARTCHAR. Does NOT enumerate glyphs (that is Phase 2).
+  // STARTCHAR. Does NOT enumerate glyphs.
   //
   // The parser yields and resets the watchdog every `wdtTickEvery` lines so
   // a 9 MB Unifont scan does not trip the task watchdog.
   static BdfHeader readHeader(HalFile& in, size_t wdtTickEvery = 256);
+
+  // Enumerate every glyph (STARTCHAR..ENDCHAR block) in the file. Caller is
+  // responsible for seeking `in` to the byte right after readHeader returned
+  // — i.e. the first STARTCHAR line (or use rewind + re-call readHeader).
+  //
+  // For each glyph, fires `cb(meta)`. If `cb` returns false, enumeration
+  // stops with ok=true. Glyphs without a parseable ENCODING (e.g. ENCODING
+  // -1) are counted as skipped, not yielded.
+  //
+  // Bitmap bytes are NOT yielded — the consumer can re-open the file at
+  // `meta.bdfOffset` and parse STARTCHAR..ENDCHAR independently.
+  static BdfEnumResult readAllGlyphs(HalFile& in, const BdfGlyphCallback& cb, size_t wdtTickEvery = 32);
 };
 
 }  // namespace bdf

--- a/lib/BdfFont/CustomFontGlyphSource.cpp
+++ b/lib/BdfFont/CustomFontGlyphSource.cpp
@@ -1,0 +1,177 @@
+#include "CustomFontGlyphSource.h"
+
+#include <Arduino.h>
+#include <cctype>
+#include <cstring>
+
+namespace crosspoint {
+namespace bdf {
+
+namespace {
+
+constexpr size_t kBitmapLineBuf = 192;
+
+// Parse one hex character. Returns -1 on non-hex.
+int hexNibble(int c) {
+  if (c >= '0' && c <= '9') return c - '0';
+  if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+  if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+  return -1;
+}
+
+int readBitmapLine(HalFile& in, char* buf, size_t bufSize) {
+  if (bufSize == 0) return -1;
+  size_t len = 0;
+  bool sawAny = false;
+  while (true) {
+    const int c = in.read();
+    if (c < 0) {
+      if (!sawAny) return -1;
+      break;
+    }
+    sawAny = true;
+    if (c == '\n') break;
+    if (c == '\r') continue;
+    if (len + 1 < bufSize) buf[len++] = static_cast<char>(c);
+  }
+  buf[len] = '\0';
+  return static_cast<int>(len);
+}
+
+}  // namespace
+
+CustomFontGlyphSource::~CustomFontGlyphSource() { close(); }
+
+bool CustomFontGlyphSource::open(const char* bdfPath, const char* idxPath) {
+  close();
+
+  idxFile_ = Storage.open(idxPath);
+  if (!idxFile_) return false;
+
+  if (idxFile_.read(&hdr_, sizeof(hdr_)) != static_cast<int>(sizeof(hdr_))) {
+    idxFile_.close();
+    return false;
+  }
+  if (hdr_.magic != kBdfIndexMagic || hdr_.version != kBdfIndexVersion) {
+    idxFile_.close();
+    return false;
+  }
+  glyphCount_ = hdr_.glyphCount;
+
+  bdfFile_ = Storage.open(bdfPath);
+  if (!bdfFile_) {
+    idxFile_.close();
+    return false;
+  }
+
+  idxOpen_ = true;
+  cacheValid_ = false;
+  return true;
+}
+
+void CustomFontGlyphSource::close() {
+  if (idxOpen_) {
+    idxFile_.close();
+    bdfFile_.close();
+    idxOpen_ = false;
+  }
+  cacheValid_ = false;
+  bitmapBuf_.clear();
+}
+
+bool CustomFontGlyphSource::readIndexEntry(uint32_t indexPos, IndexEntry& out) {
+  const size_t fileOffset = sizeof(IndexHeader) + indexPos * sizeof(IndexEntry);
+  if (!idxFile_.seekSet(fileOffset)) return false;
+  return idxFile_.read(&out, sizeof(out)) == static_cast<int>(sizeof(out));
+}
+
+const CustomFontGlyphSource::Glyph* CustomFontGlyphSource::lookup(uint32_t codepoint) {
+  if (!idxOpen_ || glyphCount_ == 0) return nullptr;
+
+  if (cacheValid_ && cachedGlyph_.codepoint == codepoint) {
+    return &cachedGlyph_;
+  }
+
+  // Binary search the .idx by codepoint.
+  uint32_t lo = 0;
+  uint32_t hi = glyphCount_;
+  IndexEntry hit{};
+  bool found = false;
+  while (lo < hi) {
+    const uint32_t mid = lo + (hi - lo) / 2;
+    IndexEntry e{};
+    if (!readIndexEntry(mid, e)) return nullptr;
+    if (e.codepoint == codepoint) {
+      hit = e;
+      found = true;
+      break;
+    }
+    if (e.codepoint < codepoint) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  if (!found) {
+    cacheValid_ = false;
+    return nullptr;
+  }
+
+  if (!decodeBitmap(hit)) {
+    cacheValid_ = false;
+    return nullptr;
+  }
+
+  cachedGlyph_.codepoint = hit.codepoint;
+  cachedGlyph_.bbxW = hit.bitmapW;
+  cachedGlyph_.bbxH = hit.bitmapH;
+  cachedGlyph_.bbxOffX = hit.bbxOffX;
+  cachedGlyph_.bbxOffY = hit.bbxOffY;
+  cachedGlyph_.advance = hit.advance;
+  cachedGlyph_.bitmap = bitmapBuf_.data();
+  cachedGlyph_.bitmapBytes = bitmapBuf_.size();
+  cacheValid_ = true;
+  return &cachedGlyph_;
+}
+
+bool CustomFontGlyphSource::decodeBitmap(const IndexEntry& e) {
+  // Seek to the STARTCHAR line for this glyph. Then walk lines until BITMAP,
+  // then collect H rows of hex into bitmapBuf_.
+  if (!bdfFile_.seekSet(e.bdfOffset)) return false;
+
+  const size_t bytesPerRow = (e.bitmapW + 7) / 8;
+  const size_t totalBytes = bytesPerRow * e.bitmapH;
+  bitmapBuf_.assign(totalBytes, 0);
+  if (totalBytes == 0) return true;  // zero-size glyph (e.g. SPACE) — empty bitmap is valid
+
+  char line[kBitmapLineBuf];
+  // Walk lines until BITMAP token.
+  bool sawBitmap = false;
+  for (int safety = 0; safety < 64; ++safety) {
+    const int n = readBitmapLine(bdfFile_, line, sizeof(line));
+    if (n < 0) return false;
+    if (std::strncmp(line, "BITMAP", 6) == 0 && (line[6] == '\0' || line[6] == ' ' || line[6] == '\t')) {
+      sawBitmap = true;
+      break;
+    }
+  }
+  if (!sawBitmap) return false;
+
+  // Read H rows. Each row is `bytesPerRow * 2` hex chars (BDF pads each row
+  // to a whole byte). Tolerate trailing whitespace or CR (already stripped).
+  for (size_t row = 0; row < e.bitmapH; ++row) {
+    const int n = readBitmapLine(bdfFile_, line, sizeof(line));
+    if (n < 0) return false;
+    if (static_cast<size_t>(n) < bytesPerRow * 2) return false;
+    for (size_t b = 0; b < bytesPerRow; ++b) {
+      const int hi = hexNibble(static_cast<unsigned char>(line[b * 2]));
+      const int lo = hexNibble(static_cast<unsigned char>(line[b * 2 + 1]));
+      if (hi < 0 || lo < 0) return false;
+      bitmapBuf_[row * bytesPerRow + b] = static_cast<uint8_t>((hi << 4) | lo);
+    }
+  }
+  return true;
+}
+
+}  // namespace bdf
+}  // namespace crosspoint

--- a/lib/BdfFont/CustomFontGlyphSource.h
+++ b/lib/BdfFont/CustomFontGlyphSource.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <HalStorage.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "BdfIndex.h"
+
+namespace crosspoint {
+namespace bdf {
+
+// Runtime read-only access to a custom BDF font that has already been indexed.
+// On open() it reads the .idx header (kept in RAM) and keeps both the BDF and
+// .idx files open. lookup(cp) does a binary search in the .idx (via SD seek)
+// and lazy-decodes the bitmap from the BDF on cache miss.
+//
+// Cache: single most-recent glyph. Sufficient for Slice 2a verification (one
+// codepoint dumped at a time). Phase 2b will replace this with a real LRU
+// once GfxRenderer is dispatching multiple glyphs per page.
+class CustomFontGlyphSource {
+ public:
+  CustomFontGlyphSource() = default;
+  ~CustomFontGlyphSource();
+
+  CustomFontGlyphSource(const CustomFontGlyphSource&) = delete;
+  CustomFontGlyphSource& operator=(const CustomFontGlyphSource&) = delete;
+
+  // Open both the .idx and the BDF. On failure returns false and leaves the
+  // source in the closed state (lookup will return nullptr).
+  bool open(const char* bdfPath, const char* idxPath);
+  void close();
+  bool isOpen() const { return idxOpen_; }
+
+  uint32_t glyphCount() const { return glyphCount_; }
+  int8_t fontBbxW() const { return hdr_.fontBbxW; }
+  int8_t fontBbxH() const { return hdr_.fontBbxH; }
+  int8_t fontAscent() const { return hdr_.fontAscent; }
+  int8_t fontDescent() const { return hdr_.fontDescent; }
+
+  struct Glyph {
+    uint32_t codepoint;
+    uint8_t bbxW;
+    uint8_t bbxH;
+    int8_t bbxOffX;
+    int8_t bbxOffY;
+    uint8_t advance;
+    // ceil(bbxW / 8) * bbxH bytes, MSB-first per row, padded to byte
+    // boundary at the end of each row. Borrowed pointer; valid until the
+    // next lookup() call.
+    const uint8_t* bitmap;
+    size_t bitmapBytes;
+  };
+
+  // O(log N) binary search in .idx + bitmap decode. Returns nullptr if the
+  // codepoint is not in the index.
+  const Glyph* lookup(uint32_t codepoint);
+
+ private:
+  bool readIndexEntry(uint32_t indexPos, IndexEntry& out);
+  bool decodeBitmap(const IndexEntry& e);
+
+  HalFile bdfFile_;
+  HalFile idxFile_;
+  bool idxOpen_ = false;
+
+  IndexHeader hdr_{};
+  uint32_t glyphCount_ = 0;
+
+  // 1-slot cache.
+  bool cacheValid_ = false;
+  Glyph cachedGlyph_{};
+  std::vector<uint8_t> bitmapBuf_;
+};
+
+}  // namespace bdf
+}  // namespace crosspoint

--- a/src/activities/util/FullScreenMessageActivity.cpp
+++ b/src/activities/util/FullScreenMessageActivity.cpp
@@ -2,15 +2,37 @@
 
 #include <GfxRenderer.h>
 
+#include <vector>
+
 #include "fontIds.h"
 
 void FullScreenMessageActivity::onEnter() {
   Activity::onEnter();
 
-  const auto height = renderer.getLineHeight(UI_10_FONT_ID);
-  const auto top = (renderer.getScreenHeight() - height) / 2;
+  // Split message on '\n' so multi-line strings render as separate, centered
+  // lines instead of drawing literal LF as a missing-glyph box.
+  std::vector<std::string> lines;
+  size_t start = 0;
+  while (start <= text.size()) {
+    auto nl = text.find('\n', start);
+    if (nl == std::string::npos) nl = text.size();
+    lines.emplace_back(text.substr(start, nl - start));
+    start = nl + 1;
+  }
+  if (lines.empty()) lines.emplace_back("");
+
+  const int lineH = renderer.getLineHeight(UI_10_FONT_ID);
+  const int lineGap = 2;
+  const int blockH = static_cast<int>(lines.size()) * lineH + (static_cast<int>(lines.size()) - 1) * lineGap;
+  const int top = (renderer.getScreenHeight() - blockH) / 2;
 
   renderer.clearScreen();
-  renderer.drawCenteredText(UI_10_FONT_ID, top, text.c_str(), true, style);
+  int y = top;
+  const int maxLineW = renderer.getScreenWidth() - 16;  // small horizontal margin
+  for (const auto& raw : lines) {
+    const std::string truncated = renderer.truncatedText(UI_10_FONT_ID, raw.c_str(), maxLineW);
+    renderer.drawCenteredText(UI_10_FONT_ID, y, truncated.c_str(), true, style);
+    y += lineH + lineGap;
+  }
   renderer.displayBuffer(refreshMode);
 }

--- a/src/fonts/CustomFontManager.cpp
+++ b/src/fonts/CustomFontManager.cpp
@@ -1,7 +1,9 @@
 #include "CustomFontManager.h"
 
 #include <BdfFilename.h>
+#include <BdfIndexBuilder.h>
 #include <BdfParser.h>
+#include <CustomFontGlyphSource.h>
 #include <HalStorage.h>
 #include <Logging.h>
 #include <esp_task_wdt.h>
@@ -13,6 +15,7 @@
 
 #include "CrossPointState.h"
 #include "activities/util/CustomFontPromptActivity.h"
+#include "activities/util/FullScreenMessageActivity.h"
 
 // Defined in main.cpp; replaces the current activity slot.
 class Activity;
@@ -141,11 +144,25 @@ void CustomFontManager::scanAndQueuePrompts() {
   }
   dir.close();
 
-  // Cross-check vs persistent state.
+  // Cross-check vs persistent state. Prompt unless:
+  //   - user said "Skip forever" (always honored), OR
+  //   - user said "Install" AND the .idx file is on disk (genuine completed
+  //     install). If .idx is missing, re-prompt so the build can re-run —
+  //     this also retroactively triggers the Phase 2 index build for any
+  //     font that was "installed" under the Phase 1 stub.
   for (size_t i = 0; i < entries_.size(); ++i) {
     const auto& fn = entries_[i].filename;
     if (contains(APP_STATE.skippedCustomFonts, fn)) continue;
-    if (contains(APP_STATE.seenCustomFonts, fn)) continue;
+
+    if (contains(APP_STATE.seenCustomFonts, fn)) {
+      // .bdf -> .idx; same dir.
+      std::string idxPath = std::string(kCustomFontDir) + "/" + fn;
+      if (idxPath.size() >= 4) {
+        idxPath.resize(idxPath.size() - 4);
+        idxPath += ".idx";
+      }
+      if (Storage.exists(idxPath.c_str())) continue;
+    }
     pendingPromptIdx_.push_back(i);
   }
 
@@ -179,7 +196,81 @@ void CustomFontManager::showNextPromptIfAny(GfxRenderer& renderer, MappedInputMa
       APP_STATE.seenCustomFonts.push_back(filename);
       APP_STATE.saveToFile();
     }
-    LOG_INF(kModule, "install requested: %s", filename.c_str());
+
+    // Phase 2 Slice 2a: build the on-disk glyph index. This is the slow
+    // part — for 9 MB Unifont it walks every line. Watchdog resets are
+    // handled inside the parser (every 32 lines).
+    char bdfPath[320];
+    char idxPath[320];
+    snprintf(bdfPath, sizeof(bdfPath), "%s/%s", kCustomFontDir, filename.c_str());
+    // .bdf -> .idx
+    std::string idxStr = "/custom-font/" + filename;
+    if (idxStr.size() >= 4) {
+      idxStr.resize(idxStr.size() - 4);
+      idxStr += ".idx";
+    }
+    snprintf(idxPath, sizeof(idxPath), "%s", idxStr.c_str());
+
+    // Visual feedback — without this the device sits silent for 30+ seconds
+    // while buildIndex walks Unifont. Push a full-screen "Building..." page,
+    // force its first frame onto the e-ink, then run the build synchronously.
+    {
+      std::string msg = "Building font index\n\n";
+      msg += filename;
+      msg += "\n\nThis may take 1-3 min\nDo not reboot";
+      auto* progressActivity = new FullScreenMessageActivity(renderer, mappedInput, msg);
+      enterNewActivity(progressActivity);
+      progressActivity->requestUpdateAndWait();
+    }
+
+    LOG_INF(kModule, "building index: %s -> %s", bdfPath, idxPath);
+    const auto build = bdf::BdfIndexBuilder::buildIndex(bdfPath, idxPath);
+    if (!build.ok) {
+      LOG_INF(kModule, "index build FAILED for %s: %s", filename.c_str(),
+              build.error ? build.error : "unknown");
+    } else {
+      LOG_INF(kModule, "index built OK: %u glyphs (skipped %u) in %u ms",
+              static_cast<unsigned>(build.glyphsWritten), static_cast<unsigned>(build.glyphsSkipped),
+              static_cast<unsigned>(build.parseTimeMs));
+
+      // Verification dump — open the source and resolve a few well-known
+      // codepoints. Confirms the entire pipeline (idx → seek → bitmap decode).
+      bdf::CustomFontGlyphSource src;
+      if (src.open(bdfPath, idxPath)) {
+        const uint32_t samples[] = {0x0041, 0x0042, 0x0048, 0x0069, 0x0420, 0x4E2D};  // A B H i Р 中
+        for (uint32_t cp : samples) {
+          const auto* g = src.lookup(cp);
+          if (!g) {
+            LOG_INF(kModule, "  cp U+%04X: not in font", static_cast<unsigned>(cp));
+            continue;
+          }
+          LOG_INF(kModule, "  cp U+%04X: %ux%u adv=%u offX=%d offY=%d bitmapBytes=%u",
+                  static_cast<unsigned>(cp), static_cast<unsigned>(g->bbxW), static_cast<unsigned>(g->bbxH),
+                  static_cast<unsigned>(g->advance), static_cast<int>(g->bbxOffX), static_cast<int>(g->bbxOffY),
+                  static_cast<unsigned>(g->bitmapBytes));
+        }
+        src.close();
+      } else {
+        LOG_INF(kModule, "verification: failed to reopen %s+%s", bdfPath, idxPath);
+      }
+    }
+
+    // Result screen — brief, then chain. Even on failure the user sees
+    // something other than the build screen.
+    {
+      char doneMsg[200];
+      if (build.ok) {
+        snprintf(doneMsg, sizeof(doneMsg), "Font installed\n\n%u glyphs\n%u ms",
+                 static_cast<unsigned>(build.glyphsWritten), static_cast<unsigned>(build.parseTimeMs));
+      } else {
+        snprintf(doneMsg, sizeof(doneMsg), "Install failed\n\n%s", build.error ? build.error : "unknown");
+      }
+      auto* doneActivity = new FullScreenMessageActivity(renderer, mappedInput, doneMsg);
+      enterNewActivity(doneActivity);
+      doneActivity->requestUpdateAndWait();
+      delay(2500);
+    }
+
     showNextPromptIfAny(renderer, mappedInput, onAllDismissed);
   };
   auto onSkip = [this, filename, &renderer, &mappedInput, onAllDismissed]() {


### PR DESCRIPTION
**Stacks on #66.** Merge that one first.

## Summary

- Phase 2 Slice 2a: SD-backed glyph reader with lazy bitmap decode. The Phase 1 \"Install\" stub now does real work — builds an on-disk `.idx` file and verifies the full lookup pipeline by dumping 6 sample codepoints (Latin, Cyrillic, CJK).
- Side fix: `FullScreenMessageActivity` now splits messages on `\n` (was rendering LF as missing-glyph tofu and overflowing the screen).

## Architecture

`lib/BdfFont/` gains:

- **`BdfIndex.h`** — on-disk format. 16-byte header (magic CPBI + glyph count + font-wide metrics), then 16-byte entries per glyph (codepoint, BDF offset, bbx + advance). Sorted by codepoint for binary search.
- **`BdfParser::readAllGlyphs`** — extends Phase 1's header-only parser with a callback-driven STARTCHAR..ENDCHAR enumerator. Captures BDF file offsets so the runtime can re-seek for bitmap decode without keeping the whole BDF resident.
- **`BdfIndexBuilder`** — walks BDF, writes `.idx` atomically (`.tmp` → rename). Aborts on out-of-order codepoints (binary search invariant).
- **`CustomFontGlyphSource`** — runtime read-only API. `open()` keeps both BDF and `.idx` open. `lookup(cp)` does O(log N) binary search via SD seek + lazy bitmap decode. 1-slot cache (real LRU is Phase 2b territory once render path actually thrashes it).

`CustomFontManager` wiring:
- Install lambda runs `BdfIndexBuilder::buildIndex` synchronously + dumps verification samples (A B H i Cyrillic-Р CJK-中)
- Pushes `FullScreenMessageActivity` for visible progress before/after the long synchronous build
- Self-healing scan: re-prompts for any seen font whose `.idx` is missing — also lets Phase 1 stubs upgrade to Phase 2 indexes on next boot

## Verified on device

```
[73553] [INF] [CFONT] building index: /custom-font/unifont_16.bdf -> /custom-font/unifont_16.idx
[392318] [INF] [CFONT] index built OK: 57086 glyphs (skipped 0) in 318764 ms
[392341] [INF] [CFONT]   cp U+0041: 8x16 adv=8 offX=0 offY=-2 bitmapBytes=16
[392355] [INF] [CFONT]   cp U+0042: 8x16 adv=8 offX=0 offY=-2 bitmapBytes=16
[392367] [INF] [CFONT]   cp U+0048: 8x16 adv=8 offX=0 offY=-2 bitmapBytes=16
[392380] [INF] [CFONT]   cp U+0069: 8x16 adv=8 offX=0 offY=-2 bitmapBytes=16
[392393] [INF] [CFONT]   cp U+0420: 8x16 adv=8 offX=0 offY=-2 bitmapBytes=16
[392410] [INF] [CFONT]   cp U+4E2D: 16x16 adv=16 offX=0 offY=-2 bitmapBytes=32
```

- Build time: 318 sec for 9.4 MB Unifont. Slow but expected — first-time install only, runs once per font.
- `.idx` file: ~913 KB on SD (16 bytes × 57086 glyphs + header).
- Cyrillic + CJK lookups confirm binary search is correct across the full BMP.

## Test plan

- [x] `pio run -e debug` — clean
- [x] `pio run -e default` — clean, +3.9 KB flash vs Phase 1
- [x] Install path on device with Unifont 9.4 MB → `.idx` built + sample glyphs dump correctly
- [x] Self-healing scan detects missing `.idx` and re-prompts even when filename is in `seenCustomFonts`
- [x] Progress + result screens render readable (newline split fix)
- [ ] Reboot after install → no popup, transitions to home directly (because `.idx` exists)
- [ ] Multiple BDFs queued → second popup chains after first dismiss

## Out of scope (Phase 2b+)

- `CustomFont` class implementing `EpdFont` API
- `GfxRenderer` dispatch (today's hot path is non-virtual + assumes flash-resident font data)
- Real LRU cache (1-slot is enough for verification, will thrash under page layout)
- Font picker entry in `ReaderSettingsActivity`
- i18n strings for popup + progress screens
- Build-time progress callback (parser is yield-only today; user sees a static \"building...\" screen for 5 minutes on Unifont)

🤖 Generated with [Claude Code](https://claude.com/claude-code)