### PR TITLE
design(web): 5 dark-mode web UI mockup directions

### DIFF
--- a/mockups/01-crt-terminal.html
+++ b/mockups/01-crt-terminal.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>01 · CRT TERMINAL — CrossPoint</title>
+<style>
+  :root{
+    --bg:#050806;
+    --fg:#7cf09a;
+    --fg-dim:#3aa05a;
+    --accent:#c6ffb8;
+    --amber:#f1b44a;
+    --dash:#9bffb4;
+  }
+  *{box-sizing:border-box;}
+  html,body{height:100%;margin:0;}
+  body{
+    background:var(--bg);
+    color:var(--fg);
+    font-family:"VT323","IBM Plex Mono",ui-monospace,Menlo,Consolas,monospace;
+    overflow-x:hidden;
+    text-shadow:0 0 2px rgba(124,240,154,.6), 0 0 6px rgba(124,240,154,.25);
+  }
+  /* scanlines */
+  body::before{
+    content:"";position:fixed;inset:0;pointer-events:none;z-index:3;
+    background:repeating-linear-gradient(to bottom,
+      rgba(0,0,0,0) 0 2px,
+      rgba(0,0,0,.35) 2px 3px);
+    mix-blend-mode:multiply;
+  }
+  /* CRT vignette */
+  body::after{
+    content:"";position:fixed;inset:0;pointer-events:none;z-index:4;
+    background:radial-gradient(ellipse at center,transparent 55%,rgba(0,0,0,.75) 100%);
+  }
+  .pixels{position:fixed;inset:0;z-index:0;pointer-events:none;}
+  .pixels i{
+    position:absolute;width:3px;height:3px;background:var(--fg);
+    opacity:.35;animation:drift 14s linear infinite;
+  }
+  @keyframes drift{
+    0%{transform:translate(0,0);opacity:.1;}
+    50%{transform:translate(-30px,40px);opacity:.5;}
+    100%{transform:translate(0,0);opacity:.1;}
+  }
+  .wrap{position:relative;z-index:2;max-width:920px;margin:0 auto;padding:22px 22px 60px;font-size:18px;line-height:1.4;}
+  .bar{
+    display:flex;justify-content:space-between;align-items:center;
+    border:1px dashed var(--dash);padding:6px 10px;margin-bottom:18px;
+  }
+  .bar b{letter-spacing:.18em;}
+  .blink{animation:blink 1s steps(1) infinite;}
+  @keyframes blink{50%{opacity:0;}}
+  h1{
+    font-size:44px;margin:0 0 4px;letter-spacing:.04em;color:var(--accent);
+  }
+  .tag{color:var(--fg-dim);letter-spacing:.28em;font-size:14px;}
+  hr{border:none;border-top:1px dashed var(--dash);margin:14px 0;}
+  .ascii{white-space:pre;color:var(--fg-dim);font-size:14px;line-height:1.1;}
+  .panels{display:grid;grid-template-columns:1.2fr 1fr;gap:18px;margin-top:18px;}
+  .box{border:1px dashed var(--dash);padding:12px 14px;background:rgba(124,240,154,.03);}
+  .box h3{margin:0 0 8px;font-size:18px;color:var(--accent);letter-spacing:.16em;font-weight:normal;}
+  .kv{display:flex;justify-content:space-between;padding:2px 0;border-bottom:1px dashed rgba(155,255,180,.18);}
+  .kv span:first-child{color:var(--fg-dim);}
+  .kv span:last-child{color:var(--accent);}
+  .log{font-size:14px;color:var(--fg-dim);}
+  .log .ok{color:var(--accent);}
+  .log .warn{color:var(--amber);}
+  .prompt{margin-top:18px;font-size:18px;}
+  .prompt::before{content:"crosspoint@reader:~$ ";color:var(--amber);}
+  nav{display:flex;gap:10px;flex-wrap:wrap;margin-top:18px;}
+  nav a{
+    color:var(--fg);text-decoration:none;padding:6px 12px;
+    border:1px dashed var(--dash);letter-spacing:.18em;font-size:14px;
+  }
+  nav a:hover{background:rgba(124,240,154,.08);}
+  .tick{font-size:13px;color:var(--fg-dim);}
+  footer{margin-top:24px;font-size:13px;color:var(--fg-dim);letter-spacing:.16em;text-align:center;}
+</style>
+</head>
+<body>
+  <div class="pixels" id="pixels"></div>
+  <div class="wrap">
+
+    <div class="bar">
+      <b>CROSSPOINT // TTY0</b>
+      <span>24 APR 2026 · 21:44:02 UTC <span class="blink">█</span></span>
+    </div>
+
+    <pre class="ascii">
+  ██████╗██████╗  ██████╗ ███████╗███████╗██████╗  ██████╗ ██╗███╗   ██╗████████╗
+ ██╔════╝██╔══██╗██╔═══██╗██╔════╝██╔════╝██╔══██╗██╔═══██╗██║████╗  ██║╚══██╔══╝
+ ██║     ██████╔╝██║   ██║███████╗███████╗██████╔╝██║   ██║██║██╔██╗ ██║   ██║
+ ██║     ██╔══██╗██║   ██║╚════██║╚════██║██╔═══╝ ██║   ██║██║██║╚██╗██║   ██║
+ ╚██████╗██║  ██║╚██████╔╝███████║███████║██║     ╚██████╔╝██║██║ ╚████║   ██║
+  ╚═════╝╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚══════╝╚═╝      ╚═════╝ ╚═╝╚═╝  ╚═══╝   ╚═╝
+                                                         R E A D E R — DX34
+    </pre>
+
+    <div class="tag">&gt; BOOT OK · SERIAL 0x8A2F4 · FW 1.4.2 · HEAP 214.8 KB FREE</div>
+
+    <nav>
+      <a href="#">[ HOME ]</a>
+      <a href="#">[ FILES ]</a>
+      <a href="#">[ SETTINGS ]</a>
+      <a href="#">[ SERIAL ]</a>
+      <a href="#">[ ABOUT ]</a>
+    </nav>
+
+    <div class="panels">
+      <div class="box">
+        <h3>◤ DEVICE STATUS</h3>
+        <div class="kv"><span>FIRMWARE</span><span>1.4.2-dx34</span></div>
+        <div class="kv"><span>WIFI</span><span>CONNECTED · -52 dBm</span></div>
+        <div class="kv"><span>SSID</span><span>crosspoint-net</span></div>
+        <div class="kv"><span>IP</span><span>192.168.1.104</span></div>
+        <div class="kv"><span>MAC</span><span>8C:AA:B5:F3:22:0E</span></div>
+        <div class="kv"><span>HEAP</span><span>214.8 / 320 KB</span></div>
+        <div class="kv"><span>UPTIME</span><span>03d 14h 22m</span></div>
+        <div class="kv"><span>BATTERY</span><span>78% ▓▓▓▓▓▓▓░░░</span></div>
+      </div>
+
+      <div class="box">
+        <h3>◤ SYSTEM LOG</h3>
+        <div class="log">
+          [21:40:11] <span class="ok">OK</span> mount /spiffs<br/>
+          [21:40:11] <span class="ok">OK</span> wifi.connect <span>crosspoint-net</span><br/>
+          [21:40:12] <span class="ok">OK</span> http server :80<br/>
+          [21:40:13] <span class="ok">OK</span> epd.init 480x800<br/>
+          [21:41:02] <span class="warn">!!</span> battery low-temp warn<br/>
+          [21:41:55] <span class="ok">OK</span> sync /library 14 files<br/>
+          [21:43:10] <span class="ok">OK</span> render page 184 ~320ms<br/>
+          [21:44:02] <span class="blink">_</span>
+        </div>
+      </div>
+    </div>
+
+    <hr/>
+
+    <div class="box">
+      <h3>◤ LIBRARY</h3>
+      <div class="log" style="columns:2;column-gap:28px;">
+        ▸ calvino_invisible_cities.epub &nbsp;<span class="tick">412 KB</span><br/>
+        ▸ murakami_wind_up_bird.epub &nbsp;<span class="tick">1.2 MB</span><br/>
+        ▸ borges_ficciones.epub &nbsp;<span class="tick">188 KB</span><br/>
+        ▸ ursula_le_guin_dispossessed.epub &nbsp;<span class="tick">602 KB</span><br/>
+        ▸ sei_shonagon_pillow.epub &nbsp;<span class="tick">221 KB</span><br/>
+        ▸ dostoevsky_brothers_k.epub &nbsp;<span class="tick">2.4 MB</span><br/>
+        ▸ yoshimoto_kitchen.epub &nbsp;<span class="tick">97 KB</span><br/>
+        ▸ kawabata_snow_country.epub &nbsp;<span class="tick">142 KB</span><br/>
+      </div>
+    </div>
+
+    <div class="prompt">list --sort=recent<span class="blink">█</span></div>
+
+    <footer>── TTY0 · READY ── 80 COL ── LOCAL ECHO ON ──</footer>
+  </div>
+
+<script>
+  const layer=document.getElementById('pixels');
+  for(let i=0;i<110;i++){
+    const s=document.createElement('i');
+    s.style.left=Math.random()*100+'%';
+    s.style.top=Math.random()*100+'%';
+    s.style.animationDuration=(8+Math.random()*14)+'s';
+    s.style.animationDelay=(-Math.random()*16)+'s';
+    if(Math.random()<.3){s.style.background='#c6ffb8';}
+    if(Math.random()<.2){s.style.width='2px';s.style.height='2px';}
+    layer.appendChild(s);
+  }
+</script>
+</body>
+</html>

--- a/mockups/02-bbs-condensed.html
+++ b/mockups/02-bbs-condensed.html
@@ -1,0 +1,329 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>02 · 掲示板 — CrossPoint</title>
+<style>
+  :root{
+    --bg:#0b0a10;
+    --panel:#121119;
+    --fg:#e6e6ee;
+    --muted:#8b8aa0;
+    --cyan:#66e7ff;
+    --magenta:#ff4fbb;
+    --amber:#ffd166;
+    --dash:#ffffff;
+  }
+  *{box-sizing:border-box;}
+  html,body{margin:0;height:100%;}
+  body{
+    background:var(--bg);
+    color:var(--fg);
+    font-family:"M PLUS 1 Code","IBM Plex Mono","Noto Sans JP",ui-monospace,monospace;
+    font-size:12px;line-height:1.45;letter-spacing:.02em;
+    overflow-x:hidden;
+  }
+  .pixels{position:fixed;inset:0;z-index:0;pointer-events:none;}
+  .pixels i{
+    position:absolute;width:2px;height:2px;background:#fff;opacity:.18;
+    animation:drift 16s linear infinite;
+  }
+  @keyframes drift{
+    0%{transform:translate(0,0);}
+    50%{transform:translate(50px,-30px);opacity:.35;}
+    100%{transform:translate(0,0);opacity:.18;}
+  }
+  .wrap{position:relative;z-index:1;max-width:1100px;margin:0 auto;padding:10px;}
+  /* top ticker */
+  .ticker{
+    border:1px dashed var(--dash);padding:4px 8px;
+    display:flex;gap:14px;align-items:center;
+    font-size:11px;color:var(--muted);white-space:nowrap;overflow:hidden;
+  }
+  .ticker b{color:var(--magenta);letter-spacing:.14em;}
+  .ticker em{color:var(--cyan);font-style:normal;}
+  /* header row */
+  .hdr{
+    margin-top:6px;
+    display:grid;grid-template-columns:220px 1fr 160px;gap:6px;
+  }
+  .hdr .logo{
+    border:1px dashed var(--dash);padding:10px 12px;
+    background:linear-gradient(180deg,rgba(255,79,187,.1),rgba(102,231,255,.06));
+  }
+  .hdr .logo .en{font-size:20px;letter-spacing:.18em;}
+  .hdr .logo .jp{font-size:11px;color:var(--muted);letter-spacing:.4em;margin-top:2px;}
+  .hdr .nav{
+    border:1px dashed var(--dash);padding:6px 8px;
+    display:flex;flex-wrap:wrap;gap:4px 10px;align-items:center;
+  }
+  .hdr .nav a{
+    color:var(--fg);text-decoration:none;font-size:11px;
+    padding:2px 6px;border:1px dashed rgba(255,255,255,.35);
+  }
+  .hdr .nav a:hover{background:rgba(102,231,255,.12);color:var(--cyan);}
+  .hdr .nav a.hot{color:var(--magenta);border-color:var(--magenta);}
+  .hdr .clock{
+    border:1px dashed var(--dash);padding:8px;text-align:center;
+  }
+  .hdr .clock .big{font-size:22px;color:var(--cyan);letter-spacing:.08em;}
+  .hdr .clock .sm{font-size:10px;color:var(--muted);letter-spacing:.3em;}
+
+  /* 3-column body */
+  .cols{
+    margin-top:6px;
+    display:grid;grid-template-columns:220px 1fr 260px;gap:6px;
+  }
+  .pane{border:1px dashed var(--dash);padding:8px;background:rgba(255,255,255,.02);}
+  .pane h3{
+    margin:0 0 6px;font-size:11px;letter-spacing:.3em;color:var(--magenta);
+    border-bottom:1px dashed rgba(255,255,255,.4);padding-bottom:4px;
+    font-weight:normal;text-transform:uppercase;
+  }
+  .pane h3 span{color:var(--muted);float:right;letter-spacing:.1em;}
+
+  /* left: vertical menu */
+  .vmenu li{list-style:none;padding:3px 4px;margin:0;border-bottom:1px dashed rgba(255,255,255,.14);display:flex;justify-content:space-between;}
+  .vmenu li a{color:var(--fg);text-decoration:none;}
+  .vmenu li a:hover{color:var(--cyan);}
+  .vmenu li .num{color:var(--muted);font-size:10px;}
+  .vmenu ul{margin:0;padding:0;}
+
+  /* center: thread list */
+  .thread{
+    display:grid;grid-template-columns:24px 1fr 70px 50px;gap:6px;
+    padding:4px 6px;border-bottom:1px dashed rgba(255,255,255,.12);
+    font-size:11px;
+  }
+  .thread .n{color:var(--muted);}
+  .thread .t a{color:var(--fg);text-decoration:none;}
+  .thread .t a:hover{color:var(--magenta);}
+  .thread .t .k{color:var(--cyan);font-size:10px;margin-left:6px;letter-spacing:.2em;}
+  .thread .r{color:var(--amber);text-align:right;}
+  .thread .d{color:var(--muted);text-align:right;font-size:10px;}
+  .hot-badge{display:inline-block;background:var(--magenta);color:#000;padding:0 3px;font-size:9px;margin-right:4px;letter-spacing:.1em;}
+  .new-badge{display:inline-block;background:var(--cyan);color:#000;padding:0 3px;font-size:9px;margin-right:4px;letter-spacing:.1em;}
+
+  /* right: status + misc */
+  .stats .row{display:flex;justify-content:space-between;padding:2px 0;border-bottom:1px dashed rgba(255,255,255,.12);font-size:11px;}
+  .stats .row span:first-child{color:var(--muted);}
+  .bar-mini{height:4px;background:rgba(255,255,255,.1);border:1px dashed rgba(255,255,255,.3);margin-top:2px;}
+  .bar-mini i{display:block;height:100%;background:var(--magenta);}
+  .kawaii{font-size:10px;color:var(--muted);letter-spacing:.2em;text-align:center;margin-top:6px;}
+
+  /* bottom marquee */
+  .marq{
+    margin-top:6px;border:1px dashed var(--dash);padding:4px 8px;
+    font-size:11px;color:var(--muted);overflow:hidden;white-space:nowrap;
+  }
+  .marq span{display:inline-block;padding-right:60px;animation:scroll 40s linear infinite;}
+  @keyframes scroll{from{transform:translateX(0);}to{transform:translateX(-50%);}}
+
+  /* condensed footer grid */
+  .fgrid{
+    margin-top:6px;
+    display:grid;grid-template-columns:repeat(6,1fr);gap:6px;
+  }
+  .fgrid .cell{
+    border:1px dashed var(--dash);padding:6px;font-size:10px;
+    display:flex;flex-direction:column;gap:2px;min-height:52px;
+  }
+  .fgrid .cell b{color:var(--cyan);letter-spacing:.18em;font-size:10px;}
+  .fgrid .cell em{color:var(--magenta);font-style:normal;font-size:14px;letter-spacing:.04em;}
+  .fgrid .cell .s{color:var(--muted);font-size:9px;letter-spacing:.16em;}
+
+  .sub{color:var(--muted);}
+  .pink{color:var(--magenta);}
+  .cyan{color:var(--cyan);}
+</style>
+</head>
+<body>
+  <div class="pixels" id="pixels"></div>
+  <div class="wrap">
+
+    <div class="ticker">
+      <b>▼ NOTICE ▼</b>
+      <em>FW 1.4.2 → 1.4.3 リリース</em>
+      <span>·</span>
+      <span>バッテリー 78% / LOW-TEMP WARN</span>
+      <span>·</span>
+      <span class="cyan">同期 14件 完了</span>
+      <span>·</span>
+      <span>SSID: crosspoint-net -52dBm</span>
+      <span>·</span>
+      <span class="pink">新着スレッド 3</span>
+    </div>
+
+    <div class="hdr">
+      <div class="logo">
+        <div class="en">CrossPoint</div>
+        <div class="jp">クロスポイント・リーダー // DX34</div>
+      </div>
+      <div class="nav">
+        <a href="#" class="hot">[HOME / ホーム]</a>
+        <a href="#">[FILES / 書庫]</a>
+        <a href="#">[SETTINGS / 設定]</a>
+        <a href="#">[UPDATE / 更新]</a>
+        <a href="#">[LOG / 記録]</a>
+        <a href="#">[WIFI / 無線]</a>
+        <a href="#">[ABOUT / 情報]</a>
+        <a href="#">[HELP / 助け]</a>
+        <a href="#">[LIB / 図書]</a>
+      </div>
+      <div class="clock">
+        <div class="big">21:44:02</div>
+        <div class="sm">2026 · 04 · 24</div>
+      </div>
+    </div>
+
+    <div class="cols">
+      <!-- LEFT -->
+      <div class="pane vmenu">
+        <h3>MENU <span>一覧</span></h3>
+        <ul>
+          <li><a>▸ device / 端末</a><span class="num">01</span></li>
+          <li><a>▸ library / 書庫</a><span class="num">142</span></li>
+          <li><a>▸ upload / 送信</a><span class="num">—</span></li>
+          <li><a>▸ convert / 変換</a><span class="num">3</span></li>
+          <li><a>▸ wifi / 無線</a><span class="num">OK</span></li>
+          <li><a>▸ display / 画面</a><span class="num">e-ink</span></li>
+          <li><a>▸ keymap / 鍵盤</a><span class="num">JIS</span></li>
+          <li><a>▸ sync / 同期</a><span class="num">auto</span></li>
+          <li><a>▸ logs / 記録</a><span class="num">214</span></li>
+          <li><a>▸ about / 情報</a><span class="num">i</span></li>
+        </ul>
+        <div class="kawaii">─── 終 ───</div>
+        <div class="kawaii">(  ᴗ_ᴗ)  待機中</div>
+      </div>
+
+      <!-- CENTER -->
+      <div class="pane">
+        <h3>LIBRARY / 書庫 <span>全 142 件</span></h3>
+        <div class="thread">
+          <div class="n">001</div>
+          <div class="t"><span class="hot-badge">HOT</span><a>invisible_cities.epub</a><span class="k">カルヴィーノ</span></div>
+          <div class="r">412 KB</div>
+          <div class="d">p.184</div>
+        </div>
+        <div class="thread">
+          <div class="n">002</div>
+          <div class="t"><span class="new-badge">NEW</span><a>wind_up_bird.epub</a><span class="k">村上春樹</span></div>
+          <div class="r">1.2 MB</div>
+          <div class="d">p.032</div>
+        </div>
+        <div class="thread">
+          <div class="n">003</div>
+          <div class="t"><a>ficciones.epub</a><span class="k">ボルヘス</span></div>
+          <div class="r">188 KB</div>
+          <div class="d">p.091</div>
+        </div>
+        <div class="thread">
+          <div class="n">004</div>
+          <div class="t"><a>dispossessed.epub</a><span class="k">ル＝グウィン</span></div>
+          <div class="r">602 KB</div>
+          <div class="d">p.212</div>
+        </div>
+        <div class="thread">
+          <div class="n">005</div>
+          <div class="t"><span class="new-badge">NEW</span><a>pillow_book.epub</a><span class="k">清少納言</span></div>
+          <div class="r">221 KB</div>
+          <div class="d">p.004</div>
+        </div>
+        <div class="thread">
+          <div class="n">006</div>
+          <div class="t"><a>brothers_k.epub</a><span class="k">ドストエフスキー</span></div>
+          <div class="r">2.4 MB</div>
+          <div class="d">p.448</div>
+        </div>
+        <div class="thread">
+          <div class="n">007</div>
+          <div class="t"><a>kitchen.epub</a><span class="k">吉本ばなな</span></div>
+          <div class="r">97 KB</div>
+          <div class="d">p.012</div>
+        </div>
+        <div class="thread">
+          <div class="n">008</div>
+          <div class="t"><a>snow_country.epub</a><span class="k">川端康成</span></div>
+          <div class="r">142 KB</div>
+          <div class="d">p.060</div>
+        </div>
+        <div class="thread">
+          <div class="n">009</div>
+          <div class="t"><span class="hot-badge">HOT</span><a>the_master_and_margarita.epub</a><span class="k">ブルガーコフ</span></div>
+          <div class="r">1.8 MB</div>
+          <div class="d">p.220</div>
+        </div>
+        <div class="thread">
+          <div class="n">010</div>
+          <div class="t"><a>earthsea.epub</a><span class="k">ル＝グウィン</span></div>
+          <div class="r">840 KB</div>
+          <div class="d">—</div>
+        </div>
+      </div>
+
+      <!-- RIGHT -->
+      <div class="pane stats">
+        <h3>STATUS <span>状態</span></h3>
+        <div class="row"><span>fw</span><span class="cyan">1.4.2-dx34</span></div>
+        <div class="row"><span>ip</span><span>192.168.1.104</span></div>
+        <div class="row"><span>mac</span><span>8C:AA:…:0E</span></div>
+        <div class="row"><span>wifi</span><span>-52 dBm</span></div>
+        <div class="row"><span>heap</span><span class="pink">214.8 KB</span></div>
+        <div class="bar-mini"><i style="width:67%"></i></div>
+        <div class="row" style="margin-top:6px;"><span>battery</span><span>78%</span></div>
+        <div class="bar-mini"><i style="width:78%;background:var(--cyan)"></i></div>
+        <div class="row" style="margin-top:6px;"><span>uptime</span><span>3d 14h</span></div>
+        <div class="row"><span>sync</span><span class="cyan">auto · 60s</span></div>
+        <div class="row"><span>display</span><span>480×800</span></div>
+        <div class="row"><span>mode</span><span>e-ink · 4bpp</span></div>
+
+        <h3 style="margin-top:10px;">RECENT <span>最近</span></h3>
+        <div style="font-size:10px;color:var(--muted);line-height:1.55;">
+          <div><span class="cyan">21:41</span> sync 14 files</div>
+          <div><span class="cyan">21:40</span> wifi.up</div>
+          <div><span class="pink">21:41</span> batt low-temp</div>
+          <div><span class="cyan">21:43</span> render 320ms</div>
+          <div><span class="cyan">21:44</span> idle</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="fgrid">
+      <div class="cell"><b>HEAP</b><em>214<span class="s">.8 KB</span></em><span class="s">FREE</span></div>
+      <div class="cell"><b>BATT</b><em>78<span class="s">%</span></em><span class="s">3.92 V</span></div>
+      <div class="cell"><b>WIFI</b><em>-52<span class="s"> dBm</span></em><span class="s">ch 6</span></div>
+      <div class="cell"><b>FILES</b><em>142</em><span class="s">/ 256</span></div>
+      <div class="cell"><b>TEMP</b><em>14°<span class="s">C</span></em><span class="s">warn</span></div>
+      <div class="cell"><b>UP</b><em>03d</em><span class="s">14h 22m</span></div>
+    </div>
+
+    <div class="marq">
+      <span>
+        ※ 管理者より ※ &nbsp; サーバ稼動中 ・ 掲示板は開放されています ・
+        新しいファームウェアが利用可能です → /update ・
+        cross-point-reader // DX34 // e-ink 480×800 ・
+        press &lt;ESC&gt; to disconnect · press &lt;TAB&gt; to cycle panes · ありがとう ・
+        ※ 管理者より ※ &nbsp; サーバ稼動中 ・ 掲示板は開放されています ・
+        新しいファームウェアが利用可能です → /update ・
+      </span>
+    </div>
+  </div>
+
+<script>
+  const layer=document.getElementById('pixels');
+  for(let i=0;i<140;i++){
+    const s=document.createElement('i');
+    s.style.left=Math.random()*100+'%';
+    s.style.top=Math.random()*100+'%';
+    s.style.animationDuration=(10+Math.random()*18)+'s';
+    s.style.animationDelay=(-Math.random()*18)+'s';
+    const r=Math.random();
+    if(r<.15){s.style.background='#ff4fbb';s.style.opacity='.4';}
+    else if(r<.3){s.style.background='#66e7ff';s.style.opacity='.4';}
+    if(Math.random()<.3){s.style.width='3px';s.style.height='3px';}
+    layer.appendChild(s);
+  }
+</script>
+</body>
+</html>

--- a/mockups/03-kr-portal.html
+++ b/mockups/03-kr-portal.html
@@ -1,0 +1,423 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>03 · 포털 — CrossPoint</title>
+<style>
+  :root{
+    --bg:#0a0c12;
+    --panel:#10131b;
+    --fg:#f0f2f8;
+    --muted:#8a92a8;
+    --accent:#ff3d3d;
+    --lime:#b4ff3a;
+    --sky:#5bd1ff;
+    --gold:#ffc24a;
+    --dash:#ffffff;
+  }
+  *{box-sizing:border-box;}
+  html,body{margin:0;height:100%;}
+  body{
+    background:var(--bg);
+    color:var(--fg);
+    font-family:"Noto Sans KR","IBM Plex Sans KR","Pretendard","Helvetica Neue",Arial,sans-serif;
+    font-size:12px;line-height:1.4;
+    overflow-x:hidden;
+  }
+  .pixels{position:fixed;inset:0;z-index:0;pointer-events:none;}
+  .pixels i{
+    position:absolute;width:2px;height:2px;background:#fff;opacity:.15;
+    animation:drift 20s linear infinite;
+  }
+  @keyframes drift{
+    0%{transform:translate(0,0);opacity:.1;}
+    50%{transform:translate(-40px,40px);opacity:.28;}
+    100%{transform:translate(0,0);opacity:.1;}
+  }
+  .wrap{position:relative;z-index:1;max-width:1180px;margin:0 auto;padding:8px;}
+
+  /* top utility bar */
+  .util{
+    display:flex;justify-content:space-between;align-items:center;
+    border-bottom:1px dashed var(--dash);padding:3px 6px;font-size:10px;
+    color:var(--muted);letter-spacing:.08em;
+  }
+  .util a{color:var(--muted);margin:0 4px;text-decoration:none;}
+  .util a:hover{color:var(--sky);}
+  .util .flags{display:flex;gap:4px;}
+  .util .flags span{padding:1px 4px;border:1px dashed rgba(255,255,255,.3);}
+
+  /* masthead */
+  .mast{
+    display:grid;grid-template-columns:300px 1fr 200px;gap:6px;padding:8px 0;
+    border-bottom:1px dashed var(--dash);
+  }
+  .mast .brand{display:flex;align-items:center;gap:10px;}
+  .mast .brand .cube{
+    width:40px;height:40px;border:1px dashed #fff;
+    background:
+      linear-gradient(45deg,var(--accent) 25%,transparent 25%) 0 0/8px 8px,
+      var(--panel);
+  }
+  .mast .brand h1{margin:0;font-size:22px;letter-spacing:.02em;font-weight:900;}
+  .mast .brand h1 em{color:var(--accent);font-style:normal;}
+  .mast .brand .ko{color:var(--muted);font-size:10px;letter-spacing:.24em;}
+  .search{
+    border:1px dashed var(--dash);display:flex;align-items:center;padding:4px;
+  }
+  .search input{
+    flex:1;background:transparent;border:none;outline:none;color:var(--fg);
+    font-family:inherit;font-size:14px;padding:6px 8px;letter-spacing:.04em;
+  }
+  .search button{
+    background:var(--accent);color:#000;border:none;padding:6px 14px;font-weight:700;
+    letter-spacing:.1em;font-family:inherit;cursor:pointer;
+  }
+  .search .hint{font-size:10px;color:var(--muted);padding:0 8px;letter-spacing:.1em;}
+  .login{
+    border:1px dashed var(--dash);padding:6px 8px;display:flex;flex-direction:column;gap:2px;
+    font-size:10px;
+  }
+  .login b{color:var(--lime);letter-spacing:.18em;}
+  .login small{color:var(--muted);letter-spacing:.12em;}
+  .login .row{display:flex;justify-content:space-between;}
+
+  /* primary nav (main categories) */
+  .pnav{
+    display:flex;flex-wrap:wrap;gap:2px;border-bottom:1px dashed var(--dash);padding:6px 0;
+  }
+  .pnav a{
+    color:var(--fg);text-decoration:none;font-size:12px;font-weight:700;
+    padding:4px 10px;letter-spacing:.04em;
+  }
+  .pnav a.on{background:var(--accent);color:#000;}
+  .pnav a:hover{color:var(--sky);}
+  .pnav a.hot::after{content:" NEW";color:var(--lime);font-size:9px;margin-left:3px;letter-spacing:.2em;}
+  .pnav a.fire::after{content:" 🔥";}
+
+  /* body grid */
+  .body{
+    margin-top:6px;
+    display:grid;grid-template-columns:240px 1fr 260px;gap:6px;
+  }
+  .panel{
+    border:1px dashed var(--dash);background:rgba(255,255,255,.02);
+  }
+  .phead{
+    display:flex;justify-content:space-between;align-items:center;
+    padding:4px 8px;border-bottom:1px dashed rgba(255,255,255,.35);
+    background:rgba(255,255,255,.04);
+  }
+  .phead h3{margin:0;font-size:11px;letter-spacing:.2em;font-weight:800;}
+  .phead .more{font-size:9px;color:var(--muted);letter-spacing:.14em;text-decoration:none;}
+  .phead .more:hover{color:var(--sky);}
+  .pbody{padding:6px 8px;}
+
+  /* left sidebar mini widgets */
+  .w{margin-bottom:6px;}
+  .w .phead h3{color:var(--sky);}
+  .shortcut{
+    display:grid;grid-template-columns:repeat(3,1fr);gap:4px;padding:6px;
+  }
+  .shortcut a{
+    border:1px dashed rgba(255,255,255,.3);text-align:center;padding:8px 2px;
+    color:var(--fg);text-decoration:none;font-size:10px;letter-spacing:.1em;
+  }
+  .shortcut a:hover{border-color:var(--lime);color:var(--lime);}
+  .shortcut a b{display:block;font-size:18px;margin-bottom:2px;}
+  .miniq{padding:6px 8px;font-size:11px;}
+  .miniq .row{display:flex;justify-content:space-between;padding:2px 0;border-bottom:1px dashed rgba(255,255,255,.1);}
+  .miniq .row span:first-child{color:var(--muted);}
+  .miniq .row span:last-child{color:var(--sky);}
+
+  /* center */
+  .banner{
+    border:1px dashed var(--dash);position:relative;overflow:hidden;
+    padding:16px;background:
+      radial-gradient(circle at 85% 50%,rgba(255,61,61,.25),transparent 60%),
+      linear-gradient(120deg,rgba(91,209,255,.08),rgba(180,255,58,.06));
+    display:grid;grid-template-columns:1fr auto;align-items:end;gap:12px;min-height:120px;
+  }
+  .banner h2{
+    margin:0;font-size:28px;line-height:1.1;letter-spacing:-.01em;
+  }
+  .banner h2 em{color:var(--lime);font-style:normal;}
+  .banner h2 strong{color:var(--accent);}
+  .banner p{color:var(--muted);font-size:11px;margin:4px 0 0;letter-spacing:.12em;}
+  .banner .cta{
+    background:var(--lime);color:#000;padding:6px 14px;font-weight:900;font-size:11px;
+    letter-spacing:.16em;border:1px dashed #000;
+  }
+
+  .hotlist{margin-top:6px;}
+  .rank{
+    display:grid;grid-template-columns:28px 1fr 60px;gap:6px;
+    padding:3px 8px;border-bottom:1px dashed rgba(255,255,255,.12);font-size:11px;
+  }
+  .rank b{color:var(--accent);font-size:11px;text-align:center;}
+  .rank:nth-child(-n+4) b{color:var(--lime);}
+  .rank a{color:var(--fg);text-decoration:none;}
+  .rank a:hover{color:var(--sky);}
+  .rank .ko{color:var(--muted);font-size:10px;margin-left:4px;letter-spacing:.08em;}
+  .rank .delta{color:var(--gold);text-align:right;font-size:10px;}
+  .rank .delta.up{color:var(--lime);}
+  .rank .delta.dn{color:var(--accent);}
+
+  /* 4-col mini panels */
+  .fourup{
+    display:grid;grid-template-columns:repeat(4,1fr);gap:6px;margin-top:6px;
+  }
+  .fourup .panel .pbody{font-size:11px;}
+  .fourup .num{font-size:22px;font-weight:900;color:var(--lime);letter-spacing:.02em;}
+  .fourup .lbl{color:var(--muted);font-size:10px;letter-spacing:.18em;text-transform:uppercase;}
+
+  /* right column */
+  .ad{
+    border:1px dashed var(--dash);padding:10px;text-align:center;
+    background:
+      repeating-linear-gradient(45deg,rgba(255,194,74,.06) 0 6px,transparent 6px 12px);
+  }
+  .ad b{color:var(--gold);letter-spacing:.24em;font-size:11px;}
+  .ad p{margin:6px 0 0;font-size:18px;font-weight:900;color:var(--fg);line-height:1.15;}
+  .ad small{color:var(--muted);font-size:10px;letter-spacing:.14em;}
+
+  .live .pbody{font-size:11px;}
+  .live .item{display:flex;gap:6px;padding:4px 0;border-bottom:1px dashed rgba(255,255,255,.12);}
+  .live .dot{width:6px;height:6px;background:var(--accent);border-radius:50%;margin-top:4px;flex:0 0 auto;animation:pulse 1.4s infinite;}
+  @keyframes pulse{50%{opacity:.3;}}
+  .live time{color:var(--muted);font-size:10px;}
+
+  .chat{padding:6px 8px;}
+  .chat .msg{font-size:11px;padding:2px 0;border-bottom:1px dashed rgba(255,255,255,.08);}
+  .chat .msg b{color:var(--sky);margin-right:4px;}
+  .chat input{
+    width:100%;background:transparent;border:1px dashed rgba(255,255,255,.35);
+    color:var(--fg);font-family:inherit;padding:4px 6px;font-size:11px;margin-top:4px;
+  }
+
+  /* footer strip */
+  .fstrip{
+    margin-top:6px;border:1px dashed var(--dash);
+    display:grid;grid-template-columns:repeat(8,1fr);font-size:10px;
+  }
+  .fstrip div{padding:6px;border-right:1px dashed rgba(255,255,255,.18);letter-spacing:.1em;}
+  .fstrip div:last-child{border-right:none;}
+  .fstrip b{display:block;color:var(--sky);font-size:9px;letter-spacing:.24em;}
+
+  .mini-cube{
+    display:inline-block;width:8px;height:8px;background:var(--accent);margin-right:4px;vertical-align:middle;
+  }
+
+  .lime{color:var(--lime);}
+  .sky{color:var(--sky);}
+  .gold{color:var(--gold);}
+  .red{color:var(--accent);}
+</style>
+</head>
+<body>
+  <div class="pixels" id="pixels"></div>
+  <div class="wrap">
+
+    <div class="util">
+      <div>
+        <a>홈 설정</a>·<a>바로가기</a>·<a>도움말</a>·<a>고객센터</a>·<a>운영정책</a>
+      </div>
+      <div class="flags">
+        <span>한국어</span><span>English</span><span>日本語</span><span>中文</span>
+        <span class="lime">LOGIN: admin</span>
+      </div>
+    </div>
+
+    <div class="mast">
+      <div class="brand">
+        <div class="cube"></div>
+        <div>
+          <h1>Cross<em>Point</em></h1>
+          <div class="ko">크로스포인트 리더 · DX34 · 포털</div>
+        </div>
+      </div>
+      <div class="search">
+        <span class="hint">검색</span>
+        <input value="device settings / 설정"/>
+        <button>SEARCH ▶</button>
+      </div>
+      <div class="login">
+        <div class="row"><b>ADMIN</b><span class="lime">● online</span></div>
+        <div class="row"><small>session</small><small>00:12:44</small></div>
+        <div class="row"><small>ip</small><small>192.168.1.104</small></div>
+      </div>
+    </div>
+
+    <div class="pnav">
+      <a class="on">홈 / HOME</a>
+      <a class="hot">서재 / LIBRARY</a>
+      <a>업로드 / UPLOAD</a>
+      <a class="fire">설정 / SETTINGS</a>
+      <a>무선 / WIFI</a>
+      <a>화면 / DISPLAY</a>
+      <a>동기화 / SYNC</a>
+      <a>로그 / LOG</a>
+      <a>정보 / ABOUT</a>
+      <a>업데이트 / UPDATE</a>
+      <a>도움말 / HELP</a>
+      <a>고객센터 / SUPPORT</a>
+    </div>
+
+    <div class="body">
+      <!-- LEFT -->
+      <div>
+        <div class="panel w">
+          <div class="phead"><h3>◆ 바로가기 / SHORTCUT</h3><a class="more">편집</a></div>
+          <div class="shortcut">
+            <a><b>📚</b>서재</a>
+            <a><b>⇪</b>업로드</a>
+            <a><b>⚙</b>설정</a>
+            <a><b>⟳</b>동기화</a>
+            <a><b>⇄</b>변환</a>
+            <a><b>◉</b>무선</a>
+          </div>
+        </div>
+
+        <div class="panel w">
+          <div class="phead"><h3>◆ 단축키 / KEYS</h3><a class="more">전체</a></div>
+          <div class="miniq">
+            <div class="row"><span>← / →</span><span>page</span></div>
+            <div class="row"><span>↑ / ↓</span><span>scroll</span></div>
+            <div class="row"><span>SPACE</span><span>next</span></div>
+            <div class="row"><span>R</span><span>refresh</span></div>
+            <div class="row"><span>F</span><span>fullscreen</span></div>
+            <div class="row"><span>ESC</span><span>close</span></div>
+          </div>
+        </div>
+
+        <div class="panel w">
+          <div class="phead"><h3>◆ 날씨 / WEATHER</h3><a class="more">서울</a></div>
+          <div class="miniq" style="text-align:center;">
+            <div style="font-size:28px;color:var(--gold);font-weight:900;">14°</div>
+            <div style="color:var(--muted);letter-spacing:.18em;">맑음 · CLEAR</div>
+            <div class="row" style="margin-top:4px;"><span>미세먼지</span><span class="lime">좋음</span></div>
+            <div class="row"><span>습도</span><span>42%</span></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- CENTER -->
+      <div>
+        <div class="banner">
+          <div>
+            <h2>펌웨어 <em>1.4.3</em> <strong>출시!</strong></h2>
+            <p>새로운 e-ink 최적화 · 배터리 수명 +18% · 버그 수정 14건</p>
+          </div>
+          <a class="cta">지금 업데이트 ▶</a>
+        </div>
+
+        <div class="panel hotlist">
+          <div class="phead"><h3>◆ 인기 / HOT READS</h3><a class="more">전체보기 →</a></div>
+          <div class="pbody" style="padding:0;">
+            <div class="rank"><b>01</b><a>invisible_cities.epub<span class="ko">보이지 않는 도시들</span></a><span class="delta up">▲ 4</span></div>
+            <div class="rank"><b>02</b><a>wind_up_bird.epub<span class="ko">태엽 감는 새</span></a><span class="delta up">▲ 2</span></div>
+            <div class="rank"><b>03</b><a>ficciones.epub<span class="ko">픽션들</span></a><span class="delta">—</span></div>
+            <div class="rank"><b>04</b><a>dispossessed.epub<span class="ko">빼앗긴 자들</span></a><span class="delta dn">▼ 1</span></div>
+            <div class="rank"><b>05</b><a>pillow_book.epub<span class="ko">베갯머리 서책</span></a><span class="delta up">▲ NEW</span></div>
+            <div class="rank"><b>06</b><a>brothers_k.epub<span class="ko">카라마조프가의 형제들</span></a><span class="delta dn">▼ 2</span></div>
+            <div class="rank"><b>07</b><a>kitchen.epub<span class="ko">키친</span></a><span class="delta">—</span></div>
+            <div class="rank"><b>08</b><a>snow_country.epub<span class="ko">설국</span></a><span class="delta up">▲ 1</span></div>
+          </div>
+        </div>
+
+        <div class="fourup">
+          <div class="panel">
+            <div class="phead"><h3>HEAP</h3><span class="lime">OK</span></div>
+            <div class="pbody"><div class="num">214<small style="font-size:11px;color:var(--muted);">.8 KB</small></div><div class="lbl">free of 320kb</div></div>
+          </div>
+          <div class="panel">
+            <div class="phead"><h3>BATT</h3><span class="lime">OK</span></div>
+            <div class="pbody"><div class="num">78<small style="font-size:11px;color:var(--muted);">%</small></div><div class="lbl">3.92 V · cable</div></div>
+          </div>
+          <div class="panel">
+            <div class="phead"><h3>WIFI</h3><span class="sky">STRONG</span></div>
+            <div class="pbody"><div class="num">−52<small style="font-size:11px;color:var(--muted);">dBm</small></div><div class="lbl">crosspoint-net ch6</div></div>
+          </div>
+          <div class="panel">
+            <div class="phead"><h3>FILES</h3><span class="gold">NEW 3</span></div>
+            <div class="pbody"><div class="num">142</div><div class="lbl">of 256 · 12.4 MB</div></div>
+          </div>
+        </div>
+
+        <div class="panel" style="margin-top:6px;">
+          <div class="phead"><h3>◆ 공지 / NOTICE BOARD</h3><a class="more">더보기</a></div>
+          <div class="pbody" style="padding:0;">
+            <div class="rank"><b class="red">공지</b><a>FW 1.4.3 릴리즈 — 2026.04.24 점검 공지</a><span class="delta">방금</span></div>
+            <div class="rank"><b class="red">공지</b><a>저온 배터리 보호 모드 적용 안내</a><span class="delta">1h</span></div>
+            <div class="rank"><b>005</b><a>서재 정렬 옵션 추가됨 (날짜/크기)</a><span class="delta">3h</span></div>
+            <div class="rank"><b>004</b><a>키맵 JIS/ANSI 토글 안정화</a><span class="delta">어제</span></div>
+            <div class="rank"><b>003</b><a>SPIFFS → LittleFS 마이그레이션 메모</a><span class="delta">2d</span></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- RIGHT -->
+      <div>
+        <div class="ad">
+          <b>★ 광고 / AD ★</b>
+          <p>한정판 <span class="red">e-ink 케이스</span><br/>지금 <span class="lime">30% OFF</span></p>
+          <small>crosspoint.store</small>
+        </div>
+
+        <div class="panel live" style="margin-top:6px;">
+          <div class="phead"><h3>◆ 실시간 / LIVE</h3><span class="red">● REC</span></div>
+          <div class="pbody">
+            <div class="item"><div class="dot"></div><div><time>21:44:02</time><br/>idle · heap 214.8 KB</div></div>
+            <div class="item"><div class="dot"></div><div><time>21:43:10</time><br/>render page 184 · 320 ms</div></div>
+            <div class="item"><div class="dot"></div><div><time>21:41:55</time><br/>sync /library 14 files</div></div>
+            <div class="item"><div class="dot"></div><div><time>21:41:02</time><br/><span class="gold">warn</span> battery low-temp</div></div>
+            <div class="item"><div class="dot"></div><div><time>21:40:12</time><br/>http :80 listen</div></div>
+            <div class="item"><div class="dot"></div><div><time>21:40:11</time><br/>wifi.up crosspoint-net</div></div>
+          </div>
+        </div>
+
+        <div class="panel" style="margin-top:6px;">
+          <div class="phead"><h3>◆ 채팅 / CHAT</h3><span class="sky">4 online</span></div>
+          <div class="chat">
+            <div class="msg"><b>admin:</b> 펌업 테스트 진행 중</div>
+            <div class="msg"><b>dx34:</b> e-ink refresh 안정적</div>
+            <div class="msg"><b>reader01:</b> 키맵 JIS 적용 확인</div>
+            <div class="msg"><b>admin:</b> ok 머지합니다 ✓</div>
+            <input placeholder="메시지 입력 / type a message…"/>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="fstrip">
+      <div><b>FW</b>1.4.2-dx34</div>
+      <div><b>IP</b>192.168.1.104</div>
+      <div><b>MAC</b>8C:AA:B5:…:0E</div>
+      <div><b>UPTIME</b>03d 14h 22m</div>
+      <div><b>HEAP</b>214.8 / 320 KB</div>
+      <div><b>BATT</b>78% · 3.92V</div>
+      <div><b>DISPLAY</b>480×800 · 4bpp</div>
+      <div><b>© 2026</b>CrossPoint · open-source</div>
+    </div>
+
+  </div>
+
+<script>
+  const layer=document.getElementById('pixels');
+  for(let i=0;i<160;i++){
+    const s=document.createElement('i');
+    s.style.left=Math.random()*100+'%';
+    s.style.top=Math.random()*100+'%';
+    s.style.animationDuration=(12+Math.random()*20)+'s';
+    s.style.animationDelay=(-Math.random()*20)+'s';
+    const r=Math.random();
+    if(r<.1){s.style.background='#ff3d3d';s.style.opacity='.35';}
+    else if(r<.2){s.style.background='#b4ff3a';s.style.opacity='.35';}
+    else if(r<.3){s.style.background='#5bd1ff';s.style.opacity='.35';}
+    if(Math.random()<.3){s.style.width='3px';s.style.height='3px';}
+    layer.appendChild(s);
+  }
+</script>
+</body>
+</html>

--- a/mockups/04-vaporwave-grid.html
+++ b/mockups/04-vaporwave-grid.html
@@ -1,0 +1,304 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>04 · VAPOR GRID — CrossPoint</title>
+<style>
+  :root{
+    --bg:#06030e;
+    --fg:#f1eaff;
+    --muted:#9590b8;
+    --mag:#ff3ea5;
+    --cyan:#3ef3ff;
+    --amber:#ffd46b;
+    --violet:#9b5dff;
+    --dash:#ffffff;
+  }
+  *{box-sizing:border-box;}
+  html,body{margin:0;height:100%;}
+  body{
+    background:
+      radial-gradient(ellipse at 20% 0%,rgba(155,93,255,.22),transparent 60%),
+      radial-gradient(ellipse at 100% 100%,rgba(62,243,255,.18),transparent 55%),
+      radial-gradient(ellipse at 70% 20%,rgba(255,62,165,.18),transparent 50%),
+      var(--bg);
+    color:var(--fg);
+    font-family:"Space Grotesk","Inter",ui-sans-serif,system-ui,sans-serif;
+    overflow-x:hidden;
+  }
+  /* horizon grid */
+  body::before{
+    content:"";position:fixed;left:0;right:0;bottom:0;height:55%;
+    pointer-events:none;z-index:0;
+    background:
+      linear-gradient(to top,rgba(255,62,165,.35),transparent 70%),
+      repeating-linear-gradient(to right,transparent 0 40px,rgba(62,243,255,.3) 40px 41px),
+      repeating-linear-gradient(to bottom,transparent 0 40px,rgba(62,243,255,.3) 40px 41px);
+    transform:perspective(800px) rotateX(60deg);
+    transform-origin:center top;
+    mask-image:linear-gradient(to top,#000 30%,transparent 100%);
+  }
+  /* drifting pixel squares — BIG + small mix */
+  .pixels{position:fixed;inset:0;z-index:1;pointer-events:none;}
+  .pixels i{
+    position:absolute;width:4px;height:4px;background:#fff;opacity:.5;
+    animation:drift 12s linear infinite;
+  }
+  @keyframes drift{
+    0%{transform:translate(0,0) scale(1);opacity:.2;}
+    50%{transform:translate(60px,-80px) scale(1.3);opacity:.8;}
+    100%{transform:translate(0,0) scale(1);opacity:.2;}
+  }
+  .wrap{position:relative;z-index:2;max-width:1080px;margin:0 auto;padding:32px 28px 80px;}
+  /* header */
+  .topline{display:flex;justify-content:space-between;font-size:11px;color:var(--muted);letter-spacing:.3em;text-transform:uppercase;border-bottom:1px dashed var(--dash);padding-bottom:10px;}
+  .topline em{font-style:normal;color:var(--mag);}
+  .hero{
+    margin:36px 0 32px;position:relative;
+    display:grid;grid-template-columns:1fr auto;align-items:end;gap:24px;
+  }
+  .hero h1{
+    font-family:"Space Mono","IBM Plex Mono",ui-monospace,monospace;
+    font-size:88px;line-height:.9;margin:0;letter-spacing:-.03em;font-weight:700;
+    background:linear-gradient(100deg,var(--mag),var(--violet),var(--cyan));
+    -webkit-background-clip:text;background-clip:text;color:transparent;
+  }
+  .hero h1 small{
+    display:block;font-size:14px;font-weight:400;margin-top:10px;
+    color:var(--muted);letter-spacing:.4em;-webkit-text-fill-color:var(--muted);
+  }
+  .hero .jp{
+    font-family:"Shippori Mincho","Noto Serif JP",serif;
+    font-size:60px;color:var(--cyan);line-height:.95;
+    text-shadow:0 0 16px rgba(62,243,255,.4);
+    writing-mode:vertical-rl;letter-spacing:.2em;
+    border:1px dashed var(--dash);padding:18px 12px;
+  }
+  .hero .jp small{display:block;font-size:11px;color:var(--muted);font-family:inherit;letter-spacing:.3em;margin-top:8px;}
+
+  .tagline{
+    margin:4px 0 0;font-size:14px;color:#e7dcff;max-width:560px;letter-spacing:.04em;
+    border-left:1px dashed var(--dash);padding:6px 0 6px 14px;
+  }
+
+  /* big pixel blocks — decorative */
+  .blocks{position:absolute;right:0;top:-12px;display:grid;grid-template-columns:repeat(4,14px);grid-auto-rows:14px;gap:3px;opacity:.7;}
+  .blocks i{background:var(--mag);display:block;}
+  .blocks i:nth-child(3n){background:var(--cyan);}
+  .blocks i:nth-child(5n){background:var(--amber);}
+  .blocks i:nth-child(7n){background:var(--violet);}
+
+  /* system module */
+  .sys{
+    display:grid;grid-template-columns:1.3fr 1fr;gap:16px;margin-bottom:16px;
+  }
+  .card{
+    border:1px dashed var(--dash);
+    background:rgba(16,10,34,.55);
+    backdrop-filter:blur(6px);
+    padding:18px;
+  }
+  .card h3{
+    margin:0 0 12px;font-size:11px;letter-spacing:.32em;color:var(--cyan);
+    text-transform:uppercase;font-weight:600;
+    display:flex;justify-content:space-between;align-items:baseline;
+  }
+  .card h3 .jp-small{font-family:"Shippori Mincho",serif;color:var(--mag);letter-spacing:.16em;font-size:12px;}
+  .kv{
+    display:grid;grid-template-columns:130px 1fr auto;gap:10px;
+    padding:7px 0;border-bottom:1px dashed rgba(255,255,255,.12);font-size:13px;
+  }
+  .kv b{color:var(--muted);font-weight:500;letter-spacing:.18em;font-size:11px;text-transform:uppercase;}
+  .kv em{font-style:normal;font-family:"Space Mono",ui-monospace,monospace;color:var(--fg);}
+  .kv span.ok{color:var(--cyan);font-size:11px;letter-spacing:.2em;}
+  .kv span.warn{color:var(--amber);font-size:11px;letter-spacing:.2em;}
+
+  /* mini pixel bar */
+  .bar{display:flex;gap:2px;align-items:center;}
+  .bar i{display:inline-block;width:10px;height:10px;background:var(--cyan);opacity:.9;}
+  .bar i.off{background:rgba(255,255,255,.12);}
+
+  /* library strip */
+  .strip{
+    margin-top:10px;display:grid;grid-template-columns:repeat(6,1fr);gap:10px;
+  }
+  .book{
+    border:1px dashed var(--dash);padding:10px;background:rgba(255,255,255,.03);
+    min-height:130px;display:flex;flex-direction:column;justify-content:space-between;
+  }
+  .book .cov{
+    height:60px;
+    background:
+      repeating-linear-gradient(45deg,var(--mag) 0 4px,var(--violet) 4px 8px);
+    border:1px dashed rgba(255,255,255,.3);
+    position:relative;overflow:hidden;
+  }
+  .book:nth-child(2) .cov{background:repeating-linear-gradient(45deg,var(--cyan) 0 4px,#0b6680 4px 8px);}
+  .book:nth-child(3) .cov{background:repeating-linear-gradient(90deg,var(--amber) 0 4px,#6b4a00 4px 8px);}
+  .book:nth-child(4) .cov{background:repeating-linear-gradient(135deg,var(--violet) 0 4px,#2a005e 4px 8px);}
+  .book:nth-child(5) .cov{background:repeating-linear-gradient(0deg,var(--mag) 0 4px,#5a0030 4px 8px);}
+  .book:nth-child(6) .cov{background:repeating-linear-gradient(45deg,var(--cyan) 0 4px,var(--mag) 4px 8px);}
+  .book b{font-size:11px;margin-top:8px;letter-spacing:.04em;display:block;}
+  .book small{color:var(--muted);font-size:10px;letter-spacing:.14em;}
+
+  /* actions */
+  .actions{margin-top:16px;display:flex;flex-wrap:wrap;gap:8px;}
+  .btn{
+    border:1px dashed var(--dash);padding:10px 14px;font-size:11px;
+    letter-spacing:.24em;text-transform:uppercase;color:var(--fg);
+    background:rgba(255,255,255,.02);cursor:pointer;font-family:inherit;
+  }
+  .btn:hover{background:rgba(62,243,255,.1);color:var(--cyan);}
+  .btn.mag{color:var(--mag);border-color:var(--mag);}
+  .btn.cya{color:var(--cyan);border-color:var(--cyan);}
+  .btn.amb{color:var(--amber);border-color:var(--amber);}
+
+  /* nav pill */
+  .nav{
+    margin-top:22px;display:flex;flex-wrap:wrap;gap:6px;align-items:center;
+    border-top:1px dashed var(--dash);padding-top:14px;
+  }
+  .nav a{
+    color:var(--fg);text-decoration:none;font-size:11px;
+    letter-spacing:.22em;text-transform:uppercase;padding:6px 12px;
+    border:1px dashed rgba(255,255,255,.4);
+  }
+  .nav a:hover{border-color:var(--mag);color:var(--mag);}
+  .nav a.current{background:var(--mag);color:#000;border-color:#000;}
+
+  footer{
+    margin-top:40px;font-size:10px;color:var(--muted);letter-spacing:.32em;
+    display:flex;justify-content:space-between;border-top:1px dashed var(--dash);padding-top:14px;
+  }
+  .hira{font-family:"Shippori Mincho",serif;color:var(--cyan);letter-spacing:.4em;font-size:14px;}
+
+  .big-pixel{
+    width:18px;height:18px;display:inline-block;background:var(--mag);margin-right:8px;vertical-align:middle;
+  }
+</style>
+</head>
+<body>
+  <div class="pixels" id="pixels"></div>
+  <div class="wrap">
+
+    <div class="topline">
+      <div><em>CROSSPOINT</em> ⟡ READER ⟡ DX34</div>
+      <div>04.24.2026 · <span class="hira">夕方</span> · 21:44</div>
+    </div>
+
+    <div class="hero">
+      <div>
+        <h1>cross<br/>point<small>— 接 続 点 —</small></h1>
+        <p class="tagline">A small, open-source e-ink reader with a web interface you actually enjoy opening. Upload books, tune the font, and watch the horizon from your couch.</p>
+      </div>
+      <div class="jp">非同期 図書<small>ASYNC LIBRARY</small></div>
+      <div class="blocks" id="bx"></div>
+    </div>
+
+    <div class="nav">
+      <a class="current"><span class="big-pixel"></span>HOME</a>
+      <a>LIBRARY</a>
+      <a>UPLOAD</a>
+      <a>SETTINGS</a>
+      <a>WIFI</a>
+      <a>DISPLAY</a>
+      <a>SYNC</a>
+      <a>LOG</a>
+      <a>ABOUT</a>
+    </div>
+
+    <section class="sys" style="margin-top:22px;">
+      <div class="card">
+        <h3>◐ SYSTEM <span class="jp-small">状態 STATUS</span></h3>
+        <div class="kv"><b>firmware</b><em>1.4.2-dx34</em><span class="ok">● ACTIVE</span></div>
+        <div class="kv"><b>wifi</b><em>crosspoint-net</em><span class="ok">−52 dBm</span></div>
+        <div class="kv"><b>ip address</b><em>192.168.1.104</em><span class="ok">LAN</span></div>
+        <div class="kv"><b>heap free</b><em>214.8 / 320 KB</em>
+          <span class="bar">
+            <i></i><i></i><i></i><i></i><i></i><i></i><i class="off"></i><i class="off"></i><i class="off"></i><i class="off"></i>
+          </span>
+        </div>
+        <div class="kv"><b>battery</b><em>78% · 3.92 V</em>
+          <span class="bar">
+            <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i class="off"></i><i class="off"></i><i class="off"></i>
+          </span>
+        </div>
+        <div class="kv"><b>uptime</b><em>03d 14h 22m</em><span class="ok">STABLE</span></div>
+        <div class="kv"><b>temperature</b><em>14° C</em><span class="warn">⚠ LOW</span></div>
+        <div class="kv" style="border-bottom:none;"><b>display</b><em>e-ink 480 × 800 · 4bpp</em><span class="ok">READY</span></div>
+      </div>
+
+      <div class="card">
+        <h3>◑ NOW READING <span class="jp-small">読書中</span></h3>
+        <div style="display:flex;gap:12px;">
+          <div style="width:110px;height:150px;border:1px dashed var(--dash);background:repeating-linear-gradient(45deg,var(--cyan) 0 6px,var(--violet) 6px 12px);position:relative;flex:0 0 auto;">
+            <div style="position:absolute;bottom:6px;left:6px;right:6px;font-family:'Space Mono',monospace;font-size:10px;background:#000;padding:3px 5px;letter-spacing:.1em;">invisible_cities</div>
+          </div>
+          <div style="flex:1;">
+            <div style="font-family:'Shippori Mincho',serif;font-size:20px;color:var(--cyan);letter-spacing:.08em;">見えない都市</div>
+            <div style="margin-top:4px;font-size:18px;font-weight:600;">Invisible Cities</div>
+            <div style="color:var(--muted);font-size:12px;letter-spacing:.12em;margin-top:2px;">ITALO CALVINO · 412 KB</div>
+            <div style="margin-top:12px;font-size:11px;color:var(--muted);letter-spacing:.18em;">PROGRESS</div>
+            <div style="height:8px;border:1px dashed var(--dash);margin-top:4px;display:flex;">
+              <div style="width:62%;background:linear-gradient(90deg,var(--mag),var(--violet),var(--cyan));"></div>
+            </div>
+            <div style="display:flex;justify-content:space-between;font-family:'Space Mono',monospace;font-size:11px;margin-top:4px;color:var(--muted);">
+              <span>p. 184</span><span>62%</span><span>p. 298</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="actions">
+          <button class="btn cya">▶ RESUME</button>
+          <button class="btn mag">⇪ UPLOAD</button>
+          <button class="btn amb">⚙ SETTINGS</button>
+          <button class="btn">⟳ SYNC</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>◈ LIBRARY <span class="jp-small">書庫 · 142 ITEMS</span></h3>
+      <div class="strip">
+        <div class="book"><div class="cov"></div><b>Invisible Cities</b><small>CALVINO · 412 KB</small></div>
+        <div class="book"><div class="cov"></div><b>Wind-Up Bird</b><small>MURAKAMI · 1.2 MB</small></div>
+        <div class="book"><div class="cov"></div><b>Ficciones</b><small>BORGES · 188 KB</small></div>
+        <div class="book"><div class="cov"></div><b>Dispossessed</b><small>LE GUIN · 602 KB</small></div>
+        <div class="book"><div class="cov"></div><b>Pillow Book</b><small>SEI SHŌNAGON · 221 KB</small></div>
+        <div class="book"><div class="cov"></div><b>Kitchen</b><small>YOSHIMOTO · 97 KB</small></div>
+      </div>
+    </section>
+
+    <footer>
+      <span>◢ WEB UI · v0.MOCK</span>
+      <span class="hira">ク ロ ス ポ イ ン ト</span>
+      <span>OPEN-SOURCE · MIT</span>
+    </footer>
+  </div>
+
+<script>
+  const layer=document.getElementById('pixels');
+  for(let i=0;i<120;i++){
+    const s=document.createElement('i');
+    s.style.left=Math.random()*100+'%';
+    s.style.top=Math.random()*100+'%';
+    s.style.animationDuration=(9+Math.random()*15)+'s';
+    s.style.animationDelay=(-Math.random()*18)+'s';
+    const r=Math.random();
+    if(r<.25){s.style.background='#ff3ea5';}
+    else if(r<.5){s.style.background='#3ef3ff';}
+    else if(r<.65){s.style.background='#ffd46b';}
+    const sz=1+Math.floor(Math.random()*4);
+    s.style.width=(sz*2)+'px';s.style.height=(sz*2)+'px';
+    layer.appendChild(s);
+  }
+  const bx=document.getElementById('bx');
+  for(let i=0;i<40;i++){
+    const b=document.createElement('i');
+    if(Math.random()<.3) b.style.background='transparent';
+    bx.appendChild(b);
+  }
+</script>
+</body>
+</html>

--- a/mockups/05-brutalist-8bit.html
+++ b/mockups/05-brutalist-8bit.html
@@ -1,0 +1,402 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>05 · BRUTALIST 8-BIT — CrossPoint</title>
+<style>
+  :root{
+    --bg:#0d0d10;
+    --fg:#f4f4f4;
+    --muted:#9a9aa0;
+    --red:#ff2e3c;
+    --yellow:#ffe14a;
+    --green:#3cff8f;
+    --blue:#4dc0ff;
+    --dash:#ffffff;
+  }
+  *{box-sizing:border-box;}
+  html,body{margin:0;height:100%;}
+  body{
+    background:var(--bg);
+    color:var(--fg);
+    font-family:"Space Mono","JetBrains Mono",ui-monospace,Menlo,Consolas,monospace;
+    overflow-x:hidden;
+    image-rendering:pixelated;
+  }
+  /* overlay grid */
+  body::before{
+    content:"";position:fixed;inset:0;pointer-events:none;z-index:0;
+    background:
+      linear-gradient(to right,rgba(255,255,255,.04) 1px,transparent 1px) 0 0/48px 48px,
+      linear-gradient(to bottom,rgba(255,255,255,.04) 1px,transparent 1px) 0 0/48px 48px;
+  }
+  .pixels{position:fixed;inset:0;z-index:1;pointer-events:none;}
+  .pixels i{
+    position:absolute;width:6px;height:6px;background:#fff;opacity:.16;
+    animation:march 8s steps(20) infinite;
+  }
+  @keyframes march{
+    0%{transform:translate(0,0);}
+    100%{transform:translate(60px,-80px);opacity:.04;}
+  }
+  .wrap{position:relative;z-index:2;max-width:1200px;margin:0 auto;padding:24px;}
+
+  /* masthead: oversized logo + status chips */
+  .mast{
+    border:1px dashed var(--dash);padding:18px;
+    display:grid;grid-template-columns:1fr 1fr;gap:0;
+  }
+  .mast .lt{border-right:1px dashed var(--dash);padding-right:18px;}
+  .mast .rt{padding-left:18px;display:flex;flex-direction:column;justify-content:space-between;}
+  .mast h1{
+    margin:0;font-size:78px;line-height:.88;letter-spacing:-.04em;font-weight:700;
+    text-transform:uppercase;
+  }
+  .mast h1 em{font-style:normal;color:var(--red);}
+  .mast .sub{
+    margin-top:10px;font-size:11px;letter-spacing:.32em;color:var(--muted);text-transform:uppercase;
+  }
+  .mast .sprite{
+    display:grid;grid-template-columns:repeat(16,6px);grid-auto-rows:6px;gap:0;
+    margin-top:16px;
+  }
+  .mast .sprite i{background:transparent;}
+  .mast .sprite i.f{background:var(--yellow);}
+  .mast .sprite i.r{background:var(--red);}
+  .mast .sprite i.g{background:var(--green);}
+
+  .mast .chips{display:grid;grid-template-columns:repeat(2,1fr);gap:8px;}
+  .chip{
+    border:1px dashed var(--dash);padding:8px 10px;
+    display:flex;justify-content:space-between;align-items:baseline;
+  }
+  .chip b{font-size:10px;letter-spacing:.28em;color:var(--muted);text-transform:uppercase;}
+  .chip em{font-style:normal;font-size:22px;letter-spacing:.02em;}
+  .chip.red em{color:var(--red);}
+  .chip.yellow em{color:var(--yellow);}
+  .chip.green em{color:var(--green);}
+  .chip.blue em{color:var(--blue);}
+
+  .mast .time{
+    font-size:42px;letter-spacing:.04em;color:var(--yellow);font-weight:700;
+    text-align:right;
+  }
+  .mast .time small{display:block;font-size:11px;color:var(--muted);letter-spacing:.28em;margin-top:4px;}
+
+  /* nav row — oversized, flat */
+  .nav{
+    margin-top:16px;display:grid;grid-template-columns:repeat(6,1fr);gap:8px;
+  }
+  .nav a{
+    border:1px dashed var(--dash);text-decoration:none;color:var(--fg);
+    padding:14px 8px;text-align:center;letter-spacing:.18em;
+    font-weight:700;font-size:13px;text-transform:uppercase;
+    position:relative;
+  }
+  .nav a.on{background:var(--yellow);color:#000;border-style:dashed;}
+  .nav a:hover{background:rgba(255,255,255,.05);}
+  .nav a .k{position:absolute;top:3px;left:6px;font-size:9px;color:var(--muted);letter-spacing:.1em;}
+  .nav a.on .k{color:#000;}
+
+  /* huge numerals board */
+  .board{
+    margin-top:16px;display:grid;grid-template-columns:repeat(4,1fr);gap:8px;
+  }
+  .tile{
+    border:1px dashed var(--dash);padding:16px;display:flex;flex-direction:column;
+    gap:6px;min-height:150px;position:relative;overflow:hidden;
+  }
+  .tile .lbl{font-size:10px;letter-spacing:.3em;color:var(--muted);text-transform:uppercase;}
+  .tile .num{font-size:52px;font-weight:700;line-height:1;letter-spacing:-.02em;}
+  .tile .num small{font-size:18px;color:var(--muted);letter-spacing:.02em;margin-left:4px;}
+  .tile .foot{font-size:10px;letter-spacing:.18em;color:var(--muted);text-transform:uppercase;margin-top:auto;}
+  .tile .foot b{color:var(--fg);}
+
+  .tile.a .num{color:var(--green);}
+  .tile.b .num{color:var(--yellow);}
+  .tile.c .num{color:var(--blue);}
+  .tile.d .num{color:var(--red);}
+
+  /* pixel-art status glyph in corner */
+  .glyph{
+    position:absolute;right:10px;top:10px;
+    display:grid;grid-template-columns:repeat(6,5px);grid-auto-rows:5px;
+  }
+  .glyph i{background:transparent;}
+  .glyph i.on{background:currentColor;}
+
+  /* main area: big book + log strip */
+  .main{
+    margin-top:16px;display:grid;grid-template-columns:2fr 1fr;gap:8px;
+  }
+  .bookcard{
+    border:1px dashed var(--dash);padding:18px;
+    display:grid;grid-template-columns:200px 1fr;gap:22px;
+  }
+  .cover{
+    width:200px;height:280px;border:1px dashed var(--dash);
+    background:
+      repeating-linear-gradient(90deg,var(--red) 0 10px,#000 10px 20px),
+      #000;
+    display:flex;flex-direction:column;justify-content:space-between;padding:12px;
+    position:relative;
+  }
+  .cover::after{
+    content:"";position:absolute;inset:8px;border:1px dashed rgba(255,255,255,.4);
+  }
+  .cover b{font-size:13px;letter-spacing:.12em;background:var(--yellow);color:#000;padding:2px 6px;align-self:flex-start;z-index:1;}
+  .cover span{font-size:10px;letter-spacing:.2em;color:#fff;background:#000;padding:2px 5px;z-index:1;align-self:flex-end;}
+  .bookmeta h2{
+    margin:0;font-size:48px;line-height:.9;letter-spacing:-.02em;font-weight:700;text-transform:uppercase;
+  }
+  .bookmeta h2 em{color:var(--red);font-style:normal;}
+  .bookmeta .au{margin-top:8px;color:var(--muted);letter-spacing:.24em;font-size:12px;text-transform:uppercase;}
+  .bookmeta .prog{
+    margin-top:18px;display:grid;grid-template-columns:repeat(40,1fr);gap:2px;
+  }
+  .bookmeta .prog i{height:14px;background:rgba(255,255,255,.06);border:1px dashed rgba(255,255,255,.2);}
+  .bookmeta .prog i.f{background:var(--green);border-color:#000;}
+  .bookmeta .pmeta{
+    display:flex;justify-content:space-between;margin-top:6px;font-size:11px;color:var(--muted);letter-spacing:.2em;text-transform:uppercase;
+  }
+  .bookmeta .actions{margin-top:18px;display:flex;gap:8px;flex-wrap:wrap;}
+  .bookmeta .btn{
+    border:1px dashed var(--dash);padding:12px 14px;background:transparent;
+    color:var(--fg);font-family:inherit;font-weight:700;font-size:12px;
+    letter-spacing:.22em;text-transform:uppercase;cursor:pointer;
+  }
+  .bookmeta .btn.p{background:var(--green);color:#000;border-color:#000;}
+  .bookmeta .btn.d{background:var(--red);color:#000;border-color:#000;}
+  .bookmeta .btn.y{background:var(--yellow);color:#000;border-color:#000;}
+
+  /* log strip */
+  .log{
+    border:1px dashed var(--dash);padding:14px;font-size:11px;line-height:1.7;
+    background:rgba(255,255,255,.02);
+  }
+  .log h3{
+    margin:0 0 10px;font-size:11px;letter-spacing:.3em;color:var(--muted);text-transform:uppercase;font-weight:600;
+    border-bottom:1px dashed rgba(255,255,255,.3);padding-bottom:6px;
+  }
+  .log .ln{display:grid;grid-template-columns:70px 40px 1fr;gap:6px;border-bottom:1px dashed rgba(255,255,255,.08);padding:2px 0;}
+  .log .ln time{color:var(--muted);}
+  .log .ln .l{font-weight:700;letter-spacing:.18em;}
+  .log .ln .l.ok{color:var(--green);}
+  .log .ln .l.wn{color:var(--yellow);}
+  .log .ln .l.er{color:var(--red);}
+  .log .ln .l.in{color:var(--blue);}
+
+  /* pixel button row */
+  .filemgr{
+    margin-top:16px;border:1px dashed var(--dash);padding:14px;
+  }
+  .filemgr h3{
+    margin:0 0 10px;font-size:11px;letter-spacing:.3em;text-transform:uppercase;color:var(--muted);font-weight:600;
+    display:flex;justify-content:space-between;align-items:baseline;
+    border-bottom:1px dashed rgba(255,255,255,.3);padding-bottom:8px;
+  }
+  .flist{display:grid;grid-template-columns:repeat(2,1fr);gap:6px;}
+  .fitem{
+    display:grid;grid-template-columns:32px 1fr 90px 100px;gap:8px;align-items:center;
+    padding:6px;border:1px dashed rgba(255,255,255,.25);font-size:12px;
+  }
+  .fitem .ico{
+    width:22px;height:22px;background:var(--yellow);display:grid;place-items:center;color:#000;font-weight:700;font-size:11px;
+  }
+  .fitem .name{letter-spacing:.04em;}
+  .fitem .size{color:var(--muted);letter-spacing:.18em;font-size:10px;text-transform:uppercase;text-align:right;}
+  .fitem .btns{display:flex;gap:3px;}
+  .fitem .btns button{
+    background:transparent;border:1px dashed rgba(255,255,255,.4);color:var(--fg);
+    font-family:inherit;font-size:9px;padding:3px 5px;letter-spacing:.16em;cursor:pointer;text-transform:uppercase;
+  }
+  .fitem .btns button.x{color:var(--red);border-color:var(--red);}
+
+  /* footer bar */
+  .foot{
+    margin-top:16px;border:1px dashed var(--dash);padding:10px 14px;
+    display:flex;flex-wrap:wrap;gap:18px;justify-content:space-between;font-size:10px;color:var(--muted);
+    letter-spacing:.28em;text-transform:uppercase;
+  }
+  .foot b{color:var(--fg);}
+  .foot .heart{color:var(--red);}
+
+  .note{font-size:11px;color:var(--muted);letter-spacing:.2em;text-transform:uppercase;margin-top:4px;}
+</style>
+</head>
+<body>
+  <div class="pixels" id="pixels"></div>
+  <div class="wrap">
+
+    <!-- masthead -->
+    <div class="mast">
+      <div class="lt">
+        <h1>CROSS<br/><em>POINT</em></h1>
+        <div class="sub">Reader · DX34 · Web UI Ver. 0.MOCK</div>
+        <div class="sprite" id="sprite"></div>
+      </div>
+      <div class="rt">
+        <div class="time">21:44:02<small>WED · 24 APR 2026 · LOCAL</small></div>
+        <div class="chips">
+          <div class="chip green"><b>HEAP</b><em>214<small style="font-size:11px;color:var(--muted);">KB</small></em></div>
+          <div class="chip yellow"><b>BATT</b><em>78<small style="font-size:11px;color:var(--muted);">%</small></em></div>
+          <div class="chip blue"><b>WIFI</b><em>−52<small style="font-size:11px;color:var(--muted);">dB</small></em></div>
+          <div class="chip red"><b>TEMP</b><em>14<small style="font-size:11px;color:var(--muted);">°C ⚠</small></em></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- nav -->
+    <nav class="nav">
+      <a class="on"><span class="k">[1]</span>HOME</a>
+      <a><span class="k">[2]</span>LIBRARY</a>
+      <a><span class="k">[3]</span>UPLOAD</a>
+      <a><span class="k">[4]</span>SETTINGS</a>
+      <a><span class="k">[5]</span>SYNC</a>
+      <a><span class="k">[6]</span>ABOUT</a>
+    </nav>
+
+    <!-- big numeral board -->
+    <div class="board">
+      <div class="tile a">
+        <div class="lbl">UPTIME</div>
+        <div class="num">03<small>d</small></div>
+        <div class="glyph" style="color:var(--green);"></div>
+        <div class="foot"><b>14h 22m</b> · STABLE</div>
+      </div>
+      <div class="tile b">
+        <div class="lbl">FILES</div>
+        <div class="num">142<small>/256</small></div>
+        <div class="foot"><b>12.4 MB</b> USED · 3 NEW</div>
+      </div>
+      <div class="tile c">
+        <div class="lbl">SYNC</div>
+        <div class="num">14<small>ok</small></div>
+        <div class="foot"><b>AUTO 60s</b> · NEXT 00:23</div>
+      </div>
+      <div class="tile d">
+        <div class="lbl">ALERTS</div>
+        <div class="num">02</div>
+        <div class="foot"><b>BATT · LOW-TEMP</b> CLEAR?</div>
+      </div>
+    </div>
+
+    <!-- main area -->
+    <div class="main">
+      <div class="bookcard">
+        <div class="cover">
+          <b>NOW READING</b>
+          <span>P. 184 / 298</span>
+        </div>
+        <div class="bookmeta">
+          <div class="lbl" style="font-size:10px;letter-spacing:.3em;color:var(--muted);text-transform:uppercase;">CURRENT BOOK</div>
+          <h2>INVISIBLE<br/><em>CITIES</em></h2>
+          <div class="au">ITALO CALVINO · 412 KB · EPUB</div>
+          <div class="prog" id="prog"></div>
+          <div class="pmeta"><span>P.184</span><span>62% ▰</span><span>P.298</span></div>
+          <div class="actions">
+            <button class="btn p">▶ RESUME</button>
+            <button class="btn y">⇪ UPLOAD</button>
+            <button class="btn">⚙ FONT</button>
+            <button class="btn d">✕ REMOVE</button>
+          </div>
+          <div class="note">press &lt;SPACE&gt; to resume · &lt;F&gt; fullscreen · &lt;ESC&gt; quit</div>
+        </div>
+      </div>
+
+      <div class="log">
+        <h3>SYSTEM LOG <span>TAIL -20</span></h3>
+        <div class="ln"><time>21:44:02</time><span class="l in">IDLE</span><span>heap 214.8 KB · no tasks</span></div>
+        <div class="ln"><time>21:43:10</time><span class="l ok">OK</span><span>render page 184 (320 ms)</span></div>
+        <div class="ln"><time>21:41:55</time><span class="l ok">OK</span><span>sync /library 14 files</span></div>
+        <div class="ln"><time>21:41:02</time><span class="l wn">WARN</span><span>battery low-temp (14 °C)</span></div>
+        <div class="ln"><time>21:40:13</time><span class="l ok">OK</span><span>epd.init 480×800 4bpp</span></div>
+        <div class="ln"><time>21:40:12</time><span class="l ok">OK</span><span>http server :80 listen</span></div>
+        <div class="ln"><time>21:40:11</time><span class="l ok">OK</span><span>wifi.connect crosspoint-net</span></div>
+        <div class="ln"><time>21:40:11</time><span class="l ok">OK</span><span>mount /spiffs</span></div>
+        <div class="ln"><time>21:40:10</time><span class="l in">BOOT</span><span>fw 1.4.2-dx34 · 320 KB heap</span></div>
+        <div class="ln"><time>21:40:10</time><span class="l in">BOOT</span><span>serial 0x8A2F4 · esp32-s3</span></div>
+        <div class="ln"><time>21:40:09</time><span class="l er">ERR</span><span>lfs: prev mount dirty · repaired</span></div>
+        <div class="ln"><time>21:40:08</time><span class="l in">POR</span><span>cold start · vbat 3.92V</span></div>
+      </div>
+    </div>
+
+    <!-- file manager -->
+    <div class="filemgr">
+      <h3>LIBRARY ─ QUICK VIEW <span>142 FILES · 12.4 MB</span></h3>
+      <div class="flist">
+        <div class="fitem"><div class="ico">E</div><div class="name">invisible_cities.epub</div><div class="size">412 KB</div><div class="btns"><button>OPEN</button><button>DL</button><button class="x">DEL</button></div></div>
+        <div class="fitem"><div class="ico">E</div><div class="name">wind_up_bird.epub</div><div class="size">1.2 MB</div><div class="btns"><button>OPEN</button><button>DL</button><button class="x">DEL</button></div></div>
+        <div class="fitem"><div class="ico">E</div><div class="name">ficciones.epub</div><div class="size">188 KB</div><div class="btns"><button>OPEN</button><button>DL</button><button class="x">DEL</button></div></div>
+        <div class="fitem"><div class="ico">E</div><div class="name">dispossessed.epub</div><div class="size">602 KB</div><div class="btns"><button>OPEN</button><button>DL</button><button class="x">DEL</button></div></div>
+        <div class="fitem"><div class="ico">P</div><div class="name">pillow_book.pdf</div><div class="size">221 KB</div><div class="btns"><button>OPEN</button><button>DL</button><button class="x">DEL</button></div></div>
+        <div class="fitem"><div class="ico">E</div><div class="name">brothers_karamazov.epub</div><div class="size">2.4 MB</div><div class="btns"><button>OPEN</button><button>DL</button><button class="x">DEL</button></div></div>
+        <div class="fitem"><div class="ico">E</div><div class="name">kitchen.epub</div><div class="size">97 KB</div><div class="btns"><button>OPEN</button><button>DL</button><button class="x">DEL</button></div></div>
+        <div class="fitem"><div class="ico">E</div><div class="name">snow_country.epub</div><div class="size">142 KB</div><div class="btns"><button>OPEN</button><button>DL</button><button class="x">DEL</button></div></div>
+      </div>
+    </div>
+
+    <div class="foot">
+      <span><b>FW</b> 1.4.2-dx34</span>
+      <span><b>IP</b> 192.168.1.104</span>
+      <span><b>MAC</b> 8C:AA:B5:F3:22:0E</span>
+      <span><b>HOST</b> crosspoint.local</span>
+      <span><b>OPEN-SOURCE</b> · MIT</span>
+      <span class="heart">● REC · 00:12:44</span>
+    </div>
+
+  </div>
+
+<script>
+  // pixel drift
+  const layer=document.getElementById('pixels');
+  for(let i=0;i<80;i++){
+    const s=document.createElement('i');
+    s.style.left=Math.random()*100+'%';
+    s.style.top=Math.random()*100+'%';
+    s.style.animationDuration=(5+Math.random()*9)+'s';
+    s.style.animationDelay=(-Math.random()*14)+'s';
+    const r=Math.random();
+    if(r<.15){s.style.background='#ff2e3c';}
+    else if(r<.3){s.style.background='#ffe14a';}
+    else if(r<.45){s.style.background='#3cff8f';}
+    else if(r<.6){s.style.background='#4dc0ff';}
+    if(Math.random()<.4){s.style.width='4px';s.style.height='4px';}
+    layer.appendChild(s);
+  }
+  // pixel sprite (little face/icon in masthead)
+  const spritePattern=[
+    "..ffff....ffff..",
+    ".f....f..f....f.",
+    "f......ff......f",
+    "f..rr......rr..f",
+    "f..rr......rr..f",
+    "f......ff......f",
+    "f..............f",
+    ".f..gg....gg..f.",
+    "..f..gggggg..f..",
+    "...ff......ff...",
+    ".....ffffff.....",
+    "................",
+  ];
+  const sp=document.getElementById('sprite');
+  for(const row of spritePattern){
+    for(const c of row){
+      const el=document.createElement('i');
+      if(c==='f') el.className='f';
+      else if(c==='r') el.className='r';
+      else if(c==='g') el.className='g';
+      sp.appendChild(el);
+    }
+  }
+  // progress bar (62%)
+  const prog=document.getElementById('prog');
+  for(let i=0;i<40;i++){
+    const el=document.createElement('i');
+    if(i<25) el.className='f';
+    prog.appendChild(el);
+  }
+</script>
+</body>
+</html>

--- a/mockups/index.html
+++ b/mockups/index.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>CrossPoint Reader — Web UI Mockups</title>
+<style>
+  :root {
+    --bg: #07080c;
+    --fg: #e8e8e8;
+    --muted: #8a8a8a;
+    --dash: #ffffff;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, Consolas, monospace;
+    overflow-x: hidden;
+  }
+  /* animated pixel squares background */
+  .pixels { position: fixed; inset: 0; z-index: 0; pointer-events: none; }
+  .pixels i {
+    position: absolute;
+    width: 3px; height: 3px;
+    background: #fff;
+    opacity: .12;
+    animation: drift 18s linear infinite;
+  }
+  @keyframes drift {
+    0%   { transform: translate(0,0); }
+    50%  { transform: translate(40px,-60px); opacity:.28; }
+    100% { transform: translate(0,0); opacity:.12; }
+  }
+  .wrap { position: relative; z-index: 1; max-width: 1100px; margin: 0 auto; padding: 40px 24px 80px; }
+  header.top {
+    display: flex; align-items: baseline; justify-content: space-between;
+    border-bottom: 1px dashed var(--dash);
+    padding-bottom: 16px; margin-bottom: 28px;
+  }
+  h1 { font-size: 20px; letter-spacing: .2em; margin: 0; text-transform: uppercase; }
+  .sub { color: var(--muted); font-size: 12px; letter-spacing: .18em; }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 18px;
+  }
+  a.card {
+    display: block; text-decoration: none; color: inherit;
+    border: 1px dashed var(--dash);
+    padding: 18px;
+    background: rgba(255,255,255,0.02);
+    transition: transform .15s ease, background .15s ease;
+  }
+  a.card:hover { background: rgba(255,255,255,0.06); transform: translate(-2px,-2px); }
+  .num { font-size: 11px; color: var(--muted); letter-spacing: .24em; }
+  .ttl { font-size: 16px; margin: 6px 0 10px; letter-spacing: .08em; }
+  .desc { font-size: 12px; color: #b9b9b9; line-height: 1.55; }
+  footer { margin-top: 40px; font-size: 11px; color: var(--muted); letter-spacing: .2em; text-align: center; }
+  .ascii { white-space: pre; color: var(--muted); font-size: 11px; line-height: 1.2; margin-top: 18px; }
+</style>
+</head>
+<body>
+  <div class="pixels" id="pixels"></div>
+  <div class="wrap">
+    <header class="top">
+      <h1>CROSSPOINT ─ WEB UI // MOCKUPS</h1>
+      <span class="sub">v0.MOCK · 2026.04</span>
+    </header>
+
+    <p class="desc" style="margin:0 0 22px;max-width:640px;">
+      Five alternative directions for the embedded web interface.
+      All share a dark background, drifting pixel squares, and 1px dashed
+      borders — each takes the brief in a different visual direction.
+    </p>
+
+    <div class="grid">
+      <a class="card" href="01-crt-terminal.html">
+        <div class="num">01 / 05</div>
+        <div class="ttl">CRT TERMINAL</div>
+        <div class="desc">Green phosphor. Scanlines. Blinking cursor. A literal 80s serial console dressed up as a dashboard.</div>
+      </a>
+      <a class="card" href="02-bbs-condensed.html">
+        <div class="num">02 / 05</div>
+        <div class="ttl">JP BBS ─ CONDENSED</div>
+        <div class="desc">Dense vertical bands, katakana ornaments, tight monospace, magenta + cyan spot colour. A 2ch-flavoured control panel.</div>
+      </a>
+      <a class="card" href="03-kr-portal.html">
+        <div class="num">03 / 05</div>
+        <div class="ttl">KR PORTAL ─ MULTIWINDOW</div>
+        <div class="desc">Naver-era busy portal. Many small panes, ticker bars, badges, mixed Hangul + English labels.</div>
+      </a>
+      <a class="card" href="04-vaporwave-grid.html">
+        <div class="num">04 / 05</div>
+        <div class="ttl">VAPOR / PIXEL GRID</div>
+        <div class="desc">Magenta-cyan gradient, large drifting pixel blocks, hiragana/kanji accents, modern type mixed with bitmap.</div>
+      </a>
+      <a class="card" href="05-brutalist-8bit.html">
+        <div class="num">05 / 05</div>
+        <div class="ttl">BRUTALIST / 8-BIT</div>
+        <div class="desc">Flat, chunky, oversized labels. Huge numerals, thick dashed dividers, pixel-art status glyphs.</div>
+      </a>
+    </div>
+
+    <pre class="ascii">
+ ┌─ drift ─┐  ┌─ drift ─┐  ┌─ drift ─┐
+ │  ▚▚▚▚  │  │  ▖▖▖▖  │  │  ░░░░  │
+ └────────┘  └────────┘  └────────┘
+    </pre>
+
+    <footer>— select a mockup above —</footer>
+  </div>
+
+<script>
+  // seed pixel drift
+  const layer = document.getElementById('pixels');
+  const N = 90;
+  for (let i=0;i<N;i++){
+    const s = document.createElement('i');
+    s.style.left = Math.random()*100 + '%';
+    s.style.top = Math.random()*100 + '%';
+    s.style.animationDuration = (10 + Math.random()*20) + 's';
+    s.style.animationDelay = (-Math.random()*20) + 's';
+    if (Math.random() < .25) { s.style.width='2px'; s.style.height='2px'; }
+    if (Math.random() < .15) { s.style.background='#6ef08a'; s.style.opacity='.25'; }
+    layer.appendChild(s);
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Five static HTML mockups exploring alternative looks for the embedded web UI (Home / Files / Settings). All share a dark background, drifting pixel-square background animation, and 1px white dashed borders — each takes a different direction within the modern + 80s + JP/KR condensed brief.

- **01 · CRT Terminal** — green phosphor, scanlines, ASCII banner, blinking cursor
- **02 · JP BBS (Condensed)** — dense 3-column dashboard, katakana ornaments, cyan/magenta spot colour, ticker + marquee
- **03 · KR Portal (Multi-window)** — Naver-era busy portal with shortcuts, live feed, chat, rankings, mixed Hangul + English labels
- **04 · Vapor / Pixel Grid** — gradient horizon, large drifting pixel blocks, hiragana/kanji vertical caption, gradient type
- **05 · Brutalist / 8-bit** — oversized numerals, pixel-art sprite, chunky nav, flat colour chips

Entry point: `mockups/index.html` (links to all five).

No changes to the firmware or existing web pages — these are design explorations only. Nothing is wired into the device server yet.

## Test plan

- [ ] Open `mockups/index.html` in a browser and click through each of the 5 mockups
- [ ] Confirm the pixel-square background animates smoothly in each mockup
- [ ] Pick a direction (or combination) to develop into the real UI
- [ ] Follow-up: port chosen styling into `src/network/html/HomePage.html` / `FilesPage.html` / `SettingsPage.html`

---
_Generated by [Claude Code](https://claude.ai/code/session_011biwx7YJVfVdKTDxW5gmZ3)_