### PR TITLE
feat(web/files): port brutalist 8-bit design to FilesPage modals (3b)

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1670,6 +1670,439 @@
     @media (max-width: 380px) {
       .nav-links a { padding: 14px 10px !important; font-size: 13px !important; }
     }
+
+    /* ── Phase 3b: modals ──────────────────────────────────── */
+    .modal-overlay {
+      background: rgba(0, 0, 0, 0.78) !important;
+    }
+    .modal {
+      background: var(--bg) !important;
+      color: var(--fg) !important;
+      border: 1px dashed var(--dash) !important;
+      border-radius: 0 !important;
+      box-shadow: none !important;
+      padding: var(--pad) !important;
+    }
+    .modal h3 {
+      margin: 0 0 14px 0 !important;
+      color: var(--fg) !important;
+      font-size: 11px !important;
+      letter-spacing: 0.3em !important;
+      text-transform: uppercase !important;
+      font-weight: 400 !important;
+      border-bottom: 1px dashed rgba(255, 255, 255, 0.15) !important;
+      padding-bottom: 10px !important;
+    }
+    .modal-close {
+      background: transparent !important;
+      color: var(--muted) !important;
+      border: 1px dashed var(--dash) !important;
+      border-radius: 0 !important;
+      box-shadow: none !important;
+      width: 32px !important;
+      height: 32px !important;
+      padding: 0 !important;
+      font-size: 18px !important;
+      line-height: 1 !important;
+    }
+    .modal-close:hover {
+      background: var(--red) !important;
+      color: #000 !important;
+      border-color: var(--red) !important;
+    }
+
+    /* Modal text */
+    .modal .file-info,
+    .modal .modal-hint {
+      color: var(--muted) !important;
+      font-size: 11px !important;
+      letter-spacing: 0.06em;
+      line-height: 1.5;
+    }
+    .modal .file-info strong { color: var(--fg) !important; }
+    .modal .delete-warning {
+      color: var(--red) !important;
+      border: 1px dashed var(--red) !important;
+      padding: 10px var(--pad) !important;
+      font-size: 11px !important;
+      letter-spacing: 0.18em !important;
+      text-transform: uppercase !important;
+      margin: 10px 0 !important;
+    }
+
+    /* Modal text inputs */
+    .modal input[type="text"],
+    .modal input[type="number"],
+    .modal input[type="password"],
+    .modal .folder-input {
+      background: var(--bg) !important;
+      color: var(--fg) !important;
+      border: 1px dashed var(--dash) !important;
+      border-radius: 0 !important;
+      padding: 10px !important;
+      font-family: inherit !important;
+      font-size: 14px !important;
+      letter-spacing: 0.02em !important;
+      box-shadow: none !important;
+      width: 100% !important;
+      box-sizing: border-box;
+    }
+    .modal input[type="text"]:focus,
+    .modal input[type="number"]:focus,
+    .modal input[type="password"]:focus,
+    .modal .folder-input:focus {
+      outline: none !important;
+      border-color: var(--yellow) !important;
+    }
+
+    /* Modal file input */
+    .modal input[type="file"] {
+      background: var(--bg) !important;
+      color: var(--muted) !important;
+      border: 1px dashed var(--dash) !important;
+      border-radius: 0 !important;
+      padding: 10px !important;
+      font-family: inherit !important;
+      font-size: 11px !important;
+      box-shadow: none !important;
+      width: 100% !important;
+      box-sizing: border-box;
+    }
+    .modal input[type="file"]::file-selector-button {
+      background: transparent !important;
+      color: var(--fg) !important;
+      border: 1px dashed var(--dash) !important;
+      border-radius: 0 !important;
+      padding: 6px 12px !important;
+      font-family: inherit !important;
+      font-size: 11px !important;
+      letter-spacing: 0.18em !important;
+      text-transform: uppercase !important;
+      margin-right: 10px !important;
+      cursor: pointer;
+    }
+    .modal input[type="file"]::file-selector-button:hover {
+      background: var(--blue) !important;
+      color: #000 !important;
+    }
+    .modal input[type="file"].has-files::file-selector-button {
+      border-color: var(--green) !important;
+      color: var(--green) !important;
+    }
+
+    /* Modal action buttons */
+    .modal .upload-btn,
+    .modal .folder-btn,
+    .modal .delete-btn-confirm,
+    .modal .rename-btn-confirm,
+    .modal .move-btn-confirm,
+    .modal .delete-btn-cancel {
+      background: transparent !important;
+      color: var(--fg) !important;
+      border: 1px dashed var(--dash) !important;
+      border-radius: 0 !important;
+      padding: 14px 28px !important;
+      font-family: inherit !important;
+      font-size: 12px !important;
+      font-weight: 700 !important;
+      letter-spacing: 0.24em !important;
+      text-transform: uppercase !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      min-height: 56px;
+      margin-top: 12px;
+    }
+    .modal .upload-btn:hover:not(:disabled),
+    .modal .folder-btn:hover:not(:disabled) {
+      background: var(--green) !important;
+      color: #000 !important;
+      border-color: var(--green) !important;
+    }
+    .modal .upload-btn.optimize:hover:not(:disabled) {
+      background: var(--blue) !important;
+      border-color: var(--blue) !important;
+    }
+    .modal .delete-btn-confirm:hover:not(:disabled),
+    .modal .rename-btn-confirm:hover:not(:disabled),
+    .modal .move-btn-confirm:hover:not(:disabled) {
+      background: var(--red) !important;
+      color: #000 !important;
+      border-color: var(--red) !important;
+    }
+    .modal .rename-btn-confirm:hover:not(:disabled),
+    .modal .move-btn-confirm:hover:not(:disabled) {
+      background: var(--yellow) !important;
+      border-color: var(--yellow) !important;
+    }
+    .modal .delete-btn-cancel:hover:not(:disabled) {
+      background: rgba(255, 255, 255, 0.05) !important;
+    }
+    .modal .upload-btn:disabled,
+    .modal .folder-btn:disabled,
+    .modal .delete-btn-confirm:disabled {
+      opacity: 0.35 !important;
+      cursor: not-allowed;
+      background: transparent !important;
+      color: var(--fg) !important;
+    }
+
+    /* Image preview modal action buttons (override inline bg-colors) */
+    #imagePreviewModal .action-btn {
+      background: transparent !important;
+      color: var(--fg) !important;
+      border: 1px dashed var(--dash) !important;
+      border-radius: 0 !important;
+      padding: 12px 18px !important;
+      letter-spacing: 0.2em !important;
+      text-transform: uppercase !important;
+    }
+    #imagePreviewModal .action-btn:hover { background: var(--yellow) !important; color: #000 !important; }
+    #imagePreviewModal img {
+      border: 1px dashed var(--dash) !important;
+      background: var(--bg) !important;
+      border-radius: 0 !important;
+    }
+
+    /* Convert options + advanced settings */
+    .modal .convert-options { color: var(--fg) !important; }
+    .modal .convert-row {
+      color: var(--muted);
+      letter-spacing: 0.06em;
+    }
+    .modal .convert-checkbox {
+      color: var(--fg) !important;
+      font-size: 12px !important;
+      letter-spacing: 0.06em !important;
+    }
+    .modal .convert-checkbox input[type="checkbox"] {
+      accent-color: var(--yellow);
+    }
+    .modal .convert-warning {
+      background: transparent !important;
+      border: 1px dashed var(--yellow) !important;
+      border-radius: 0 !important;
+      color: var(--yellow) !important;
+      padding: 12px var(--pad) !important;
+      font-size: 11px !important;
+      letter-spacing: 0.06em;
+      line-height: 1.5;
+    }
+    .modal .convert-info {
+      color: var(--muted) !important;
+      font-size: 11px !important;
+      letter-spacing: 0.04em;
+    }
+    .modal .convert-settings {
+      color: var(--muted) !important;
+      font-size: 11px !important;
+      letter-spacing: 0.06em;
+    }
+    .modal .convert-separator {
+      color: var(--muted) !important;
+    }
+    .modal .advanced-options-toggle {
+      color: var(--blue) !important;
+      letter-spacing: 0.16em !important;
+      text-transform: uppercase;
+      font-size: 11px;
+      cursor: pointer;
+    }
+    .modal .advanced-options-toggle:hover { color: var(--yellow) !important; }
+    .modal .advanced-options-arrow { color: var(--blue) !important; }
+    .modal .advanced-options-text { color: var(--blue) !important; }
+    .modal .advanced-settings-content {
+      border: 1px dashed rgba(255, 255, 255, 0.2) !important;
+      background: transparent !important;
+      border-radius: 0 !important;
+      padding: 12px !important;
+      margin-top: 10px;
+    }
+    .modal .advanced-setting-row {
+      border-bottom: 1px dashed rgba(255, 255, 255, 0.12) !important;
+      padding: 10px 0;
+    }
+    .modal .advanced-setting-row:last-child { border-bottom: none !important; }
+    .modal .setting-title,
+    .modal .setting-label .setting-title {
+      color: var(--fg) !important;
+      font-size: 11px !important;
+      letter-spacing: 0.18em !important;
+      text-transform: uppercase !important;
+      font-weight: 700;
+    }
+    .modal .setting-desc {
+      color: var(--muted) !important;
+      font-size: 10px !important;
+      letter-spacing: 0.08em;
+    }
+    .modal .setting-value {
+      color: var(--yellow) !important;
+      font-weight: 700;
+    }
+
+    /* Quality presets / rotation / overlap — chip-style toggle row */
+    .modal .quality-presets,
+    .modal .rotation-buttons,
+    .modal .overlap-selector {
+      display: flex !important;
+      flex-wrap: wrap;
+      gap: 6px !important;
+    }
+    .modal .quality-preset,
+    .modal .rotation-btn,
+    .modal .overlap-btn {
+      background: transparent !important;
+      color: var(--fg) !important;
+      border: 1px dashed var(--dash) !important;
+      border-radius: 0 !important;
+      padding: 8px 12px !important;
+      font-family: inherit !important;
+      font-size: 11px !important;
+      font-weight: 700 !important;
+      letter-spacing: 0.14em !important;
+      text-transform: uppercase !important;
+      box-shadow: none !important;
+      cursor: pointer;
+    }
+    .modal .quality-preset:hover:not(.active),
+    .modal .rotation-btn:hover:not(.active),
+    .modal .overlap-btn:hover:not(.active) {
+      background: rgba(255, 255, 255, 0.05) !important;
+    }
+    .modal .quality-preset.active,
+    .modal .rotation-btn.active,
+    .modal .overlap-btn.active {
+      background: var(--yellow) !important;
+      color: #000 !important;
+      border-color: var(--yellow) !important;
+    }
+
+    /* Toggle switch (within modals) */
+    .modal .toggle-switch {
+      position: relative !important;
+      display: inline-block !important;
+      width: 56px !important;
+      height: 28px !important;
+    }
+    .modal .toggle-switch input { opacity: 0 !important; width: 0 !important; height: 0 !important; }
+    .modal .toggle-slider {
+      position: absolute !important;
+      inset: 0 !important;
+      background: transparent !important;
+      border: 1px dashed var(--dash) !important;
+      border-radius: 0 !important;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .modal .toggle-slider:before {
+      content: "" !important;
+      position: absolute !important;
+      top: 3px !important;
+      left: 3px !important;
+      width: 20px !important;
+      height: 20px !important;
+      background: var(--muted) !important;
+      border-radius: 0 !important;
+      transition: transform 0.15s, background 0.15s;
+    }
+    .modal .toggle-switch input:checked + .toggle-slider {
+      background: var(--yellow) !important;
+    }
+    .modal .toggle-switch input:checked + .toggle-slider:before {
+      transform: translateX(28px) !important;
+      background: var(--bg) !important;
+    }
+
+    /* Image picker section */
+    .modal .image-picker-section {
+      border: 1px dashed rgba(255, 255, 255, 0.2) !important;
+      background: transparent !important;
+      border-radius: 0 !important;
+      padding: 10px !important;
+    }
+    .modal .image-picker-header {
+      color: var(--fg) !important;
+      border-bottom: 1px dashed rgba(255, 255, 255, 0.15) !important;
+      padding-bottom: 8px !important;
+    }
+    .modal .image-picker-title {
+      font-size: 11px !important;
+      letter-spacing: 0.18em !important;
+      text-transform: uppercase !important;
+    }
+    .modal .image-picker-count {
+      color: var(--muted) !important;
+      font-size: 10px !important;
+      letter-spacing: 0.18em !important;
+      text-transform: uppercase !important;
+    }
+    .modal .state-legend {
+      display: flex !important;
+      flex-wrap: wrap;
+      gap: 6px !important;
+      margin: 8px 0 !important;
+    }
+    .modal .legend-item,
+    .modal .legend-btn {
+      background: transparent !important;
+      color: var(--fg) !important;
+      border: 1px dashed var(--dash) !important;
+      border-radius: 0 !important;
+      padding: 6px 10px !important;
+      font-family: inherit !important;
+      font-size: 10px !important;
+      letter-spacing: 0.14em !important;
+      text-transform: uppercase !important;
+      box-shadow: none !important;
+    }
+    .modal .legend-btn:hover { background: rgba(255, 255, 255, 0.05) !important; }
+    .modal .legend-color { display: none !important; }
+
+    /* Progress bar (inside modal) */
+    .modal #progress-bar {
+      border: 1px dashed var(--dash) !important;
+      background: transparent !important;
+      border-radius: 0 !important;
+      height: 14px !important;
+      overflow: hidden;
+    }
+    .modal #progress-fill {
+      background: var(--blue) !important;
+      border-radius: 0 !important;
+    }
+    .modal #progress-text {
+      color: var(--muted) !important;
+      font-size: 10px !important;
+      letter-spacing: 0.18em !important;
+      text-transform: uppercase !important;
+      margin-top: 6px;
+    }
+
+    /* Conversion log section */
+    .modal .log-section {
+      border: 1px dashed rgba(255, 255, 255, 0.2) !important;
+      background: transparent !important;
+      border-radius: 0 !important;
+      margin-top: 10px;
+    }
+    .modal .log-header {
+      color: var(--fg) !important;
+      border-bottom: 1px dashed rgba(255, 255, 255, 0.15) !important;
+      padding: 8px var(--pad) !important;
+    }
+    .modal .log-title {
+      font-size: 11px !important;
+      letter-spacing: 0.18em !important;
+      text-transform: uppercase !important;
+    }
+    .modal .log-container {
+      background: rgba(0, 0, 0, 0.4) !important;
+      color: var(--fg) !important;
+      font-family: inherit !important;
+      font-size: 11px !important;
+      line-height: 1.5 !important;
+      padding: 10px var(--pad) !important;
+    }
   </style>
 </head>
 <body>

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1676,6 +1676,7 @@
       background: rgba(0, 0, 0, 0.78) !important;
     }
     .modal {
+      position: relative !important;
       background: var(--bg) !important;
       color: var(--fg) !important;
       border: 1px dashed var(--dash) !important;
@@ -1684,16 +1685,21 @@
       padding: var(--pad) !important;
     }
     .modal h3 {
-      margin: 0 0 14px 0 !important;
+      margin: 0 50px 16px 0 !important;
       color: var(--fg) !important;
-      font-size: 11px !important;
-      letter-spacing: 0.3em !important;
+      font-size: 18px !important;
+      letter-spacing: 0.12em !important;
       text-transform: uppercase !important;
-      font-weight: 400 !important;
+      font-weight: 700 !important;
       border-bottom: 1px dashed rgba(255, 255, 255, 0.15) !important;
-      padding-bottom: 10px !important;
+      padding-bottom: 12px !important;
+      line-height: 1.2;
     }
     .modal-close {
+      position: absolute !important;
+      top: 14px !important;
+      right: 14px !important;
+      float: none !important;
       background: transparent !important;
       color: var(--muted) !important;
       border: 1px dashed var(--dash) !important;
@@ -1704,6 +1710,7 @@
       padding: 0 !important;
       font-size: 18px !important;
       line-height: 1 !important;
+      z-index: 1;
     }
     .modal-close:hover {
       background: var(--red) !important;
@@ -1715,11 +1722,12 @@
     .modal .file-info,
     .modal .modal-hint {
       color: var(--muted) !important;
-      font-size: 11px !important;
-      letter-spacing: 0.06em;
-      line-height: 1.5;
+      font-size: 13px !important;
+      letter-spacing: 0.04em;
+      line-height: 1.6;
+      margin: 8px 0 12px 0 !important;
     }
-    .modal .file-info strong { color: var(--fg) !important; }
+    .modal .file-info strong { color: var(--fg) !important; font-weight: 700; }
     .modal .delete-warning {
       color: var(--red) !important;
       border: 1px dashed var(--red) !important;
@@ -1758,15 +1766,16 @@
     /* Modal file input */
     .modal input[type="file"] {
       background: var(--bg) !important;
-      color: var(--muted) !important;
+      color: var(--fg) !important;
       border: 1px dashed var(--dash) !important;
       border-radius: 0 !important;
-      padding: 10px !important;
+      padding: 12px !important;
       font-family: inherit !important;
-      font-size: 11px !important;
+      font-size: 13px !important;
       box-shadow: none !important;
       width: 100% !important;
       box-sizing: border-box;
+      margin: 8px 0 14px 0 !important;
     }
     .modal input[type="file"]::file-selector-button {
       background: transparent !important;


### PR DESCRIPTION
## Summary

**Phase 3b** of the web UI redesign rollout (see [docs/web-redesign-plan.md](../blob/feat/web-redesign-plan/docs/web-redesign-plan.md) on #80).

Stacks on **#83** (Phase 3a chrome) and applies the brutalist palette to all six modals — upload, new folder, rename, move, delete, image preview — and every modal-internal control. With this PR, FilesPage is fully brutalist.

## What changed

### Modal frame
- \`.modal-overlay\` backdrop deepens to \`rgba(0,0,0,.78)\` for stronger contrast against the dark page.
- \`.modal\` container flips to dark bg, dashed border, no rounded corners, no shadow.
- \`.modal h3\` becomes an uppercased letterspaced category label with a dashed underline; \`.modal-close\` is a 32 px square dashed X that fills red on hover.

### Modal forms
- File-info / hint paragraphs render in muted uppercase tracking; \`.delete-warning\` becomes a red dashed alert.
- Text / number / password inputs and \`.folder-input\` adopt the dark + dashed + yellow-focus pattern shared with Settings (#81).
- File inputs in the upload form get a brutalist file-selector button that turns blue on hover, green when files are loaded.

### Modal action buttons
Buttons covered: Upload, Create Folder, Delete, Rename, Move, Cancel, Optimize & Upload.

- 56 px tap-target dashed buttons with a 24-em letter-spaced uppercase label.
- Hover affordances: **green** for create / upload, **blue** for optimize, **red** for destructive Delete-confirm, **yellow** for non-destructive edits (Rename, Move), **neutral** for Cancel.
- Disabled state dims to 35 % opacity.

### Image-preview modal
The four colored \`.action-btn\` buttons (Sleep / Pause / Download / Delete) lose their inline \`bg-color\` and adopt the standard dashed yellow-on-hover pattern. Image frame becomes a dashed wrapper.

### Convert + advanced settings (inside the upload modal)
- Convert checkbox uses the yellow accent-color.
- Convert-warning becomes a yellow dashed alert.
- Advanced-options toggle reads as a blue uppercase link, dark dashed card containing the rows with dashed dividers.
- Quality / rotation / overlap chip groups all collapse onto the same dashed-chip pattern with a yellow filled \`.active\` state — matching the size-grid convention from #82.
- Toggle switches reuse the brutalist toggle (dashed rail, yellow filled when checked, bg-coloured thumb) shared with Settings.

### Image picker section
- Dashed dark frame around the section + header with a dashed underline.
- Legend items / state buttons collapse to dashed chips. \`.legend-color\` swatches are hidden — the per-state intent is now conveyed by the caption text alone, which scales much better at small sizes.

### Progress bar + log section
- Progress bar gets a dashed rail with a blue fill; status text is muted uppercase tracking.
- Log section becomes a dashed dark card; log container deepens to \`rgba(0,0,0,.4)\` for readability.

## Compatibility

- **All existing class names + IDs preserved. JS untouched.**
- Override CSS continues to use \`.modal\`-prefixed selectors so it can't bleed into chrome.
- Any orphan light-theme rule in the original style block is overridden via \`!important\`; nothing is removed yet. A future cleanup pass can prune the now-dead rules once Phase 3a + 3b have soaked.

## Size impact

| Asset | After 3a (gzip) | After 3b (gzip) |
| --- | --- | --- |
| FilesPage.html | 35147 B | 36568 B |
| **Net 3b delta** | — | **+1421 B** |

## Verification

- \`pio run -e debug\` — clean build.
- No device test yet — will batch with #76 / #79 / #81 / #82 / #83 device-test session.

## Test plan

- [ ] Merge #79 first so \`/css/brutalist.css\` is reachable
- [ ] Flash, open \`http://crosspoint.local/files\`
- [ ] Open every modal in turn:
  - [ ] **Upload** — confirm dashed dark frame, file selector, optimize toggle, advanced options panel (quality presets, rotation, overlap, log toggle), upload progress + log; confirm button hover colours match (green / blue / yellow)
  - [ ] **New Folder** — confirm input + green Create button
  - [ ] **Rename** — confirm yellow Rename + neutral Cancel
  - [ ] **Move** — confirm yellow Move + neutral Cancel; datalist autocomplete still works
  - [ ] **Delete** — confirm red dashed warning banner + red Delete-confirm button
  - [ ] **Image preview** — open from a BMP file; confirm 4 action buttons render dashed and adopt yellow-on-hover
- [ ] Resize to phone (375 px) — confirm modals fit and chip groups wrap

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)