### PR TITLE
feat(web/settings): port brutalist 8-bit design to SettingsPage

### DIFF
--- a/src/network/html/SettingsPage.html
+++ b/src/network/html/SettingsPage.html
@@ -1,457 +1,434 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CrossPoint Reader - Settings</title>
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-        Oxygen, Ubuntu, sans-serif;
-      max-width: 800px;
-      margin: 0 auto;
-      padding: 20px;
-      background-color: #f5f5f5;
-      color: #333;
-    }
-    h1 {
-      color: #2c3e50;
-      border-bottom: 2px solid #3498db;
-      padding-bottom: 10px;
-    }
-    h2 {
-      color: #34495e;
-      margin-top: 0;
-    }
-    .card {
-      background: white;
-      border-radius: 8px;
-      padding: 20px;
-      margin: 15px 0;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    }
-    .nav-links {
-      margin: 20px 0;
-    }
-    .nav-links a {
-      display: inline-block;
-      padding: 10px 20px;
-      background-color: #3498db;
-      color: white;
-      text-decoration: none;
-      border-radius: 4px;
-      margin-right: 10px;
-    }
-    .nav-links a:hover {
-      background-color: #2980b9;
-    }
-    .setting-row {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 10px 0;
-      border-bottom: 1px solid #eee;
-    }
-    .setting-row:last-child {
-      border-bottom: none;
-    }
-    .setting-name {
-      font-weight: 500;
-      color: #2c3e50;
-      flex: 1;
-      min-width: 0;
-      padding-right: 12px;
-    }
-    .setting-control {
-      flex-shrink: 0;
-    }
-    .setting-control select,
-    .setting-control input[type="number"],
-    .setting-control input[type="text"],
-    .setting-control input[type="password"] {
-      padding: 6px 10px;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      font-size: 0.95em;
-      background: white;
-    }
-    .setting-control select {
-      min-width: 160px;
-    }
-    .setting-control input[type="text"],
-    .setting-control input[type="password"] {
-      width: 220px;
-    }
-    .setting-control input[type="number"] {
-      width: 80px;
-    }
-    /* Toggle switch */
-    .toggle-switch {
-      display: inline-block;
-      position: relative;
-      width: 48px;
-      height: 26px;
-    }
-    .toggle-switch input {
-      opacity: 0;
-      width: 0;
-      height: 0;
-    }
-    .toggle-slider {
-      position: absolute;
-      cursor: pointer;
-      top: 0; left: 0; right: 0; bottom: 0;
-      background-color: #ccc;
-      border-radius: 26px;
-      transition: 0.3s;
-    }
-    .toggle-slider:before {
-      position: absolute;
-      content: "";
-      height: 20px;
-      width: 20px;
-      left: 3px;
-      bottom: 3px;
-      background-color: white;
-      border-radius: 50%;
-      transition: 0.3s;
-    }
-    .toggle-switch input:checked + .toggle-slider {
-      background-color: #27ae60;
-    }
-    .toggle-switch input:checked + .toggle-slider:before {
-      transform: translateX(22px);
-    }
-    .save-container {
-      text-align: center;
-      margin: 20px 0;
-    }
-    .save-btn {
-      background-color: #27ae60;
-      color: white;
-      padding: 12px 40px;
-      border: none;
-      border-radius: 4px;
-      cursor: pointer;
-      font-size: 1.1em;
-      font-weight: 600;
-    }
-    .save-btn:hover {
-      background-color: #219a52;
-    }
-    .save-btn:disabled {
-      background-color: #95a5a6;
-      cursor: not-allowed;
-    }
-    .message {
-      padding: 12px;
-      border-radius: 4px;
-      margin: 15px 0;
-      text-align: center;
-      display: none;
-    }
-    .message.success {
-      background-color: #d4edda;
-      color: #155724;
-      border: 1px solid #c3e6cb;
-    }
-    .message.error {
-      background-color: #f8d7da;
-      color: #721c24;
-      border: 1px solid #f5c6cb;
-    }
-    .loader-container {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      margin: 20px 0;
-    }
-    .loader {
-      width: 48px;
-      height: 48px;
-      border: 5px solid #AAA;
-      border-bottom-color: transparent;
-      border-radius: 50%;
-      display: inline-block;
-      box-sizing: border-box;
-      animation: rotation 1s linear infinite;
-    }
-    @keyframes rotation {
-      from { transform: rotate(0deg); }
-      to { transform: rotate(360deg); }
-    }
-    @media (max-width: 600px) {
-      body {
-        padding: 10px;
-        font-size: 14px;
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#0d0d10" />
+    <title>CrossPoint Reader · Settings</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/css/brutalist.css" />
+    <style>
+      /* Page-specific layout. Tokens, reset, .wrap, nav.nav, .foot, and
+         small-screen / reduced-motion rules live in /css/brutalist.css. */
+
+      /* ── Masthead ───────────────────────────────────────────── */
+      .mast {
+        border: 1px dashed var(--dash);
+        padding: var(--pad);
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: var(--pad);
       }
+      @media (min-width: 760px) {
+        .mast { grid-template-columns: 1fr 1fr; }
+        .mast .rt {
+          border-left: 1px dashed var(--dash);
+          padding-left: var(--pad);
+          display: flex;
+          align-items: center;
+        }
+      }
+      .mast h1 {
+        margin: 0;
+        font-weight: 700;
+        font-size: clamp(36px, 9vw, 72px);
+        line-height: 0.9;
+        letter-spacing: -0.04em;
+        text-transform: uppercase;
+      }
+      .mast h1 em { font-style: normal; color: var(--yellow); }
+      .mast .sub {
+        margin-top: 10px;
+        font-size: 11px;
+        letter-spacing: 0.28em;
+        color: var(--muted);
+        text-transform: uppercase;
+      }
+      .mast .meta {
+        font-size: 11px;
+        letter-spacing: 0.24em;
+        color: var(--muted);
+        text-transform: uppercase;
+      }
+      .mast .meta b { color: var(--green); font-weight: 700; }
+
+      /* ── Category card ──────────────────────────────────────── */
       .card {
-        padding: 12px;
-        margin: 10px 0;
+        margin-top: var(--gap);
+        border: 1px dashed var(--dash);
+        padding: var(--pad);
+        background: rgba(255, 255, 255, 0.02);
       }
-      h1 {
-        font-size: 1.3em;
+      .card h2 {
+        margin: 0 0 14px 0;
+        font-size: 11px;
+        letter-spacing: 0.3em;
+        color: var(--muted);
+        text-transform: uppercase;
+        font-weight: 400;
+        border-bottom: 1px dashed rgba(255, 255, 255, 0.15);
+        padding-bottom: 10px;
       }
-      .nav-links a {
-        padding: 8px 12px;
-        margin-right: 6px;
-        font-size: 0.9em;
-      }
+
+      /* ── Setting row ────────────────────────────────────────── */
       .setting-row {
-        flex-wrap: wrap;
-        gap: 6px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 12px 0;
+        border-bottom: 1px dashed rgba(255, 255, 255, 0.12);
+        gap: 14px;
       }
+      .setting-row:last-child { border-bottom: none; }
+      .setting-name {
+        flex: 1;
+        min-width: 0;
+        font-size: 13px;
+        letter-spacing: 0.04em;
+        overflow-wrap: anywhere;
+      }
+      .setting-control { flex-shrink: 0; }
+
+      /* ── Form controls ──────────────────────────────────────── */
       .setting-control select,
+      .setting-control input[type="number"],
       .setting-control input[type="text"],
       .setting-control input[type="password"] {
-        min-width: 0;
-        width: 100%;
+        background: var(--bg);
+        color: var(--fg);
+        border: 1px dashed var(--dash);
+        padding: 8px 10px;
+        font-family: inherit;
+        font-size: 13px;
+        letter-spacing: 0.02em;
+        outline: none;
       }
-    }
+      .setting-control select { min-width: 160px; }
+      .setting-control input[type="text"],
+      .setting-control input[type="password"] { width: 220px; max-width: 100%; }
+      .setting-control input[type="number"] { width: 90px; }
+      .setting-control select:focus,
+      .setting-control input:focus { border-color: var(--yellow); }
 
-    /* Dashed-border restyle — shared across Home/Files/Settings. */
-    :root {
-      --acc-upload:  #27ae60;
-      --acc-folder:  #f39c12;
-      --acc-danger:  #c0392b;
-      --acc-primary: #2980b9;
-      --acc-teal:    #16a085;
-      --acc-neutral: #555;
-    }
-    button, .nav-links a, .save-btn, .action-btn {
-      background: #fff !important;
-      color: #000 !important;
-      border: 2px dashed var(--btn-acc, var(--acc-primary)) !important;
-      box-shadow: none !important;
-      text-shadow: none !important;
-    }
-    .save-btn { --btn-acc: var(--acc-upload); }
-    button:hover, .nav-links a:hover, .save-btn:hover, .action-btn:hover {
-      background: #f2f2f2 !important;
-      color: #000 !important;
-    }
-    input[type=text], input[type=password], input[type=number],
-    input[type=search], input[type=email], input[type=url],
-    select, textarea {
-      background: #fff !important;
-      color: #000 !important;
-      border: 2px dashed var(--acc-neutral) !important;
-      box-shadow: none !important;
-    }
-    input[type=text]:focus, input[type=password]:focus,
-    input[type=number]:focus, input[type=search]:focus,
-    input[type=email]:focus, input[type=url]:focus,
-    select:focus, textarea:focus {
-      outline: none;
-      border-color: var(--acc-primary) !important;
-    }
-    .card {
-      background: #fff !important;
-      color: #000 !important;
-      border: 2px dashed #333 !important;
-      box-shadow: none !important;
-    }
-  </style>
-</head>
-<body>
-  <h1>⚙️ Settings</h1>
+      /* ── Toggle switch ──────────────────────────────────────── */
+      .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 56px;
+        height: 28px;
+      }
+      .toggle-switch input { opacity: 0; width: 0; height: 0; }
+      .toggle-slider {
+        position: absolute;
+        inset: 0;
+        background: transparent;
+        border: 1px dashed var(--dash);
+        cursor: pointer;
+        transition: background 0.15s;
+      }
+      .toggle-slider::before {
+        content: "";
+        position: absolute;
+        top: 3px;
+        left: 3px;
+        width: 20px;
+        height: 20px;
+        background: var(--muted);
+        transition: transform 0.15s, background 0.15s;
+      }
+      .toggle-switch input:checked + .toggle-slider { background: var(--yellow); }
+      .toggle-switch input:checked + .toggle-slider::before {
+        transform: translateX(28px);
+        background: var(--bg);
+      }
 
-  <div class="nav-links">
-    <a href="/">Home</a>
-    <a href="/files">File Manager</a>
-    <a href="/settings">Settings</a>
-  </div>
+      /* ── Save button ────────────────────────────────────────── */
+      .save-container {
+        margin-top: var(--gap);
+        text-align: center;
+      }
+      .save-btn {
+        background: transparent;
+        color: var(--fg);
+        border: 1px dashed var(--dash);
+        padding: 16px 40px;
+        font-family: inherit;
+        font-size: 13px;
+        font-weight: 700;
+        letter-spacing: 0.28em;
+        text-transform: uppercase;
+        cursor: pointer;
+        min-height: 56px;
+        min-width: 220px;
+      }
+      .save-btn:hover:not(:disabled) {
+        background: var(--yellow);
+        color: #000;
+      }
+      .save-btn:disabled {
+        opacity: 0.35;
+        cursor: not-allowed;
+      }
 
-  <div id="message" class="message"></div>
+      /* ── Message banner ─────────────────────────────────────── */
+      .message {
+        margin-top: var(--gap);
+        padding: 12px var(--pad);
+        border: 1px dashed var(--dash);
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        display: none;
+        text-align: center;
+      }
+      .message.success { border-color: var(--green); color: var(--green); }
+      .message.error { border-color: var(--red); color: var(--red); }
 
-  <div id="settings-container">
-    <div class="loader-container">
-      <span class="loader"></span>
+      /* ── Loader ─────────────────────────────────────────────── */
+      .loader-container {
+        display: flex;
+        justify-content: center;
+        padding: 40px 0;
+      }
+      .loader {
+        width: 32px;
+        height: 32px;
+        border: 2px dashed var(--dash);
+        border-bottom-color: transparent;
+        border-radius: 50%;
+        animation: rotation 1s linear infinite;
+      }
+      @keyframes rotation {
+        to { transform: rotate(360deg); }
+      }
+
+      @media (max-width: 600px) {
+        .setting-row { flex-wrap: wrap; }
+        .setting-control { width: 100%; }
+        .setting-control select,
+        .setting-control input[type="text"],
+        .setting-control input[type="password"],
+        .setting-control input[type="number"] { width: 100%; min-width: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <!-- Masthead -->
+      <header class="mast">
+        <div class="lt">
+          <h1>SET<br /><em>TINGS</em></h1>
+          <div class="sub">CrossPoint · Web UI · /api/settings</div>
+        </div>
+        <div class="rt">
+          <div class="meta">Live config &middot; <b>persisted</b> on save</div>
+        </div>
+      </header>
+
+      <!-- Nav -->
+      <nav class="nav" aria-label="Primary">
+        <a href="/"><span class="k">[1]</span>HOME</a>
+        <a href="/files"><span class="k">[2]</span>FILES</a>
+        <a href="/settings" class="on"><span class="k">[3]</span>SETTINGS</a>
+      </nav>
+
+      <!-- Status banner (success/error) -->
+      <div id="message" class="message"></div>
+
+      <!-- Settings cards (filled by JS) -->
+      <div id="settings-container">
+        <div class="loader-container">
+          <span class="loader" aria-hidden="true"></span>
+        </div>
+      </div>
+
+      <!-- Save -->
+      <div class="save-container" id="save-container" style="display: none;">
+        <button class="save-btn" id="saveBtn" onclick="saveSettings()">SAVE SETTINGS</button>
+      </div>
+
+      <!-- Footer -->
+      <footer class="foot">
+        <span><b>Host</b> crosspoint.local</span>
+        <span><b>Endpoint</b> /api/settings</span>
+        <span class="heart">&bull; Open-source &middot; MIT</span>
+      </footer>
     </div>
-  </div>
 
-  <div class="save-container" id="save-container" style="display:none;">
-    <button class="save-btn" id="saveBtn" onclick="saveSettings()">Save Settings</button>
-  </div>
+    <script>
+      let allSettings = [];
+      let originalValues = {};
 
-  <div class="card">
-    <p style="text-align: center; color: #95a5a6; margin: 0;">
-      CrossPoint E-Reader • Open Source
-    </p>
-  </div>
-
-<script>
-  let allSettings = [];
-  let originalValues = {};
-
-  function escapeHtml(unsafe) {
-    return unsafe
-      .replaceAll("&", "&amp;")
-      .replaceAll("<", "&lt;")
-      .replaceAll(">", "&gt;")
-      .replaceAll('"', "&quot;")
-      .replaceAll("'", "&#039;");
-  }
-
-  function showMessage(text, isError) {
-    const msg = document.getElementById('message');
-    msg.textContent = text;
-    msg.className = 'message ' + (isError ? 'error' : 'success');
-    msg.style.display = 'block';
-    setTimeout(function() { msg.style.display = 'none'; }, 4000);
-  }
-
-  function renderControl(setting) {
-    const id = 'setting-' + setting.key;
-
-    if (setting.type === 'toggle') {
-      const checked = setting.value ? 'checked' : '';
-      return '<label class="toggle-switch">' +
-        '<input type="checkbox" id="' + id + '" ' + checked + ' onchange="markChanged()">' +
-        '<span class="toggle-slider"></span></label>';
-    }
-
-    if (setting.type === 'enum') {
-      let html = '<select id="' + id + '" onchange="markChanged()">';
-      setting.options.forEach(function(opt, idx) {
-        const selected = idx === setting.value ? ' selected' : '';
-        html += '<option value="' + idx + '"' + selected + '>' + escapeHtml(opt) + '</option>';
-      });
-      html += '</select>';
-      return html;
-    }
-
-    if (setting.type === 'value') {
-      return '<input type="number" id="' + id + '" value="' + setting.value + '"' +
-        ' min="' + setting.min + '" max="' + setting.max + '" step="' + setting.step + '"' +
-        ' onchange="markChanged()">';
-    }
-
-    if (setting.type === 'string') {
-      const inputType = setting.name.toLowerCase().includes('password') ? 'password' : 'text';
-      const val = setting.value || '';
-      return '<input type="' + inputType + '" id="' + id + '" value="' + escapeHtml(val) + '"' +
-        ' oninput="markChanged()">';
-    }
-
-    return '';
-  }
-
-  function getValue(setting) {
-    const el = document.getElementById('setting-' + setting.key);
-    if (!el) return undefined;
-
-    if (setting.type === 'toggle') {
-      return el.checked ? 1 : 0;
-    }
-    if (setting.type === 'enum') {
-      return parseInt(el.value, 10);
-    }
-    if (setting.type === 'value') {
-      return parseInt(el.value, 10);
-    }
-    if (setting.type === 'string') {
-      return el.value;
-    }
-    return undefined;
-  }
-
-  function markChanged() {
-    document.getElementById('saveBtn').disabled = false;
-  }
-
-  async function loadSettings() {
-    try {
-      const response = await fetch('/api/settings');
-      if (!response.ok) {
-        throw new Error('Failed to load settings: ' + response.status);
+      function escapeHtml(unsafe) {
+        return unsafe
+          .replaceAll("&", "&amp;")
+          .replaceAll("<", "&lt;")
+          .replaceAll(">", "&gt;")
+          .replaceAll('"', "&quot;")
+          .replaceAll("'", "&#039;");
       }
-      allSettings = await response.json();
 
-      // Store original values
-      originalValues = {};
-      allSettings.forEach(function(s) {
-        originalValues[s.key] = s.value;
-      });
+      function showMessage(text, isError) {
+        const msg = document.getElementById("message");
+        msg.textContent = text;
+        msg.className = "message " + (isError ? "error" : "success");
+        msg.style.display = "block";
+        setTimeout(function () {
+          msg.style.display = "none";
+        }, 4000);
+      }
 
-      // Group by category
-      const groups = {};
-      allSettings.forEach(function(s) {
-        if (!groups[s.category]) groups[s.category] = [];
-        groups[s.category].push(s);
-      });
+      function renderControl(setting) {
+        const id = "setting-" + setting.key;
 
-      const container = document.getElementById('settings-container');
-      let html = '';
+        if (setting.type === "toggle") {
+          const checked = setting.value ? "checked" : "";
+          return (
+            '<label class="toggle-switch">' +
+            '<input type="checkbox" id="' + id + '" ' + checked + ' onchange="markChanged()">' +
+            '<span class="toggle-slider"></span></label>'
+          );
+        }
 
-      for (const category in groups) {
-        html += '<div class="card"><h2>' + escapeHtml(category) + '</h2>';
-        groups[category].forEach(function(s) {
-          html += '<div class="setting-row">' +
-            '<span class="setting-name">' + escapeHtml(s.name) + '</span>' +
-            '<span class="setting-control">' + renderControl(s) + '</span>' +
-            '</div>';
+        if (setting.type === "enum") {
+          let html = '<select id="' + id + '" onchange="markChanged()">';
+          setting.options.forEach(function (opt, idx) {
+            const selected = idx === setting.value ? " selected" : "";
+            html += '<option value="' + idx + '"' + selected + ">" + escapeHtml(opt) + "</option>";
+          });
+          html += "</select>";
+          return html;
+        }
+
+        if (setting.type === "value") {
+          return (
+            '<input type="number" id="' + id + '" value="' + setting.value + '"' +
+            ' min="' + setting.min + '" max="' + setting.max + '" step="' + setting.step + '"' +
+            ' onchange="markChanged()">'
+          );
+        }
+
+        if (setting.type === "string") {
+          const inputType = setting.name.toLowerCase().includes("password") ? "password" : "text";
+          const val = setting.value || "";
+          return (
+            '<input type="' + inputType + '" id="' + id + '" value="' + escapeHtml(val) + '"' +
+            ' oninput="markChanged()">'
+          );
+        }
+
+        return "";
+      }
+
+      function getValue(setting) {
+        const el = document.getElementById("setting-" + setting.key);
+        if (!el) return undefined;
+
+        if (setting.type === "toggle") return el.checked ? 1 : 0;
+        if (setting.type === "enum") return parseInt(el.value, 10);
+        if (setting.type === "value") return parseInt(el.value, 10);
+        if (setting.type === "string") return el.value;
+        return undefined;
+      }
+
+      function markChanged() {
+        document.getElementById("saveBtn").disabled = false;
+      }
+
+      async function loadSettings() {
+        try {
+          const response = await fetch("/api/settings");
+          if (!response.ok) {
+            throw new Error("Failed to load settings: " + response.status);
+          }
+          allSettings = await response.json();
+
+          originalValues = {};
+          allSettings.forEach(function (s) {
+            originalValues[s.key] = s.value;
+          });
+
+          const groups = {};
+          allSettings.forEach(function (s) {
+            if (!groups[s.category]) groups[s.category] = [];
+            groups[s.category].push(s);
+          });
+
+          const container = document.getElementById("settings-container");
+          let html = "";
+
+          for (const category in groups) {
+            html += '<div class="card"><h2>' + escapeHtml(category) + "</h2>";
+            groups[category].forEach(function (s) {
+              html +=
+                '<div class="setting-row">' +
+                '<span class="setting-name">' + escapeHtml(s.name) + "</span>" +
+                '<span class="setting-control">' + renderControl(s) + "</span>" +
+                "</div>";
+            });
+            html += "</div>";
+          }
+
+          container.innerHTML = html;
+          document.getElementById("save-container").style.display = "";
+          document.getElementById("saveBtn").disabled = true;
+        } catch (e) {
+          console.error(e);
+          document.getElementById("settings-container").innerHTML =
+            '<div class="card"><p style="text-align:center;color:var(--red);letter-spacing:.18em;text-transform:uppercase;font-size:11px;">Failed to load settings</p></div>';
+        }
+      }
+
+      async function saveSettings() {
+        const btn = document.getElementById("saveBtn");
+        btn.disabled = true;
+        btn.textContent = "SAVING...";
+
+        const changes = {};
+        allSettings.forEach(function (s) {
+          const current = getValue(s);
+          if (current !== undefined && current !== originalValues[s.key]) {
+            changes[s.key] = current;
+          }
         });
-        html += '</div>';
+
+        if (Object.keys(changes).length === 0) {
+          showMessage("No changes to save.", false);
+          btn.textContent = "SAVE SETTINGS";
+          return;
+        }
+
+        try {
+          const response = await fetch("/api/settings", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(changes),
+          });
+
+          if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || "Save failed");
+          }
+
+          for (const key in changes) {
+            originalValues[key] = changes[key];
+          }
+
+          showMessage("Settings saved successfully!", false);
+        } catch (e) {
+          console.error(e);
+          showMessage("Error: " + e.message, true);
+        }
+
+        btn.textContent = "SAVE SETTINGS";
       }
 
-      container.innerHTML = html;
-      document.getElementById('save-container').style.display = '';
-      document.getElementById('saveBtn').disabled = true;
-    } catch (e) {
-      console.error(e);
-      document.getElementById('settings-container').innerHTML =
-        '<div class="card"><p style="text-align:center;color:#e74c3c;">Failed to load settings</p></div>';
-    }
-  }
-
-  async function saveSettings() {
-    const btn = document.getElementById('saveBtn');
-    btn.disabled = true;
-    btn.textContent = 'Saving...';
-
-    // Collect only changed values
-    const changes = {};
-    allSettings.forEach(function(s) {
-      const current = getValue(s);
-      if (current !== undefined && current !== originalValues[s.key]) {
-        changes[s.key] = current;
-      }
-    });
-
-    if (Object.keys(changes).length === 0) {
-      showMessage('No changes to save.', false);
-      btn.textContent = 'Save Settings';
-      return;
-    }
-
-    try {
-      const response = await fetch('/api/settings', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(changes)
-      });
-
-      if (!response.ok) {
-        const text = await response.text();
-        throw new Error(text || 'Save failed');
-      }
-
-      // Update original values to new values
-      for (const key in changes) {
-        originalValues[key] = changes[key];
-      }
-
-      showMessage('Settings saved successfully!', false);
-    } catch (e) {
-      console.error(e);
-      showMessage('Error: ' + e.message, true);
-    }
-
-    btn.textContent = 'Save Settings';
-  }
-
-  loadSettings();
-</script>
-</body>
+      loadSettings();
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary

Phase 1 of the web UI redesign rollout (see [docs/web-redesign-plan.md](../blob/feat/web-redesign-plan/docs/web-redesign-plan.md) on #80).

Adopts \`/css/brutalist.css\` from #79 for shared chrome and replaces the light-theme card layout in \`SettingsPage.html\` with a brutalist masthead + nav + dashed category cards.

**Stacked on #79** — base branch is \`feat/web-brutalist-css\`. Will rebase as #76 → #79 → main lands.

## What changed

- Masthead with **SET / TINGS** wordmark and live-config sub-line.
- Primary nav matches HomePage \`[1][2][3]\` keyboard hints; SETTINGS slot carries the \`.on\` highlight.
- Each category renders as a dashed-border \`.card\` with an uppercased spaced label and dashed row dividers.
- Form controls (select, number/text/password input, toggle switch) restyled to the brutalist palette: dark bg, dashed borders, yellow focus + yellow toggle-on state. The toggle slider thumb darkens to bg colour when checked so it reads inverted on the yellow track.
- Save button is a 56 px tap-target dashed button that fills yellow on hover; disabled state dims to 35 % opacity.
- Success / error messages reuse the dashed banner pattern with green / red border + text colours.
- **All JS is unchanged** — same \`/api/settings\` GET, same change tracking, same POST shape. Only DOM structure + CSS swapped, plus button label uppercase and saving-state copy.

## Size impact

| Asset | Before (gzip) | After (gzip) |
| --- | --- | --- |
| SettingsPage.html | 3423 B | 3650 B |
| brutalist.css | 1619 B | 1619 B (reused, no extra cost) |
| **Net flash on this PR** | — | **+227 B** |

## Verification

- \`pio run -e debug\` — clean build.
- No device test yet — will batch with #76 / #79 device-test session.

## Test plan

- [ ] Flash, open \`http://crosspoint.local/settings\`
- [ ] Confirm masthead, nav, and category cards render in dark brutalist style
- [ ] Toggle a boolean setting — confirm slider animates to yellow with bg-colour thumb
- [ ] Change a numeric / text / enum value — confirm save button enables and the value persists across reload
- [ ] Confirm success message appears for 4 s in green
- [ ] Force a save error (e.g. send invalid payload) — confirm red error banner
- [ ] Resize to phone (375 px) — confirm rows stack and inputs go full-width

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)