### PR TITLE
refactor(fonts): custom-font architecture v2 — perf + UX overhaul

### DIFF
--- a/src/fonts/CustomFontManager.h
+++ b/src/fonts/CustomFontManager.h
@@ -41,7 +41,11 @@ struct CustomFontFamilyGroup {
 // state.json seenCustomFonts / skippedCustomFonts).
 //
 // Phase 1: prompt only — "Install" logs + marks seen, no glyph extraction.
-// Phase 2 will hang real install + render integration off the same entries.
+// Phase 2: real install + render integration + single-active registration
+// (PR #69).
+// Phase 3 (in progress): architecture + performance refactor — see the
+// v2 PR for the roadmap (lazy variant loading, per-font cache sizing,
+// prewarm, zero-copy decode, etc.).
 class CustomFontManager {
  public:
   static CustomFontManager& instance();


### PR DESCRIPTION
> **Status: draft / planning.** Nothing functional here yet — this PR is the tracking surface for the Phase 3 rework. Commits will land against this branch as each item is tackled. Split into a stack of merged PRs once items are scoped.

## Why this exists

[#69](https://github.com/diogo7dias/crosspoint-reader-DX34/pull/69) stopped the crashes, but the resulting experience is poor:

- Opening a book with a custom font takes seconds per page turn for the first few pages while the 32-slot cache warms up.
- Inputs feel unresponsive during first-page layout.
- Every cache miss is an SD read.
- Only one family is usable at a time (good for heap, bad for anything that wants a mix, e.g. a header font + body font).

The underlying issue is that Phase 2 was designed when the user had 1–2 families. At 15–20 families scanned, the single-arena-per-variant model breaks down on a 192 KB ESP32-C3 heap.

## Goals

1. Custom fonts feel as fast as built-in fonts for the common case (ASCII + Latin-1).
2. No boot-loops, no book-open OOM, no "REBOOT DEVICE" screen — even at 100+ BDFs on SD.
3. Architecture is obvious — one person should be able to read `CustomFontManager` + `CustomFontGlyphSource` and understand the lifecycle without grepping.

## Roadmap (from PR #69's follow-up list)

- [ ] **Lazy variant loading.** Don't open bold/italic/bolditalic until first use. Saves ~40 KB per family at register time.
- [ ] **Per-font cache sizing.** Replace `kCustomFontCacheSlots = 32` with a byte-budget (e.g. 16 KB per variant). Small-bbx fonts get more slots, giant fonts get fewer. No more 20 KB slabs on a 12 KB device-font.
- [ ] **Prewarm common glyphs at book open.** ASCII + Latin-1 supplement (~192 codepoints) during the section-build progress bar. Eliminates slow-first-page.
- [ ] **Shared glyph arena across variants.** Regular + italic of the same family share 70%+ codepoints. Keyed on `(cp, variant)`, cut per-family memory ~half.
- [ ] **Heap-budget-derived scan cap.** Today: static 250. Should derive from free heap and expected per-entry footprint.
- [ ] **Fragmentation-aware heap guard.** Track `heap_caps_get_largest_free_block` + allocation pattern; fail early when registering a font that *would* later cause `createSectionFile` to OOM.
- [ ] **Fully lazy registration.** `GfxRenderer` on unknown-font-id calls into `CustomFontManager::resolveOnDemand(id)` — evict the prior active, register the new one. Removes the per-call-site plumbing (reader-settings activity, EpubReaderActivity::onEnter).
- [ ] **Zero-copy / scan-line decode.** `decodeBitmap` → slab → per-pixel `drawPixel` wastes CPU. A row-major path that ORs 8 pixels per byte directly into the framebuffer would roughly halve draw CPU on pages.
- [ ] **Async install UX.** Installing Unifont takes ~6 min on device. Either index on host and ship `.idx` pre-built, or show proper progress instead of "Do not reboot".
- [ ] **Boot-loop self-recovery.** If `checkPanic()` detects an abort stack with `CFONT` in the backtrace or last-logs, skip the custom-font scan on the next boot. User doesn't have to pull SD.

## Non-goals (for this PR)

- Expanding the BDF parser beyond what Phase 2 handles.
- Changing how fonts are installed from the web UI (keep the existing flow).
- Multi-active rendering (two custom fonts simultaneously in one book). Possible later, not required for goal #1.

## How to use this PR

- Each roadmap item lands as a commit on this branch. When ready, squash-split into its own PR for review.
- Discussion for each item → top-level PR comment, threaded.
- When all items are merged and the branch has diverged meaningfully, convert this to "ready for review" and merge as a single squash if still preferred, or close with all the stack PRs merged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)