### PR TITLE
feat(web/nav): add [4] FONTS slot to HomePage and SettingsPage

### DIFF
--- a/src/network/html/HomePage.html
+++ b/src/network/html/HomePage.html
@@ -194,6 +194,7 @@
         <a href="/" class="on"><span class="k">[1]</span>HOME</a>
         <a href="/files"><span class="k">[2]</span>FILES</a>
         <a href="/settings"><span class="k">[3]</span>SETTINGS</a>
+        <a href="/fonts"><span class="k">[4]</span>FONTS</a>
       </nav>
 
       <!-- Numerals board -->

--- a/src/network/html/SettingsPage.html
+++ b/src/network/html/SettingsPage.html
@@ -235,6 +235,7 @@
         <a href="/"><span class="k">[1]</span>HOME</a>
         <a href="/files"><span class="k">[2]</span>FILES</a>
         <a href="/settings" class="on"><span class="k">[3]</span>SETTINGS</a>
+        <a href="/fonts"><span class="k">[4]</span>FONTS</a>
       </nav>
 
       <!-- Status banner (success/error) -->

--- a/src/network/html/brutalist.css
+++ b/src/network/html/brutalist.css
@@ -101,7 +101,11 @@ nav.nav {
   grid-template-columns: 1fr;
   gap: 8px;
 }
-@media (min-width: 500px) { nav.nav { grid-template-columns: repeat(3, 1fr); } }
+/* 1 col on phones; 2 cols on small tablets / large phones; auto-fit
+   on real screens so 3-slot and 4-slot navs share the same rules
+   without a per-page override. */
+@media (min-width: 500px) { nav.nav { grid-template-columns: repeat(2, 1fr); } }
+@media (min-width: 760px) { nav.nav { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); } }
 nav.nav a {
   border: 1px dashed var(--dash);
   padding: 18px 12px;


### PR DESCRIPTION
## Summary

Sweep PR — brings HomePage and SettingsPage's primary nav to four-slot parity with FontsPage (#82) and FilesPage (#83).

**Stacks on #81** (Settings) — base branch \`feat/web-settings-brutalist\`. That branch already carries the brutalist HomePage (via #79 → #76) and the redesigned SettingsPage, so this is the natural home for the nav update.

## What changed

- **HomePage** and **SettingsPage** primary \`<nav>\` grow a fourth \`<a>\` pointing at \`/fonts\` with the \`[4]\` keyboard hint, matching the convention already used on Fonts and Files.
- **\`brutalist.css\`** \`nav.nav\` \`grid-template-columns\` refactored so 3-slot and 4-slot navs share responsive layout without per-page overrides:
  - 1 col on phones (<500 px) — unchanged.
  - 2 cols on 500..760 px (small tablets / large phones).
  - \`repeat(auto-fit, minmax(140px, 1fr))\` at ≥760 px so the row stretches to N slots automatically. With 3 slots it lays out 3-up; with 4 slots it lays out 4-up; future slots auto-fit.

## Verification

- \`pio run -e debug\` — clean build.

## Test plan

- [ ] Flash, open \`/\` — confirm 4-slot nav with HOME highlighted; click [4] → /fonts works.
- [ ] Open \`/settings\` — confirm 4-slot nav with SETTINGS highlighted; \`[4]\` link goes to /fonts.
- [ ] Resize through 320 / 375 / 600 / 820 / 1280 — confirm nav stacks 1 col → 2 col → auto-fit on each page.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)