### PR TITLE
feat(fonts): SD-streamed CPBN bitmaps + 25..40 pt size grid

### DIFF
--- a/lib/EpdFont/EpdBinFontLoader.cpp
+++ b/lib/EpdFont/EpdBinFontLoader.cpp
@@ -13,15 +13,12 @@ namespace binfont {
 
 namespace {
 constexpr const char* kModule = "CPBN";
+constexpr uint8_t kMinSizePt = 25;
+constexpr uint8_t kMaxSizePt = 40;
 
-// Reads exactly `count` bytes into `dst`. Short reads return false.
-// Resets the task watchdog every ~8 KB so a slow SD on a big (~256 KB)
-// font file can't trip the 10-second WDT when activate() opens four
-// variants back-to-back at reader-open time.
 bool readExact(HalFile& f, void* dst, size_t count) {
   constexpr size_t kWdtEveryBytes = 8192;
-  size_t got = 0;
-  size_t sinceWdt = 0;
+  size_t got = 0, sinceWdt = 0;
   auto* out = static_cast<uint8_t*>(dst);
   while (got < count) {
     const int n = f.read(out + got, count - got);
@@ -36,52 +33,24 @@ bool readExact(HalFile& f, void* dst, size_t count) {
   return true;
 }
 
-// Validate a Header filled from disk. Leaves `error` untouched on
-// success. Used by both openFromFile and validateFile so the
-// criteria match in both call sites.
 bool validateHeader(const Header& h, uint32_t fileBytes, std::string* error) {
-  if (h.magic != kMagic) {
-    if (error) *error = "bad magic (not CPBN)";
+  if (h.magic != kMagic) { if (error) *error = "bad magic (not CPBN)"; return false; }
+  if (h.version != kVersion) { if (error) *error = "unsupported version"; return false; }
+  if (h.bitsPerPixel != 2) { if (error) *error = "only 2 bits/pixel supported"; return false; }
+  if (h.sizePt < kMinSizePt || h.sizePt > kMaxSizePt) {
+    if (error) *error = "size outside 25..40";
     return false;
   }
-  if (h.version != kVersion) {
-    if (error) *error = "unsupported version";
-    return false;
-  }
-  if (h.bitsPerPixel != 2) {
-    if (error) *error = "only 2 bits/pixel supported";
-    return false;
-  }
-  if (h.sizePt < 9 || h.sizePt > 16) {
-    if (error) *error = "size outside 9..16";
-    return false;
-  }
-  if (h.variant > kVariantBoldItalic) {
-    if (error) *error = "bad variant";
-    return false;
-  }
-  if (h.glyphCount == 0 || h.glyphCount > kMaxGlyphs) {
-    if (error) *error = "bad glyphCount";
-    return false;
-  }
-  if (h.intervalCount == 0) {
-    if (error) *error = "no unicode intervals";
-    return false;
-  }
-  if (h.groupCount == 0 || h.groupCount > kMaxGroups) {
-    if (error) *error = "bad groupCount";
-    return false;
-  }
+  if (h.variant > kVariantBoldItalic) { if (error) *error = "bad variant"; return false; }
+  if (h.glyphCount == 0 || h.glyphCount > kMaxGlyphs) { if (error) *error = "bad glyphCount"; return false; }
+  if (h.intervalCount == 0) { if (error) *error = "no unicode intervals"; return false; }
+  if (h.groupCount == 0 || h.groupCount > kMaxGroups) { if (error) *error = "bad groupCount"; return false; }
 
-  // Cross-check that header + tables + blob all fit in the file.
   const uint64_t glyphsBytes = static_cast<uint64_t>(h.glyphCount) * sizeof(EpdGlyph);
   const uint64_t intervalsBytes = static_cast<uint64_t>(h.intervalCount) * sizeof(EpdUnicodeInterval);
   const uint64_t groupsBytes = static_cast<uint64_t>(h.groupCount) * sizeof(EpdFontGroup);
   const uint64_t expected = sizeof(Header) + glyphsBytes + intervalsBytes + groupsBytes + h.bitmapBlobSize;
-  if (expected != fileBytes) {
-    if (error) *error = "tables + blob do not match file size";
-    return false;
-  }
+  if (expected != fileBytes) { if (error) *error = "tables + blob do not match file size"; return false; }
   return true;
 }
 
@@ -90,11 +59,13 @@ bool validateHeader(const Header& h, uint32_t fileBytes, std::string* error) {
 EpdBinFontLoader::~EpdBinFontLoader() { release(); }
 
 void EpdBinFontLoader::release() {
-  if (buffer_) {
-    free(buffer_);
-    buffer_ = nullptr;
+  if (tablesBuf_) {
+    free(tablesBuf_);
+    tablesBuf_ = nullptr;
   }
-  fileBytes_ = 0;
+  tablesBytes_ = 0;
+  if (file_.isOpen()) file_.close();
+  bitmapBlobFileOffset_ = 0;
   fontData_ = {};
   header_ = {};
 }
@@ -114,8 +85,6 @@ bool EpdBinFontLoader::openFromFile(const std::string& path) {
     return false;
   }
 
-  // Read the header first so we can reject garbage before allocating
-  // the full buffer. 32 bytes is trivial.
   Header hdr;
   if (!readExact(f, &hdr, sizeof(hdr))) {
     lastError_ = "header read failed";
@@ -127,37 +96,80 @@ bool EpdBinFontLoader::openFromFile(const std::string& path) {
     return false;
   }
 
-  // One contiguous allocation for the whole file. The EpdFontData
-  // view below just pokes pointers into it.
-  uint8_t* buf = static_cast<uint8_t*>(malloc(fileSize));
+  // Allocate just the tables: header + glyph metadata + intervals +
+  // groups. The bitmap blob stays on SD.
+  const uint32_t tablesBytes = sizeof(Header) + hdr.glyphCount * sizeof(EpdGlyph) +
+                               hdr.intervalCount * sizeof(EpdUnicodeInterval) +
+                               hdr.groupCount * sizeof(EpdFontGroup);
+  uint8_t* buf = static_cast<uint8_t*>(malloc(tablesBytes));
   if (!buf) {
-    lastError_ = "malloc failed";
+    lastError_ = "tables malloc failed";
     f.close();
     return false;
   }
   std::memcpy(buf, &hdr, sizeof(hdr));
-  if (!readExact(f, buf + sizeof(hdr), fileSize - sizeof(hdr))) {
-    lastError_ = "body read failed";
+  if (!readExact(f, buf + sizeof(hdr), tablesBytes - sizeof(hdr))) {
+    lastError_ = "tables read failed";
     free(buf);
     f.close();
     return false;
   }
-  f.close();
 
-  // Wire up the in-memory view. Layout is: header, glyphs, intervals,
-  // groups, bitmap blob. The header is already copied into header_ so
-  // we keep a stable copy for the accessors.
-  buffer_ = buf;
-  fileBytes_ = static_cast<uint32_t>(fileSize);
+  // Smoke-test group 0: pull its compressed bytes from the file and
+  // inflate. Catches a malformed or zlib-wrapped bitmap blob before
+  // we hand the font to the renderer.
+  const auto* groupsPtr = reinterpret_cast<const EpdFontGroup*>(
+      buf + sizeof(Header) + hdr.glyphCount * sizeof(EpdGlyph) + hdr.intervalCount * sizeof(EpdUnicodeInterval));
+  const auto& g0 = groupsPtr[0];
+  if (g0.compressedSize > 0 && g0.uncompressedSize > 0 && g0.compressedSize <= hdr.bitmapBlobSize) {
+    auto* compressed = static_cast<uint8_t*>(malloc(g0.compressedSize));
+    auto* probe = static_cast<uint8_t*>(malloc(g0.uncompressedSize));
+    if (!compressed || !probe) {
+      free(compressed);
+      free(probe);
+      free(buf);
+      f.close();
+      lastError_ = "probe alloc failed";
+      return false;
+    }
+    if (!f.seekSet(tablesBytes + g0.compressedOffset) ||
+        !readExact(f, compressed, g0.compressedSize)) {
+      free(compressed);
+      free(probe);
+      free(buf);
+      f.close();
+      lastError_ = "probe SD read failed";
+      return false;
+    }
+    InflateReader rd;
+    rd.init(false);
+    rd.setSource(compressed, g0.compressedSize);
+    const bool ok = rd.read(probe, g0.uncompressedSize);
+    free(compressed);
+    free(probe);
+    if (!ok) {
+      free(buf);
+      f.close();
+      lastError_ = "group 0 inflate failed (likely zlib-wrapped, want raw deflate)";
+      return false;
+    }
+  }
+
+  // Commit: take ownership of the file handle for the rest of the
+  // loader's life so readBitmapBytesCallback can pread without a
+  // re-open per request.
+  tablesBuf_ = buf;
+  tablesBytes_ = tablesBytes;
+  file_ = std::move(f);
+  bitmapBlobFileOffset_ = tablesBytes;
   header_ = hdr;
 
   const uint8_t* glyphsPtr = buf + sizeof(Header);
   const uint8_t* intervalsPtr = glyphsPtr + hdr.glyphCount * sizeof(EpdGlyph);
-  const uint8_t* groupsPtr = intervalsPtr + hdr.intervalCount * sizeof(EpdUnicodeInterval);
-  const uint8_t* bitmapPtr = groupsPtr + hdr.groupCount * sizeof(EpdFontGroup);
+  const uint8_t* groupsBytes = intervalsPtr + hdr.intervalCount * sizeof(EpdUnicodeInterval);
 
   fontData_ = {};
-  fontData_.bitmap = bitmapPtr;
+  // bitmap stays null — readBitmapBytes is the source of truth.
   fontData_.glyph = reinterpret_cast<const EpdGlyph*>(glyphsPtr);
   fontData_.intervals = reinterpret_cast<const EpdUnicodeInterval*>(intervalsPtr);
   fontData_.intervalCount = hdr.intervalCount;
@@ -165,42 +177,29 @@ bool EpdBinFontLoader::openFromFile(const std::string& path) {
   fontData_.ascender = hdr.ascent;
   fontData_.descender = hdr.descent;
   fontData_.is2Bit = (hdr.bitsPerPixel == 2);
-  fontData_.groups = reinterpret_cast<const EpdFontGroup*>(groupsPtr);
+  fontData_.groups = reinterpret_cast<const EpdFontGroup*>(groupsBytes);
   fontData_.groupCount = static_cast<uint16_t>(hdr.groupCount);
-  // No kerning / ligature tables in v1 — leave nullptr (zero-initialised).
+  fontData_.bitmapCtx = this;
+  fontData_.readBitmapBytes = &EpdBinFontLoader::readBitmapBytesCallback;
 
-  // Smoke-test group 0: confirm the DEFLATE stream actually inflates.
-  // Catches files produced by a baker that wrote zlib-wrapped output
-  // instead of raw deflate — without this, a broken font activates
-  // "successfully" and then floods the heap with failed group-decode
-  // mallocs every time the renderer touches a glyph, which fragments
-  // the heap until layout itself can't allocate (observed with the
-  // pre-deflateRaw browser baker).
-  const auto* g0 = reinterpret_cast<const EpdFontGroup*>(groupsPtr);
-  if (g0->compressedSize > 0 && g0->uncompressedSize > 0 &&
-      g0->compressedSize <= hdr.bitmapBlobSize) {
-    auto* probe = static_cast<uint8_t*>(malloc(g0->uncompressedSize));
-    if (!probe) {
-      lastError_ = "probe alloc failed";
-      release();
-      return false;
-    }
-    InflateReader rd;
-    rd.init(false);
-    rd.setSource(bitmapPtr + g0->compressedOffset, g0->compressedSize);
-    const bool ok = rd.read(probe, g0->uncompressedSize);
-    free(probe);
-    if (!ok) {
-      lastError_ = "group 0 inflate failed (likely zlib-wrapped, want raw deflate)";
-      release();
-      return false;
-    }
-  }
-
-  LOG_DBG(kModule, "loaded %s: %u glyphs / %u groups / %u B bitmap (%u B total)", path.c_str(),
+  LOG_DBG(kModule, "streamed open %s: %u glyphs / %u groups / tables %u B (blob stays on SD)", path.c_str(),
           static_cast<unsigned>(hdr.glyphCount), static_cast<unsigned>(hdr.groupCount),
-          static_cast<unsigned>(hdr.bitmapBlobSize), static_cast<unsigned>(fileSize));
+          static_cast<unsigned>(tablesBytes));
   return true;
+}
+
+// static
+int EpdBinFontLoader::readBitmapBytesCallback(void* ctx, uint32_t offset, uint8_t* dst, size_t len) {
+  auto* self = static_cast<EpdBinFontLoader*>(ctx);
+  if (!self || !self->file_.isOpen()) return -1;
+  if (!self->file_.seekSet(self->bitmapBlobFileOffset_ + offset)) return -1;
+  size_t got = 0;
+  while (got < len) {
+    const int n = self->file_.read(dst + got, len - got);
+    if (n <= 0) return -1;
+    got += static_cast<size_t>(n);
+  }
+  return static_cast<int>(got);
 }
 
 // static

--- a/lib/EpdFont/EpdBinFontLoader.cpp
+++ b/lib/EpdFont/EpdBinFontLoader.cpp
@@ -34,23 +34,47 @@ bool readExact(HalFile& f, void* dst, size_t count) {
 }
 
 bool validateHeader(const Header& h, uint32_t fileBytes, std::string* error) {
-  if (h.magic != kMagic) { if (error) *error = "bad magic (not CPBN)"; return false; }
-  if (h.version != kVersion) { if (error) *error = "unsupported version"; return false; }
-  if (h.bitsPerPixel != 2) { if (error) *error = "only 2 bits/pixel supported"; return false; }
+  if (h.magic != kMagic) {
+    if (error) *error = "bad magic (not CPBN)";
+    return false;
+  }
+  if (h.version != kVersion) {
+    if (error) *error = "unsupported version";
+    return false;
+  }
+  if (h.bitsPerPixel != 2) {
+    if (error) *error = "only 2 bits/pixel supported";
+    return false;
+  }
   if (h.sizePt < kMinSizePt || h.sizePt > kMaxSizePt) {
     if (error) *error = "size outside 25..40";
     return false;
   }
-  if (h.variant > kVariantBoldItalic) { if (error) *error = "bad variant"; return false; }
-  if (h.glyphCount == 0 || h.glyphCount > kMaxGlyphs) { if (error) *error = "bad glyphCount"; return false; }
-  if (h.intervalCount == 0) { if (error) *error = "no unicode intervals"; return false; }
-  if (h.groupCount == 0 || h.groupCount > kMaxGroups) { if (error) *error = "bad groupCount"; return false; }
+  if (h.variant > kVariantBoldItalic) {
+    if (error) *error = "bad variant";
+    return false;
+  }
+  if (h.glyphCount == 0 || h.glyphCount > kMaxGlyphs) {
+    if (error) *error = "bad glyphCount";
+    return false;
+  }
+  if (h.intervalCount == 0) {
+    if (error) *error = "no unicode intervals";
+    return false;
+  }
+  if (h.groupCount == 0 || h.groupCount > kMaxGroups) {
+    if (error) *error = "bad groupCount";
+    return false;
+  }
 
   const uint64_t glyphsBytes = static_cast<uint64_t>(h.glyphCount) * sizeof(EpdGlyph);
   const uint64_t intervalsBytes = static_cast<uint64_t>(h.intervalCount) * sizeof(EpdUnicodeInterval);
   const uint64_t groupsBytes = static_cast<uint64_t>(h.groupCount) * sizeof(EpdFontGroup);
   const uint64_t expected = sizeof(Header) + glyphsBytes + intervalsBytes + groupsBytes + h.bitmapBlobSize;
-  if (expected != fileBytes) { if (error) *error = "tables + blob do not match file size"; return false; }
+  if (expected != fileBytes) {
+    if (error) *error = "tables + blob do not match file size";
+    return false;
+  }
   return true;
 }
 
@@ -99,8 +123,7 @@ bool EpdBinFontLoader::openFromFile(const std::string& path) {
   // Allocate just the tables: header + glyph metadata + intervals +
   // groups. The bitmap blob stays on SD.
   const uint32_t tablesBytes = sizeof(Header) + hdr.glyphCount * sizeof(EpdGlyph) +
-                               hdr.intervalCount * sizeof(EpdUnicodeInterval) +
-                               hdr.groupCount * sizeof(EpdFontGroup);
+                               hdr.intervalCount * sizeof(EpdUnicodeInterval) + hdr.groupCount * sizeof(EpdFontGroup);
   uint8_t* buf = static_cast<uint8_t*>(malloc(tablesBytes));
   if (!buf) {
     lastError_ = "tables malloc failed";
@@ -132,8 +155,7 @@ bool EpdBinFontLoader::openFromFile(const std::string& path) {
       lastError_ = "probe alloc failed";
       return false;
     }
-    if (!f.seekSet(tablesBytes + g0.compressedOffset) ||
-        !readExact(f, compressed, g0.compressedSize)) {
+    if (!f.seekSet(tablesBytes + g0.compressedOffset) || !readExact(f, compressed, g0.compressedSize)) {
       free(compressed);
       free(probe);
       free(buf);

--- a/lib/EpdFont/EpdBinFontLoader.h
+++ b/lib/EpdFont/EpdBinFontLoader.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <HalStorage.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -9,10 +11,17 @@
 #include "EpdFont.h"
 #include "EpdFontData.h"
 
-// SD-backed loader for a single CPBN .bin file. Owns a heap buffer
-// holding the entire file; presents an EpdFontData view on top so the
-// built-in renderer + FontDecompressor consume it without branching.
-// Must outlive any EpdFont/EpdFontFamily constructed from its data().
+// SD-backed loader for a single CPBN .bin file.
+//
+// Loads only the small fixed tables (header, glyph metadata, intervals,
+// groups) into heap. The DEFLATE bitmap blob stays on SD and is read
+// on demand via the EpdFontData read-bitmap callback. Total heap per
+// loaded variant is a few KB regardless of font size, so a 4-variant
+// active family at 30 pt costs roughly the same RAM as at 14 pt — the
+// previous full-file-in-heap design didn't.
+//
+// Must outlive any EpdFont/EpdFontFamily constructed from its data();
+// destruction closes the underlying HalFile.
 namespace crosspoint {
 namespace binfont {
 
@@ -25,24 +34,36 @@ class EpdBinFontLoader {
 
   bool openFromFile(const std::string& path);
 
-  // Header-only precheck without allocating the full buffer. Used by
-  // the upload endpoint before committing the atomic rename.
+  // Header-only precheck without holding the file open. Used by the
+  // upload endpoint before the atomic rename commits the new file.
   static bool validateFile(const std::string& path, std::string* error = nullptr);
 
-  bool isOpen() const { return buffer_ != nullptr; }
+  bool isOpen() const { return tablesBuf_ != nullptr; }
   const EpdFontData* data() const { return isOpen() ? &fontData_ : nullptr; }
   uint8_t sizePt() const { return header_.sizePt; }
   uint8_t variant() const { return header_.variant; }
   const std::string& lastError() const { return lastError_; }
 
  private:
-  uint8_t* buffer_ = nullptr;
-  uint32_t fileBytes_ = 0;
+  // Heap buffer holding header + glyph table + interval table + group
+  // table only. fontData_ pointers all index into this region.
+  uint8_t* tablesBuf_ = nullptr;
+  uint32_t tablesBytes_ = 0;
+
+  // SD-resident bitmap blob. The HalFile stays open for the lifetime
+  // of the loader; readBitmapBytes seeks + reads on each call.
+  HalFile file_;
+  uint32_t bitmapBlobFileOffset_ = 0;  // absolute file offset to start of blob
+
   Header header_ = {};
   EpdFontData fontData_ = {};
   std::string lastError_;
 
   void release();
+
+  // Static trampoline matching EpdFontData::readBitmapBytes. ctx is a
+  // pointer to the EpdBinFontLoader instance.
+  static int readBitmapBytesCallback(void* ctx, uint32_t offset, uint8_t* dst, size_t len);
 };
 
 }  // namespace binfont

--- a/lib/EpdFont/EpdBinFormat.h
+++ b/lib/EpdFont/EpdBinFormat.h
@@ -34,8 +34,8 @@ struct __attribute__((packed)) Header {
   uint8_t variant;       // Variant enum
   int16_t ascent;
   int16_t descent;
-  uint16_t advanceY;     // line height in px
-  uint16_t reserved0;    // MBZ
+  uint16_t advanceY;   // line height in px
+  uint16_t reserved0;  // MBZ
   uint32_t glyphCount;
   uint32_t intervalCount;
   uint32_t groupCount;

--- a/lib/EpdFont/EpdFontData.h
+++ b/lib/EpdFont/EpdFontData.h
@@ -2,6 +2,7 @@
 // https://github.com/vroland/epdiy/blob/c61e9e923ce2418150d54f88cea5d196cdc40c54/src/epd_internals.h
 
 #pragma once
+#include <cstddef>
 #include <cstdint>
 
 /// Font metrics use "fixed-point 4" (4 fractional bits, i.e. 1/16-pixel
@@ -132,4 +133,15 @@ typedef struct {
   uint8_t kernRightClassCount = 0;                 ///< Number of distinct right classes (CSR columns)
   const EpdLigaturePair* ligaturePairs = nullptr;  ///< Sorted ligature pair table (nullptr if none)
   uint32_t ligaturePairCount = 0;                  ///< Number of entries in ligaturePairs
+
+  /// Optional read-bitmap callback. When non-null, FontDecompressor invokes
+  /// this instead of reading `bitmap[offset]` directly — used by SD-backed
+  /// custom fonts to keep the compressed glyph blob on disk rather than
+  /// pinning ~30 KB per variant in heap. Implementations must read exactly
+  /// `len` bytes starting at `offset` (relative to the start of the blob)
+  /// into `dst` and return `len` on success, anything else on failure.
+  /// Built-in fonts leave this null and the decompressor uses the embedded
+  /// PROGMEM pointer as before.
+  void* bitmapCtx = nullptr;
+  int (*readBitmapBytes)(void* ctx, uint32_t offset, uint8_t* dst, size_t len) = nullptr;
 } EpdFontData;

--- a/lib/EpdFont/FontDecompressor.cpp
+++ b/lib/EpdFont/FontDecompressor.cpp
@@ -62,8 +62,26 @@ bool FontDecompressor::decompressGroup(const EpdFontData* fontData, uint16_t gro
   const EpdFontGroup& group = fontData->groups[groupIndex];
 
   const uint32_t tDecomp = millis();
+  const uint8_t* src = nullptr;
+  if (fontData->readBitmapBytes) {
+    // SD-backed font: pull this group's compressed bytes off disk
+    // into the reusable scratch, then point inflate at the scratch.
+    if (sdCompressedScratch.size() < group.compressedSize) {
+      sdCompressedScratch.resize(group.compressedSize);
+    }
+    const int got = fontData->readBitmapBytes(fontData->bitmapCtx, group.compressedOffset, sdCompressedScratch.data(),
+                                              group.compressedSize);
+    if (got != static_cast<int>(group.compressedSize)) {
+      stats.decompressTimeMs += millis() - tDecomp;
+      LOG_ERR("FDC", "SD read failed for group %u (got %d / %u)", groupIndex, got, group.compressedSize);
+      return false;
+    }
+    src = sdCompressedScratch.data();
+  } else {
+    src = &fontData->bitmap[group.compressedOffset];
+  }
   inflateReader.init(false);
-  inflateReader.setSource(&fontData->bitmap[group.compressedOffset], group.compressedSize);
+  inflateReader.setSource(src, group.compressedSize);
   if (!inflateReader.read(outBuf, outSize)) {
     stats.decompressTimeMs += millis() - tDecomp;
     LOG_ERR("FDC", "Decompression failed for group %u", groupIndex);

--- a/lib/EpdFont/FontDecompressor.h
+++ b/lib/EpdFont/FontDecompressor.h
@@ -75,6 +75,11 @@ class FontDecompressor {
   // Valid until the next getBitmap() call.
   std::vector<uint8_t> hotGlyphBuf;
 
+  // Scratch for compressed group bytes when the font is SD-backed
+  // (EpdFontData::readBitmapBytes is set). Reused across decompress
+  // calls so we don't churn the heap. Empty for built-in fonts.
+  std::vector<uint8_t> sdCompressedScratch;
+
   void freePageBuffer();
   void freeHotGroup();
   uint16_t getGroupIndex(const EpdFontData* fontData, uint32_t glyphIndex);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -132,10 +132,9 @@ void EpubReaderActivity::onEnter() {
   // bricked the device on broken-DEFLATE fonts.
   if (SETTINGS.fontFamily == CrossPointSettings::CUSTOM_FAMILY && !SETTINGS.customFontName.empty()) {
     const bool ok = crosspoint::fonts::CustomBinFontManager::instance().activate(SETTINGS.customFontName,
-                                                                                  SETTINGS.customFontSizePt);
+                                                                                 SETTINGS.customFontSizePt);
     if (!ok) {
-      LOG_ERR("ERS", "custom font '%s' failed to activate; reverting to CHAREINK 12",
-              SETTINGS.customFontName.c_str());
+      LOG_ERR("ERS", "custom font '%s' failed to activate; reverting to CHAREINK 12", SETTINGS.customFontName.c_str());
       SETTINGS.fontFamily = CrossPointSettings::CHAREINK;
       SETTINGS.fontSize = CrossPointSettings::SIZE_12;
       SETTINGS.customFontName.clear();

--- a/src/activities/reader/ReaderSettingsActivity.cpp
+++ b/src/activities/reader/ReaderSettingsActivity.cpp
@@ -443,7 +443,8 @@ void ReaderSettingsActivity::toggleCurrentSetting() {
         SETTINGS.fontFamily = CrossPointSettings::CUSTOM_FAMILY;
         const size_t customSlot = nextIndex - builtinCount;
         SETTINGS.customFontName = names[customSlot];
-        const auto sizes = crosspoint::fonts::CustomBinFontManager::instance().installedSizesFor(SETTINGS.customFontName);
+        const auto sizes =
+            crosspoint::fonts::CustomBinFontManager::instance().installedSizesFor(SETTINGS.customFontName);
         // Keep the previously-selected size if it still exists for the
         // new family; otherwise pick the smallest so the picker has a
         // valid default.

--- a/src/activities/settings/CustomFontsSettingsActivity.cpp
+++ b/src/activities/settings/CustomFontsSettingsActivity.cpp
@@ -84,16 +84,14 @@ void CustomFontsSettingsActivity::loop() {
       }
       return;
     }
-    buttonNavigator.onPressAndContinuous(
-        {MappedInputManager::Button::Down, MappedInputManager::Button::Right}, [this] {
-          actionIndex = (actionIndex + 1) % kActionCount;
-          requestUpdate();
-        });
-    buttonNavigator.onPressAndContinuous(
-        {MappedInputManager::Button::Up, MappedInputManager::Button::Left}, [this] {
-          actionIndex = (actionIndex + kActionCount - 1) % kActionCount;
-          requestUpdate();
-        });
+    buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Down, MappedInputManager::Button::Right}, [this] {
+      actionIndex = (actionIndex + 1) % kActionCount;
+      requestUpdate();
+    });
+    buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Up, MappedInputManager::Button::Left}, [this] {
+      actionIndex = (actionIndex + kActionCount - 1) % kActionCount;
+      requestUpdate();
+    });
     return;
   }
 
@@ -131,8 +129,7 @@ void CustomFontsSettingsActivity::runDeleteSize() {
   enterNewActivity(new ConfirmDialogActivity(
       renderer, mappedInput, prompt,
       [this, name, sizePt]() {
-        const size_t removed =
-            crosspoint::fonts::CustomBinFontManager::instance().deleteFamilySize(name, sizePt);
+        const size_t removed = crosspoint::fonts::CustomBinFontManager::instance().deleteFamilySize(name, sizePt);
         LOG_INF("CFONT", "UI deleted size %s %upt (%u files)", name.c_str(), static_cast<unsigned>(sizePt),
                 static_cast<unsigned>(removed));
         exitActivity();

--- a/src/fonts/CustomBinFontManager.cpp
+++ b/src/fonts/CustomBinFontManager.cpp
@@ -34,9 +34,7 @@ bool endsWithCI(const char* name, const char* suffix) {
   return n >= s && strcasecmp(name + n - s, suffix) == 0;
 }
 
-bool isLegacyFontName(const char* name) {
-  return endsWithCI(name, ".bdf") || endsWithCI(name, ".idx");
-}
+bool isLegacyFontName(const char* name) { return endsWithCI(name, ".bdf") || endsWithCI(name, ".idx"); }
 
 size_t walkAndDeleteLegacy(const char* dirPath, int depth) {
   if (depth > 1) return 0;
@@ -81,9 +79,7 @@ constexpr VariantTag kTags[] = {
     {"bolditalic_", binfont::kVariantBoldItalic},
 };
 
-const char* variantPrefix(uint8_t v) {
-  return v <= binfont::kVariantBoldItalic ? kTags[v].prefix : "regular_";
-}
+const char* variantPrefix(uint8_t v) { return v <= binfont::kVariantBoldItalic ? kTags[v].prefix : "regular_"; }
 
 // Configured legal point-size range. Files outside this range get
 // auto-deleted by scan() so a firmware revision can't leave stale
@@ -128,17 +124,28 @@ bool isStaleSizeFile(const char* name) {
 void insertVariant(std::vector<CustomBinFontSize>& sizes, uint8_t variant, uint16_t sizePt) {
   CustomBinFontSize* target = nullptr;
   for (auto& s : sizes) {
-    if (s.sizePt == sizePt) { target = &s; break; }
+    if (s.sizePt == sizePt) {
+      target = &s;
+      break;
+    }
   }
   if (!target) {
     sizes.push_back({sizePt, false, false, false, false});
     target = &sizes.back();
   }
   switch (variant) {
-    case binfont::kVariantRegular:    target->hasRegular = true; break;
-    case binfont::kVariantBold:       target->hasBold = true; break;
-    case binfont::kVariantItalic:     target->hasItalic = true; break;
-    case binfont::kVariantBoldItalic: target->hasBoldItalic = true; break;
+    case binfont::kVariantRegular:
+      target->hasRegular = true;
+      break;
+    case binfont::kVariantBold:
+      target->hasBold = true;
+      break;
+    case binfont::kVariantItalic:
+      target->hasItalic = true;
+      break;
+    case binfont::kVariantBoldItalic:
+      target->hasBoldItalic = true;
+      break;
   }
 }
 
@@ -155,14 +162,20 @@ std::string variantPath(const std::string& name, uint8_t variant, uint16_t sizeP
 void rmdirIfEmpty(const std::string& name) {
   const std::string dirPath = familyDir(name);
   auto dir = Storage.open(dirPath.c_str());
-  if (!dir || !dir.isDirectory()) { if (dir) dir.close(); return; }
+  if (!dir || !dir.isDirectory()) {
+    if (dir) dir.close();
+    return;
+  }
   bool empty = true;
   char entryName[256];
   for (auto e = dir.openNextFile(); e; e = dir.openNextFile()) {
     e.getName(entryName, sizeof(entryName));
     const bool isDot = entryName[0] == '.' && (entryName[1] == '\0' || (entryName[1] == '.' && entryName[2] == '\0'));
     e.close();
-    if (!isDot) { empty = false; break; }
+    if (!isDot) {
+      empty = false;
+      break;
+    }
   }
   dir.close();
   if (empty) Storage.rmdir(dirPath.c_str());
@@ -188,7 +201,10 @@ CustomBinFontManager& CustomBinFontManager::instance() {
 void CustomBinFontManager::scan() {
   families_.clear();
   auto root = Storage.open(kCustomFontDir);
-  if (!root || !root.isDirectory()) { if (root) root.close(); return; }
+  if (!root || !root.isDirectory()) {
+    if (root) root.close();
+    return;
+  }
 
   char name[256];
   size_t familyCount = 0;
@@ -204,7 +220,10 @@ void CustomBinFontManager::scan() {
     fam.name = name;
     const std::string subDirPath = familyDir(fam.name);
     auto subDir = Storage.open(subDirPath.c_str());
-    if (!subDir || !subDir.isDirectory()) { if (subDir) subDir.close(); continue; }
+    if (!subDir || !subDir.isDirectory()) {
+      if (subDir) subDir.close();
+      continue;
+    }
 
     char varName[256];
     size_t seen = 0;
@@ -223,11 +242,15 @@ void CustomBinFontManager::scan() {
         }
         continue;
       }
-      uint8_t variant; uint16_t sizePt;
+      uint8_t variant;
+      uint16_t sizePt;
       if (!parseVariantFile(varName, variant, sizePt)) continue;
       insertVariant(fam.sizes, variant, sizePt);
       if (++seen > kVariantScanCap) break;
-      if (seen % 16 == 0) { esp_task_wdt_reset(); yield(); }
+      if (seen % 16 == 0) {
+        esp_task_wdt_reset();
+        yield();
+      }
     }
     subDir.close();
 
@@ -275,7 +298,10 @@ void CustomBinFontManager::clearActive() {
 }
 
 bool CustomBinFontManager::activate(const std::string& name, uint16_t sizePt) {
-  if (!renderer_) { LOG_ERR(kModule, "activate before setRenderer()"); return false; }
+  if (!renderer_) {
+    LOG_ERR(kModule, "activate before setRenderer()");
+    return false;
+  }
   if (!isValidFamilyName(name)) return false;
   if (active_ && active_->name == name && active_->sizePt == sizePt) return true;
 
@@ -314,10 +340,8 @@ bool CustomBinFontManager::activate(const std::string& name, uint16_t sizePt) {
   // so the four-variant load is back to being the default. Bold +
   // italic + boldItalic uploaded by the browser display verbatim;
   // missing slots fall back via EpdFontFamily::getFont.
-  EpdFontFamily family(fresh->fonts[binfont::kVariantRegular].get(),
-                       fresh->fonts[binfont::kVariantBold].get(),
-                       fresh->fonts[binfont::kVariantItalic].get(),
-                       fresh->fonts[binfont::kVariantBoldItalic].get());
+  EpdFontFamily family(fresh->fonts[binfont::kVariantRegular].get(), fresh->fonts[binfont::kVariantBold].get(),
+                       fresh->fonts[binfont::kVariantItalic].get(), fresh->fonts[binfont::kVariantBoldItalic].get());
 
   clearActive();
   renderer_->insertFont(fresh->fontId, family);
@@ -346,7 +370,10 @@ size_t CustomBinFontManager::deleteFamily(const std::string& name) {
   if (active_ && active_->name == name) clearActive();
   const std::string dirPath = familyDir(name);
   auto dir = Storage.open(dirPath.c_str());
-  if (!dir || !dir.isDirectory()) { if (dir) dir.close(); return 0; }
+  if (!dir || !dir.isDirectory()) {
+    if (dir) dir.close();
+    return 0;
+  }
   size_t removed = 0;
   char entryName[256];
   for (auto e = dir.openNextFile(); e; e = dir.openNextFile()) {

--- a/src/fonts/CustomBinFontManager.cpp
+++ b/src/fonts/CustomBinFontManager.cpp
@@ -85,6 +85,12 @@ const char* variantPrefix(uint8_t v) {
   return v <= binfont::kVariantBoldItalic ? kTags[v].prefix : "regular_";
 }
 
+// Configured legal point-size range. Files outside this range get
+// auto-deleted by scan() so a firmware revision can't leave stale
+// files that the current build's picker won't offer.
+constexpr uint16_t kMinSizePt = 25;
+constexpr uint16_t kMaxSizePt = 40;
+
 bool parseVariantFile(const char* name, uint8_t& outVariant, uint16_t& outSize) {
   for (const auto& t : kTags) {
     const size_t pl = std::strlen(t.prefix);
@@ -94,10 +100,27 @@ bool parseVariantFile(const char* name, uint8_t& outVariant, uint16_t& outSize) 
     const long sz = std::strtol(rest, &end, 10);
     if (end == rest) return false;
     if (strcasecmp(end, ".bin") != 0) return false;
-    if (sz < 9 || sz > 16) return false;
+    if (sz < kMinSizePt || sz > kMaxSizePt) return false;
     outVariant = t.variant;
     outSize = static_cast<uint16_t>(sz);
     return true;
+  }
+  return false;
+}
+
+// Returns true when `name` looks like a variant file but its parsed
+// size sits outside [kMinSizePt, kMaxSizePt]. Used by scan() to
+// auto-delete leftover files from a wider-range firmware.
+bool isStaleSizeFile(const char* name) {
+  for (const auto& t : kTags) {
+    const size_t pl = std::strlen(t.prefix);
+    if (strncasecmp(name, t.prefix, pl) != 0) continue;
+    const char* rest = name + pl;
+    char* end = nullptr;
+    const long sz = std::strtol(rest, &end, 10);
+    if (end == rest) return false;
+    if (strcasecmp(end, ".bin") != 0) return false;
+    return sz < kMinSizePt || sz > kMaxSizePt;
   }
   return false;
 }
@@ -190,6 +213,16 @@ void CustomBinFontManager::scan() {
       const bool vfIsDir = vf.isDirectory();
       vf.close();
       if (vfIsDir) continue;
+      // Stale files from a previous, wider-range firmware are deleted
+      // here so the inventory only ever lists sizes the current build
+      // can actually render.
+      if (isStaleSizeFile(varName)) {
+        const std::string p = subDirPath + "/" + varName;
+        if (Storage.remove(p.c_str())) {
+          LOG_INF(kModule, "scan: deleted out-of-range %s", p.c_str());
+        }
+        continue;
+      }
       uint8_t variant; uint16_t sizePt;
       if (!parseVariantFile(varName, variant, sizePt)) continue;
       insertVariant(fam.sizes, variant, sizePt);
@@ -272,23 +305,19 @@ bool CustomBinFontManager::activate(const std::string& name, uint16_t sizePt) {
 
   if (!openSlot(binfont::kVariantRegular)) return false;
   openSlot(binfont::kVariantBold);
-  // Italic + BoldItalic intentionally NOT loaded into heap. With four
-  // variants resident, the resulting fragmentation starves the ZIP
-  // inflator (which needs ~32 KB contiguous) during EPUB section
-  // layout — observed as `Failed to allocate memory for inflator`
-  // followed by an OOM panic on page-turn. Italic glyphs synthesise
-  // via the renderer's existing shear path; users still get a
-  // visible difference between regular and italic text without the
-  // heap cost.
+  openSlot(binfont::kVariantItalic);
+  openSlot(binfont::kVariantBoldItalic);
 
   if (!fresh->fonts[binfont::kVariantRegular]) return false;
 
+  // SD-streamed loaders only hold a few KB of tables in heap each,
+  // so the four-variant load is back to being the default. Bold +
+  // italic + boldItalic uploaded by the browser display verbatim;
+  // missing slots fall back via EpdFontFamily::getFont.
   EpdFontFamily family(fresh->fonts[binfont::kVariantRegular].get(),
                        fresh->fonts[binfont::kVariantBold].get(),
-                       /*italic=*/nullptr, /*boldItalic=*/nullptr,
-                       /*syntheticRegularBoldPasses=*/0,
-                       /*syntheticBoldExtraPasses=*/0,
-                       /*syntheticItalic=*/true);
+                       fresh->fonts[binfont::kVariantItalic].get(),
+                       fresh->fonts[binfont::kVariantBoldItalic].get());
 
   clearActive();
   renderer_->insertFont(fresh->fontId, family);

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -1726,8 +1726,8 @@ void CrossPointWebServer::handleUploadFont(FontUploadState& state) {
       return;
     }
     const long sz = sizeStr.toInt();
-    if (sz < 9 || sz > 16) {
-      state.error = "size must be 9..16";
+    if (sz < 25 || sz > 40) {
+      state.error = "size must be 25..40";
       return;
     }
     state.family = family;
@@ -1848,8 +1848,8 @@ void CrossPointWebServer::handleDeleteFont() {
   size_t removed = 0;
   if (server->hasArg("size")) {
     const long sz = server->arg("size").toInt();
-    if (sz < 9 || sz > 16) {
-      server->send(400, "application/json", "{\"ok\":false,\"error\":\"size must be 9..16\"}");
+    if (sz < 25 || sz > 40) {
+      server->send(400, "application/json", "{\"ok\":false,\"error\":\"size must be 25..40\"}");
       return;
     }
     removed = mgr.deleteFamilySize(familyStd, static_cast<uint16_t>(sz));

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -2,6 +2,8 @@
 
 #include <ArduinoJson.h>
 #include <BookFingerprint.h>
+#include <EpdBinFontLoader.h>
+#include <EpdBinFormat.h>
 #include <Epub.h>
 #include <FsHelpers.h>
 #include <HalStorage.h>
@@ -15,15 +17,12 @@
 #include <functional>
 #include <memory>
 
-#include <EpdBinFontLoader.h>
-#include <EpdBinFormat.h>
-
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
 #include "Paths.h"
-#include "fonts/CustomBinFontManager.h"
 #include "RecentBooksStore.h"
 #include "SettingsList.h"
+#include "fonts/CustomBinFontManager.h"
 #if __has_include("WebDAVHandler.h")
 #include "WebDAVHandler.h"
 #define CROSSPOINT_HAS_WEBDAV 1
@@ -1649,10 +1648,14 @@ uint8_t parseVariantTag(const String& v) {
 
 const char* variantTagFor(uint8_t v) {
   switch (v) {
-    case 0: return "regular";
-    case 1: return "bold";
-    case 2: return "italic";
-    case 3: return "bolditalic";
+    case 0:
+      return "regular";
+    case 1:
+      return "bold";
+    case 2:
+      return "italic";
+    case 3:
+      return "bolditalic";
   }
   return "regular";
 }

--- a/src/network/html/FontsPage.html
+++ b/src/network/html/FontsPage.html
@@ -184,9 +184,10 @@
       <div class="help">
         Drop a TTF or OTF for each variant you want. Only <b>Regular</b> is
         required — Bold, Italic and Bold&nbsp;Italic are synthesised from
-        Regular when you leave them empty. Choose one or more sizes (9–16 pt);
+        Regular when you leave them empty. Choose one or more sizes (25–40 pt);
         the browser rasterises every glyph in the font at each size, compresses
-        the output and streams it to the device.
+        the output and streams it to the device. The device reads glyphs from
+        the SD card on demand, so even big sizes don't pin RAM.
       </div>
       <div class="field">
         <label for="family-name">Family name</label>
@@ -271,7 +272,12 @@
   const CPBN_VERSION = 1;
   const BPP = 2;
   const MAX_GROUP_UNCOMPRESSED = 4096; // ~4 KB per DEFLATE group (matches built-in)
-  const SIZES = [9, 10, 11, 12, 13, 14, 15, 16];
+  // Reader-comfortable pt range. Calibrated empirically against the
+  // built-in fonts: a contemporary serif/sans-serif at 25 pt reads
+  // similar to the built-in ChareInk 12. C++ side validates the same
+  // bounds in CustomBinFontManager and the upload handler; anything
+  // outside 25..40 is rejected before it lands on SD.
+  const SIZES = [25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40];
 
   const files = [null, null, null, null]; // per-variant parsed opentype.Font
   const fileNames = ["", "", "", ""];

--- a/src/network/ws/WsUploadSession.h
+++ b/src/network/ws/WsUploadSession.h
@@ -60,7 +60,7 @@ class WsUploadSession {
   // eventually releases the SD file descriptor. User-facing session
   // stays up regardless.
   static constexpr uint32_t kIdleTimeoutMs = 10u * 60u * 1000u;  // 10 minutes
-  static constexpr size_t kProgressIntervalBytes = 65536;  // 64 KiB
+  static constexpr size_t kProgressIntervalBytes = 65536;        // 64 KiB
   static constexpr uint8_t kNoClient = 255;
 
   explicit WsUploadSession(WsUploadDeps deps);


### PR DESCRIPTION
## Summary

- Switches the SD-backed custom-font loader from \"load entire file into heap\" to streaming: only the small fixed tables stay in RAM (a few KB per variant), the DEFLATE bitmap blob lives on SD and groups are pread'd on demand. Eliminates the heap-fragmentation crash that bit page-turn marathons under the previous design.
- Restores the four-variant load (Regular + Bold + Italic + BoldItalic) now that the heap can take it. Previously had to drop italic + boldItalic to keep the ZIP inflator happy during EPUB layout.
- Replaces the web UI's pt-size grid: was 9–16, now **25–40**. Calibrated empirically — a typical contemporary serif/sans at 25 pt reads similar to the built-in ChareInk 12.
- Auto-deletes any \`/custom-font/<family>/<variant>_<n>.bin\` whose \`n\` falls outside the active range on scan, so firmware revisions with different ranges can't leave stale files behind.

## Why streaming

Previous design loaded each variant file (~7–25 KB, more at big sizes) into a contiguous heap allocation. Four variants × 25 KB = 100 KB of heap fragmented into 4 chunks — the EPUB layout's ZIP inflator can't allocate its 32 KB contiguous block, so the device crashed on page-turn. Observed in the wild as \`Failed to allocate memory for inflator\` followed by \`abort()\` and a reboot loop.

New shape: \`EpdFontData\` gains an optional \`readBitmapBytes\` callback. \`FontDecompressor\` uses it when set (SD-backed) and falls back to direct pointer dereference when null (built-in PROGMEM). The \`EpdBinFontLoader\` keeps its \`HalFile\` open for its lifetime and \`pread\`s the compressed group bytes from disk per decompress request. Per-variant heap drops from ~25 KB to ~2 KB regardless of font size, so 30 pt fonts cost no more RAM than 14 pt did.

## Files touched

- \`lib/EpdFont/EpdFontData.h\` — add \`bitmapCtx\` + \`readBitmapBytes\` callback
- \`lib/EpdFont/FontDecompressor.{h,cpp}\` — use callback when set; reusable scratch buffer for SD reads
- \`lib/EpdFont/EpdBinFontLoader.{h,cpp}\` — stream from SD; tables-only heap; persistent open file
- \`src/fonts/CustomBinFontManager.cpp\` — re-enable four-variant load; bump \`kMinSizePt\`/\`kMaxSizePt\`; auto-delete out-of-range files on scan
- \`src/network/CrossPointWebServer.cpp\` — upload endpoint validates 25..40
- \`src/network/html/FontsPage.html\` — \`SIZES\` array 25..40; help text updated

## Test plan

- [x] Build clean on \`debug\` env
- [x] Flash to hardware; boot reaches Home with healthy heap baseline
- [x] Web UI grid renders 16 checkboxes (25..40)
- [x] Install a font (PlayfairDisplay 30 pt verified) — all four variants land
- [x] Reader picks \`C: <family>\` and renders text
- [x] Page turns + chapter jumps survive a marathon read (previously crashed after dozens of pages)
- [ ] Verify auto-delete on scan: install a font at one range, downgrade firmware to a different range, confirm out-of-range files removed on next boot
- [ ] Verify upload endpoint rejects size=10 with HTTP 400 \`size must be 25..40\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)