### PR TITLE
fix(fonts): single-active registration to stop boot-loop + book-open OOM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ releases/
 .claude/.DS_Store
 .claude/scheduled_tasks.lock
 CLAUDE.md
+logs/

--- a/lib/BdfFont/CustomFont.cpp
+++ b/lib/BdfFont/CustomFont.cpp
@@ -21,7 +21,7 @@ constexpr size_t kSlotForStyle(CustomFont::StyleBits style) {
 bool CustomFont::open(const char* bdfPath, const char* idxPath, uint16_t sizePt, size_t cacheSlots) {
   auto src = std::make_unique<CustomFontGlyphSource>();
   if (!src->open(bdfPath, idxPath)) return false;
-  src->setCacheCap(cacheSlots == 0 ? 1 : cacheSlots);
+  if (!src->setCacheCap(cacheSlots == 0 ? 1 : cacheSlots)) return false;
   variants_[SLOT_REGULAR] = std::move(src);
   sizePt_ = sizePt;
   return true;
@@ -31,9 +31,17 @@ bool CustomFont::openVariant(size_t slot, const char* bdfPath, const char* idxPa
   if (slot == SLOT_REGULAR || slot >= 4) return false;
   auto src = std::make_unique<CustomFontGlyphSource>();
   if (!src->open(bdfPath, idxPath)) return false;
-  src->setCacheCap(cacheSlots == 0 ? 1 : cacheSlots);
+  if (!src->setCacheCap(cacheSlots == 0 ? 1 : cacheSlots)) return false;
   variants_[slot] = std::move(src);
   return true;
+}
+
+void CustomFont::trimCache(size_t slots) {
+  for (auto& v : variants_) {
+    if (v && v->isOpen()) {
+      v->setCacheCap(slots == 0 ? 1 : slots);
+    }
+  }
 }
 
 CustomFontGlyphSource* CustomFont::getVariant(StyleBits style) const {

--- a/lib/BdfFont/CustomFont.h
+++ b/lib/BdfFont/CustomFont.h
@@ -58,6 +58,11 @@ class CustomFont {
   bool hasVariant(size_t slot) const { return slot < 4 && variants_[slot] && variants_[slot]->isOpen(); }
   uint16_t sizePt() const { return sizePt_; }
 
+  // Shrink every variant's glyph cache to `slots` (default 1). Frees the
+  // existing slab so a large contiguous allocation elsewhere can succeed.
+  // Cache rebuilds organically on next lookup().
+  void trimCache(size_t slots = 1);
+
   // Synthetic-bold tuning. Mirrors EpdFontFamily:
   // totalPasses(style) = syntheticRegularBoldPasses_
   //                    + (no real bold variant AND style has BOLD ? syntheticBoldExtraPasses_ : 0)

--- a/lib/BdfFont/CustomFontGlyphSource.cpp
+++ b/lib/BdfFont/CustomFontGlyphSource.cpp
@@ -1,6 +1,8 @@
 #include "CustomFontGlyphSource.h"
 
 #include <Arduino.h>
+#include <esp_heap_caps.h>
+
 #include <cctype>
 #include <cstring>
 
@@ -73,7 +75,10 @@ bool CustomFontGlyphSource::open(const char* bdfPath, const char* idxPath) {
   if (maxBitmapBytes_ == 0) maxBitmapBytes_ = 1;
 
   idxOpen_ = true;
-  allocSlab_();
+  if (!allocSlab_()) {
+    close();
+    return false;
+  }
   return true;
 }
 
@@ -88,22 +93,49 @@ void CustomFontGlyphSource::close() {
   maxBitmapBytes_ = 0;
 }
 
-void CustomFontGlyphSource::setCacheCap(size_t slots) {
+bool CustomFontGlyphSource::setCacheCap(size_t slots) {
   if (slots == 0) slots = 1;
   if (slots > 65534) slots = 65534;
-  if (slots == cacheCap_) return;
+  if (slots == cacheCap_) return true;
+  const size_t prevCap = cacheCap_;
   cacheCap_ = slots;
-  if (idxOpen_) allocSlab_();
+  if (idxOpen_ && !allocSlab_()) {
+    cacheCap_ = prevCap;
+    close();
+    return false;
+  }
+  return true;
 }
 
-void CustomFontGlyphSource::allocSlab_() {
+bool CustomFontGlyphSource::allocSlab_() {
   // Rebuild cache structures from scratch. Called from open() (cold) and
   // setCacheCap() when the cap actually changes. All prior cached glyphs
   // are dropped — callers holding a Glyph* from before this call must not
   // dereference it.
-  cacheMap_.clear();
-  slots_.clear();
-  bitmapSlab_.clear();
+  //
+  // vector::clear() + assign(smaller) does NOT shrink capacity, so the old
+  // (possibly tens of KB) heap block stays attached to the vector. Swap with
+  // a default-constructed container guarantees the release, which is what
+  // trimCache(1) relies on to reclaim contiguous heap for the epub section
+  // ZIP dict.
+  std::unordered_map<uint32_t, uint16_t>().swap(cacheMap_);
+  std::vector<Slot>().swap(slots_);
+  std::vector<uint8_t>().swap(bitmapSlab_);
+
+  // -fno-exceptions: a failed std::vector::assign aborts via operator new
+  // rather than throwing. Pre-check the largest contiguous free block so
+  // we can bail gracefully and let the caller continue without this font.
+  // Safety margin only applies when the slab is big — trim paths allocate
+  // a few hundred bytes and MUST succeed (otherwise setCacheCap closes the
+  // source, leaving the font unrenderable and the book with blank text).
+  constexpr size_t kHeapSafetyMargin = 32 * 1024;
+  constexpr size_t kLargeSlabThreshold = 2048;
+  const size_t slabBytes = cacheCap_ * maxBitmapBytes_;
+  const size_t requiredMargin = slabBytes >= kLargeSlabThreshold ? kHeapSafetyMargin : 0;
+  const size_t largest = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+  if (slabBytes + requiredMargin > largest) {
+    return false;
+  }
 
   slots_.resize(cacheCap_);
   bitmapSlab_.assign(cacheCap_ * maxBitmapBytes_, 0);
@@ -118,12 +150,15 @@ void CustomFontGlyphSource::allocSlab_() {
   freeHead_ = cacheCap_ > 0 ? 0 : kNil;
   lruHead_ = kNil;
   lruTail_ = kNil;
+  return true;
 }
 
 void CustomFontGlyphSource::clearSlab_() {
-  cacheMap_.clear();
-  slots_.clear();
-  bitmapSlab_.clear();
+  // See allocSlab_ — swap idiom forces heap release where clear() alone
+  // would keep the underlying allocation attached.
+  std::unordered_map<uint32_t, uint16_t>().swap(cacheMap_);
+  std::vector<Slot>().swap(slots_);
+  std::vector<uint8_t>().swap(bitmapSlab_);
   freeHead_ = kNil;
   lruHead_ = kNil;
   lruTail_ = kNil;

--- a/lib/BdfFont/CustomFontGlyphSource.h
+++ b/lib/BdfFont/CustomFontGlyphSource.h
@@ -44,7 +44,9 @@ class CustomFontGlyphSource {
 
   // Configure max cached glyphs. Must be >=1; clamped to 65534. Changing
   // the cap while open clears all cached glyphs and reallocates the slab.
-  void setCacheCap(size_t slots);
+  // Returns false if reallocation failed due to heap pressure — source is
+  // left closed in that case (caller should treat the font as unavailable).
+  bool setCacheCap(size_t slots);
   size_t cacheCap() const { return cacheCap_; }
 
   uint32_t glyphCount() const { return glyphCount_; }
@@ -86,7 +88,9 @@ class CustomFontGlyphSource {
   bool readIndexEntry(uint32_t indexPos, IndexEntry& out);
   bool decodeBitmap(const IndexEntry& e, uint8_t* dst, size_t dstCap);
 
-  void allocSlab_();
+  // Returns false if required slab size cannot fit in the largest free heap
+  // block (plus safety margin). On failure the source is left closed.
+  bool allocSlab_();
   void clearSlab_();
   void lruUnlink_(uint16_t idx);
   void lruPushFront_(uint16_t idx);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -34,6 +34,7 @@
 #include "activities/util/ConfirmDialogActivity.h"
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"
+#include "fonts/CustomFontManager.h"
 #include "persist/BackupMirror.h"
 #include "util/DrawUtils.h"
 #include "util/FavoriteBmp.h"
@@ -1236,6 +1237,12 @@ bool EpubReaderActivity::ensureSectionLoaded(const uint16_t viewportWidth, const
   const uint8_t sectionTextRenderMode = SETTINGS.textRenderMode;
   const bool boldSwapEnabled = RECENT_BOOKS.getBoldSwap(epub->getPath());
 
+  // Single-active custom-font registration. Per-book ReadingThemes can
+  // change SETTINGS.customFontName after boot-time setup, so re-register
+  // here — unconditionally, since the cache-hit path still needs the font
+  // resolvable when drawText runs.
+  crosspoint::fonts::CustomFontManager::instance().registerWithRenderer(renderer);
+
   if (!section->loadSectionFile(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
                                 SETTINGS.extraParagraphSpacingLevel, SETTINGS.paragraphAlignment, viewportWidth,
                                 viewportHeight, SETTINGS.hyphenationEnabled != 0, SETTINGS.wordSpacingPercent,
@@ -1247,6 +1254,7 @@ bool EpubReaderActivity::ensureSectionLoaded(const uint16_t viewportWidth, const
     // dictionary). They rebuild automatically on next render.
     auto* fcm = renderer.getFontCacheManager();
     if (fcm) fcm->clearCache();
+    crosspoint::fonts::CustomFontManager::instance().trimAllCaches(renderer);
 
     // Progress hook: the layout parser emits percentages as it chews the HTML. We only use it
     // to gate the "Still working on it..." toast, not a real progress bar — keeps UX simple

--- a/src/activities/reader/ReaderSettingsActivity.cpp
+++ b/src/activities/reader/ReaderSettingsActivity.cpp
@@ -128,6 +128,9 @@ void ReaderSettingsActivity::applyFontSizeEdit() {
     if (!sizes.empty() && fontSizeEditDraftIndex < sizes.size()) {
       SETTINGS.customFontSizePt = sizes[fontSizeEditDraftIndex];
     }
+    // Registration is single-active — re-register so the renderer has
+    // the new (name, size) pair before the next draw.
+    crosspoint::fonts::CustomFontManager::instance().registerWithRenderer(renderer);
   } else {
     SETTINGS.fontSize = CrossPointSettings::displayIndexToFontSize(SETTINGS.fontFamily, fontSizeEditDraftIndex);
   }
@@ -457,6 +460,10 @@ void ReaderSettingsActivity::toggleCurrentSetting() {
       SETTINGS.fontFamily = CrossPointSettings::normalizeFontFamily(SETTINGS.fontFamily);
       SETTINGS.fontSize = CrossPointSettings::normalizeFontSizeForFamily(SETTINGS.fontFamily, SETTINGS.fontSize);
       SETTINGS.lineSpacingPercent = CrossPointSettings::resetLineSpacingPercentForFamily(SETTINGS.fontFamily);
+      // Single-active registration: drop the previously-active custom font
+      // and register the new one (if any) so the renderer has the right
+      // glyph source before the next draw.
+      crosspoint::fonts::CustomFontManager::instance().registerWithRenderer(renderer);
       buildSettingsList();
       selectedRowIndex = std::min(selectedRowIndex, static_cast<int>(flatRows.size()) - 1);
     } else {

--- a/src/fonts/CustomFontManager.cpp
+++ b/src/fonts/CustomFontManager.cpp
@@ -8,6 +8,7 @@
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <Logging.h>
+#include <esp_heap_caps.h>
 #include <esp_task_wdt.h>
 #include <strings.h>
 
@@ -37,13 +38,24 @@ namespace {
 
 constexpr const char* kModule = "CFONT";
 constexpr const char* kCustomFontDir = "/custom-font";
-constexpr size_t kScanCap = 50;          // hard limit on .bdf files scanned per boot
+constexpr size_t kScanCap = 250;         // hard limit on .bdf files scanned per boot
 constexpr size_t kWdtResetInterval = 32; // reset watchdog every N dir entries
 
-// Phase 2b LRU cache budget. Unifont-16 glyphs are 32 bytes each, so 384
-// slots ≈ 12 KB of bitmap + ~6 KB of std::list/unordered_map overhead on
-// top. Sits comfortably in the ~180 KB free heap.
-constexpr size_t kCustomFontCacheSlots = 384;
+// Phase 2b LRU cache budget. Per-variant slab = slots * maxBitmapBytes, where
+// maxBitmapBytes scales with the font's bounding box. For a 32pt display font
+// with bbx 112x46 that is ~644 B/slot. Only the reader-active family gets the
+// full cap; the rest register with kCacheSlotsInactive so they take minimal
+// heap and do not fragment the arena into pieces too small for the epub
+// section-cache's 32 KB contiguous block (which shows the OOM/reboot screen
+// when it fails).
+constexpr size_t kCustomFontCacheSlots = 32;
+constexpr size_t kCacheSlotsInactive = 4;
+
+// Stop opening more families when the largest contiguous free block drops
+// below this threshold. Leaves room for render buffers, epub section cache,
+// webserver, etc. Also protects against fragmentation — free heap may be
+// higher but split into pieces too small for a single slab.
+constexpr size_t kHeapFloorForNextFamilyBytes = 56 * 1024;
 
 bool isBdfName(const char* name) {
   if (!name || name[0] == '\0' || name[0] == '.') return false;
@@ -170,8 +182,45 @@ void CustomFontManager::registerWithRenderer(GfxRenderer& renderer) {
   // fontA_20) can switch between them via the reader Font Size picker
   // without re-scanning SD.
   static constexpr const char* kSlotNames[4] = {"regular", "bold", "italic", "bolditalic"};
-
+  // Only the user's currently-active family is registered in the renderer.
+  // Every previous attempt to preload multiple families fragmented the
+  // ESP32-C3 heap badly enough that the 32 KB epub section ZIP dict could
+  // no longer coalesce, crashing book open with a `std::terminate` from
+  // operator new. Non-active families are still visible in the picker
+  // (from `entries_`/`families_`) — selecting one triggers re-register
+  // via ReaderSettingsActivity → this function.
+  //
+  // Clear prior registrations first so a font switch drops the old slab
+  // before the new one is allocated. `insertCustomFont` already does this
+  // on collision, but the ID changes across families so explicit sweep is
+  // required.
   for (const auto& g : families_) {
+    renderer.removeCustomFont(idForFamily(g.fontName, g.sizePt));
+  }
+
+  if (SETTINGS.customFontName.empty() || SETTINGS.customFontSizePt == 0) {
+    LOG_INF(kModule, "no active custom font; renderer left without custom registrations");
+    return;
+  }
+
+  const CustomFontFamilyGroup* activeGroup = nullptr;
+  for (const auto& g : families_) {
+    if (g.fontName == SETTINGS.customFontName && g.sizePt == SETTINGS.customFontSizePt) {
+      activeGroup = &g;
+      break;
+    }
+  }
+  if (!activeGroup) {
+    LOG_INF(kModule, "active font '%s' @ %upt not present in scanned families",
+            SETTINGS.customFontName.c_str(), static_cast<unsigned>(SETTINGS.customFontSizePt));
+    return;
+  }
+
+  // Single-family loop — keeps the original variant/.idx handling code
+  // below untouched. `continue` inside this loop always falls through to
+  // the end of the function, which is the desired behaviour.
+  for (const auto* gp : {activeGroup}) {
+    const auto& g = *gp;
     if (g.variantEntryIdx[bdf::CustomFont::SLOT_REGULAR] < 0) continue;
 
     const int regIdx = g.variantEntryIdx[bdf::CustomFont::SLOT_REGULAR];
@@ -184,9 +233,22 @@ void CustomFontManager::registerWithRenderer(GfxRenderer& renderer) {
       continue;
     }
 
-    auto* font = new bdf::CustomFont();
-    if (!font->open(bdfPath, regIdxPath.c_str(), regEntry.sizePt, kCustomFontCacheSlots)) {
-      LOG_INF(kModule, "open failed for %s", regEntry.filename.c_str());
+    const size_t familyCacheSlots = kCustomFontCacheSlots;
+
+    const size_t largestFree = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+    if (largestFree < kHeapFloorForNextFamilyBytes) {
+      LOG_INF(kModule, "skip register: heap floor reached (largest=%u B) at %s",
+              static_cast<unsigned>(largestFree), regEntry.filename.c_str());
+      continue;
+    }
+
+    auto* font = new (std::nothrow) bdf::CustomFont();
+    if (font == nullptr) {
+      LOG_INF(kModule, "alloc CustomFont failed for %s", regEntry.filename.c_str());
+      continue;
+    }
+    if (!font->open(bdfPath, regIdxPath.c_str(), regEntry.sizePt, familyCacheSlots)) {
+      LOG_INF(kModule, "open failed for %s (heap pressure or IO)", regEntry.filename.c_str());
       delete font;
       continue;
     }
@@ -202,7 +264,7 @@ void CustomFontManager::registerWithRenderer(GfxRenderer& renderer) {
         LOG_INF(kModule, "variant %s present but .idx missing: %s", kSlotNames[slot], ve.filename.c_str());
         continue;
       }
-      if (!font->openVariant(slot, vBdfPath, vIdxPath.c_str(), kCustomFontCacheSlots)) {
+      if (!font->openVariant(slot, vBdfPath, vIdxPath.c_str(), familyCacheSlots)) {
         LOG_INF(kModule, "variant %s open failed: %s", kSlotNames[slot], ve.filename.c_str());
         continue;
       }
@@ -218,6 +280,20 @@ void CustomFontManager::registerWithRenderer(GfxRenderer& renderer) {
             font->hasVariant(bdf::CustomFont::SLOT_BOLD_ITALIC) ? "Z" : "-");
     renderer.insertCustomFont(fontId, font);
   }
+}
+
+void CustomFontManager::trimAllCaches(GfxRenderer& renderer) {
+  size_t trimmed = 0;
+  for (const auto& g : families_) {
+    const int fontId = idForFamily(g.fontName, g.sizePt);
+    if (auto* font = renderer.findCustomFont(fontId)) {
+      font->trimCache(1);
+      ++trimmed;
+    }
+  }
+  LOG_INF(kModule, "trimmed %u custom font caches (largest free now=%u B)",
+          static_cast<unsigned>(trimmed),
+          static_cast<unsigned>(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT)));
 }
 
 void CustomFontManager::scanAndQueuePrompts() {

--- a/src/fonts/CustomFontManager.h
+++ b/src/fonts/CustomFontManager.h
@@ -76,6 +76,13 @@ bool hasPendingPrompt() const { return !pendingPromptIdx_.empty(); }
   // also after an install-button-triggered build completes.
   void registerWithRenderer(GfxRenderer& renderer);
 
+  // Shrink every registered CustomFont's glyph cache to the minimum size,
+  // freeing each slab so a single large contiguous allocation (epub section
+  // ZIP dict = 32 KB) can succeed. Used by EpubReaderActivity before
+  // createSectionFile to avoid the "REBOOT DEVICE" OOM screen when custom
+  // fonts are fragmenting the heap. Caches rebuild lazily on next render.
+  void trimAllCaches(GfxRenderer& renderer);
+
   // Delete every BDF + IDX file belonging to `fontName` from /custom-font/
   // and drop the font from the renderer. Re-scans the directory to rebuild
   // entries_/families_. Returns the number of files removed.


### PR DESCRIPTION
## Summary

Stress test with 113 BDF files on `/custom-font/` exposed multiple OOM / fragmentation paths in the Phase 2b custom-font architecture:

- **Boot-loop:** scanning + registering ~15 families at 384-slot cache each exhausted the ~180 KB heap inside `allocSlab_` → `std::bad_alloc` → `std::terminate` → abort → reboot. Device would not boot without removing `/custom-font/` from SD.
- **Book-open OOM:** even when boot survived, opening a book triggered the "REBOOT DEVICE — small memory wrinkle" screen because the epub section ZIP dictionary (32 KB contiguous) could not coalesce past the registered font slabs.
- **Silent no-text:** after tightening caches, `setCacheCap(1)` tripped a heap-margin check and `close()`d the font, leaving books with a chosen custom font blank.
- **Per-book theme crashes:** a book with a ReadingTheme that overrode `SETTINGS.customFontName` aborted with "Font %d not found" spam followed by a terminate.

## What changed

Single-active-font architecture in the renderer:
- Only the currently-selected `(customFontName, customFontSizePt)` family is live in `GfxRenderer::customFontMap`.
- Re-register triggers: reader-settings font family change, reader-settings font size change, and at book open (catches per-book ReadingTheme overrides that don't go through the settings UI).
- Scan cap raised 50 → 250 so families beyond the 50th file are scannable.
- Cache slots: 384 → 32 (active) / 4 (intended-inactive; currently unused because only one family registers).

Memory-release correctness in `CustomFontGlyphSource`:
- `allocSlab_` / `clearSlab_` now use the swap-with-empty idiom so shrinking the cache actually releases the heap block (`std::vector::clear` + `assign(smaller)` does not reduce capacity — this was a latent bug masking as "trim doesn't free anything").
- Safety-margin check only applies for large slabs; `trimCache(1)` always succeeds so fonts never silently close.

Crash-path hardening:
- `new (std::nothrow)` + null-check for `CustomFont` allocation.
- `setCacheCap` propagates allocation failure as `bool`.
- `trimAllCaches(renderer)` called before `Section::createSectionFile` so the ZIP dict has room.

## Verified on device

- Boot no longer loops with 113 BDFs in `/custom-font/`.
- Installing fonts (including Unifont at 57k glyphs) does not destabilise boot.
- Books open with a custom font active — text renders correctly.

## Not fixed / follow-up work

This PR stops the crashes but the UX is still poor, and the architecture needs a proper rework. A book with a custom font:
- renders slowly (seconds per page turn; inputs feel unresponsive for the first few pages while the 32-slot cache warms up)
- reads from SD on every cache miss — worst case is every glyph on the first page

**Known follow-ups (tracked here for context; not in this PR):**

1. **Lazy variant loading.** Bold / italic / bold-italic variants are opened eagerly at register time even when the current paragraph is pure regular. They should open on first use.
2. **Cache sizing per-font.** 32 slots is an arbitrary global — small-bbx fonts could afford 128; giant display fonts (e.g. Noto 32pt @ bbx 112×46) hit a 20 KB slab at 32 slots and still thrash. Size from target slab budget, not slot count.
3. **Prewarm common glyphs at book open.** ASCII + Latin-1 supplement = ~192 codepoints. A one-shot prewarm pass during the section-build progress bar would eliminate the slow-first-page pattern entirely.
4. **Variant cache consolidation.** Today each variant has its own slab; regular and italic of the same family often share 70%+ codepoints. A shared arena keyed on `(cp, variant)` would cut per-family memory roughly in half.
5. **Scan-cap policy.** 250 was a round number. Should be heap-budget-derived, or we should scan in one pass and register lazily (see #7).
6. **Fragmentation-aware heap guard.** `kHeapFloorForNextFamilyBytes` is a static 56 KB. A smarter guard would track `heap_caps_get_largest_free_block` + allocation pattern so we fail early when a font *would* register but later cause a book to fail.
7. **Lazy registration.** Move registration fully on-demand — when the renderer encounters an unregistered font id, resolve and register right there, evicting the previous active. Avoids the per-setting-change plumbing (reader-settings and onEnter) and makes per-book themes work without an explicit hook.
8. **Decode-path zero-copy.** `decodeBitmap` writes into the slab; renderer stamps per pixel. A scan-line path (8 pixels per byte, direct framebuffer write) would halve CPU on page draw.
9. **Install flow UX.** Installing Unifont takes ~6 min on device. Either index on host and ship `.idx`, or block the UI properly with progress instead of a "Do not reboot" screen.
10. **Boot loop self-recovery.** When panic info is detected on SD with "abort in CFONT registration", skip the custom-font scan on the next boot automatically so the user doesn't have to pull the SD card.

## Test plan

- [ ] Boot clean SD, add 5–10 BDF families, install each via picker.
- [ ] Verify boot is stable with >50 BDFs in `/custom-font/`.
- [ ] Pick a custom font in Reader Settings → open a new book → first pages render (slowly, expected).
- [ ] Open a book that has a saved ReadingTheme with a custom font → does not crash.
- [ ] Change custom font size in Reader Settings while a book is open → next page renders with the new size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)