### PR TITLE
fix(sleep): heap-threshold gate for wallpaper/cover render

### DIFF
--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -92,6 +92,18 @@ void SleepActivity::onEnter() {
   // "Going to sleep..." banner on the power-button path, and a second
   // popup on top of it was read as duplicate noise.
 
+  // Heap-budget gate: weak-WiFi sessions have tipped the device into abort()
+  // during sleep wallpaper / cover render with Min Free observed at 4352 bytes.
+  // If the heap is already pressured when sleep is entered, fall back to a
+  // blank sleep screen — render fragments + bitmap parsing on top of a tight
+  // heap is the documented crash signature.
+  constexpr uint32_t kMinFreeHeapForRichSleep = 30 * 1024;
+  const uint32_t freeHeap = ESP.getFreeHeap();
+  if (freeHeap < kMinFreeHeapForRichSleep) {
+    LOG_DBG("SLP", "Free heap %u < %u, suppressing wallpaper/cover render", freeHeap, kMinFreeHeapForRichSleep);
+    return renderBlankSleepScreen();
+  }
+
   switch (SETTINGS.sleepScreen) {
     case (CrossPointSettings::SLEEP_SCREEN_MODE::BLANK):
       return renderBlankSleepScreen();


### PR DESCRIPTION
## Summary
v2 — gate sleep wallpaper / cover render on free-heap threshold.

## Why v1 was wrong
Original v1 gated on `CrossPointWebServer::isAnyInstanceRunning()`. Device
verification showed the gate is unreachable under normal flow:

\`\`\`
sleep timer fires
  → exitActivity() → CrossPointWebServerActivity::onExit()
                     → stopWebServer() → running=false, wsInstance=nullptr
  → enterNewActivity(SleepActivity)
  → SleepActivity::onEnter() → isAnyInstanceRunning() == false
  → wallpaper renders normally
\`\`\`

Activity transitions are atomic — exit before enter. Web server is always
torn down before SleepActivity starts, so the v1 gate could never fire.

Confirmed empirically in serial logs (PR #87 v1 flashed):

\`\`\`
[477986] [DBG] [SLP] Loading: /sleep/28484EEC-...bmp   ← wallpaper render proceeded
[478337] [DBG] [SLP] bitmap 480 x 800, screen 480 x 800
[478337] [DBG] [SLP] drawing to 0 x 0
\`\`\`

No `[SLP] Web mode active...` log → gate didn't fire.

## What v2 does
Check `ESP.getFreeHeap() < 30 KB` at the top of `SleepActivity::onEnter()`.
If true, render a blank sleep screen instead of parsing/drawing a bitmap.

Catches the documented crash signature (Min Free 4352 B at abort()) regardless
of which subsystem fragmented the heap — weak-WiFi web mode, heavy reader
state, or any other path that left the device tight on memory.

Removed the now-unused `CrossPointWebServer::isAnyInstanceRunning()` helper.

## Test plan
- [ ] Flash debug build, enter web mode on weak WiFi, browse Files
- [ ] Wait for sleep timer (or press power)
- [ ] Confirm: either `[SLP] Free heap N < 30720, suppressing...` log + blank screen, OR normal wallpaper render with no abort()

🤖 Generated with [Claude Code](https://claude.com/claude-code)