### PR TITLE
chore(web/files): prune dead Dashed-border restyle CSS block

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1348,76 +1348,12 @@
     .log-summary-table .saved { color: #27ae60; }
     .log-summary-table .increased { color: #f39c12; }
 
-    /* ===================================================================
-       Dashed-border restyle — white bg, black text, 2px dashed action color.
-       Appended last so it overrides earlier rules via source order (!important
-       only where prior rules hardcode gradient/shadow).
-       =================================================================== */
-    :root {
-      --acc-upload:  #27ae60;
-      --acc-folder:  #f39c12;
-      --acc-danger:  #c0392b;
-      --acc-primary: #2980b9;
-      --acc-teal:    #16a085;
-      --acc-neutral: #555;
-    }
-    button,
-    .action-btn,
-    .upload-action-btn, .folder-action-btn,
-    .delete-btn, .rename-btn, .move-btn,
-    .delete-btn-confirm, .delete-btn-cancel,
-    .rename-btn-confirm, .move-btn-confirm,
-    .nav-links a, .save-btn {
-      background: #fff !important;
-      color: #000 !important;
-      border: 2px dashed var(--btn-acc, var(--acc-neutral)) !important;
-      box-shadow: none !important;
-      text-shadow: none !important;
-    }
-    .upload-action-btn                { --btn-acc: var(--acc-upload);  }
-    .folder-action-btn                { --btn-acc: var(--acc-folder);  }
-    .delete-btn, .delete-btn-confirm  { --btn-acc: var(--acc-danger);  }
-    .rename-btn, .rename-btn-confirm,
-    .nav-links a, .save-btn           { --btn-acc: var(--acc-primary); }
-    .move-btn,   .move-btn-confirm    { --btn-acc: var(--acc-teal);    }
-    .delete-btn-cancel                { --btn-acc: var(--acc-neutral); }
-
-    /* Hover: subtle bg tint, keep dashed border */
-    button:hover,
-    .action-btn:hover,
-    .upload-action-btn:hover, .folder-action-btn:hover,
-    .delete-btn:hover, .rename-btn:hover, .move-btn:hover,
-    .delete-btn-confirm:hover, .delete-btn-cancel:hover,
-    .rename-btn-confirm:hover, .move-btn-confirm:hover,
-    .nav-links a:hover, .save-btn:hover {
-      background: #f2f2f2 !important;
-      color: #000 !important;
-    }
-
-    /* Inputs + selects */
-    input[type=text], input[type=password], input[type=number],
-    input[type=search], input[type=email], input[type=url],
-    select, textarea {
-      background: #fff !important;
-      color: #000 !important;
-      border: 2px dashed var(--acc-neutral) !important;
-      box-shadow: none !important;
-    }
-    input[type=text]:focus, input[type=password]:focus,
-    input[type=number]:focus, input[type=search]:focus,
-    input[type=email]:focus, input[type=url]:focus,
-    select:focus, textarea:focus {
-      outline: none;
-      border-color: var(--acc-primary) !important;
-    }
-
-    /* Containers */
-    .card, .modal {
-      background: #fff !important;
-      color: #000 !important;
-      border: 2px dashed #333 !important;
-      box-shadow: none !important;
-    }
+    /* The legacy "Dashed-border restyle" block (--acc-upload/folder/danger/
+       primary/teal/neutral CSS variables and the button / input / .card
+       overrides that referenced them) used to live here. It was a previous
+       attempt at a dashed-border theme; every rule it defined is now
+       superseded by /css/brutalist.css plus the brutalist override block
+       below, so removing it is a no-visual-change pruning. */
   </style>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary

Removes the legacy "Dashed-border restyle" CSS block from \`FilesPage.html\` — the \`--acc-*\` CSS variables and the button / input / \`.card\` / \`.modal\` overrides that referenced them. Every rule it defined is now superseded by \`/css/brutalist.css\` (#79) plus the brutalist overrides added in #83 (chrome) / #84 (modals) / #86 (polish).

Stacks on **#86** (Phase 3c polish).

## Why

The block was a previous attempt at a dashed-border theme appended to \`FilesPage.html\` before the brutalist redesign existed. With the brutalist stack in place, every selector it covered is now caught earlier in the cascade by ID-prefixed selectors with \`!important\` on the brutalist side. Removing dead CSS shrinks the gzip payload and makes future grep / diff sessions cleaner.

## Coverage audit

Verified each selector in the legacy block against the current override coverage:

| Legacy selector | New owner |
| --- | --- |
| \`button\`, \`.action-btn\`, \`.upload-action-btn\`, \`.folder-action-btn\` | #83 |
| \`.delete-btn\`, \`.rename-btn\`, \`.move-btn\` | #86 |
| \`.delete-btn-confirm\`, \`.delete-btn-cancel\`, \`.rename-btn-confirm\`, \`.move-btn-confirm\` | #84 |
| \`.nav-links a\` | #83 |
| \`.save-btn\` | unused on FilesPage (Settings-only) |
| \`input[type=*]\`, \`select\`, \`textarea\` | #84 |
| \`.card\` (folder contents) | #83 |
| \`.modal\` | #84 |

## Size impact

| State | FilesPage.html (gzip) |
| --- | --- |
| After #86 | 36 568 B |
| After this PR | 35 578 B |
| **Delta** | **-990 B** |

## Verification

- \`pio run -e debug\` — clean build.
- No visual change expected; this is a pure dead-code prune.

## Test plan

- [ ] Flash, open \`/files\`
- [ ] Confirm chrome (header, nav, action buttons, file table, banner) renders identically to #86
- [ ] Open every modal (Upload / New Folder / Rename / Move / Delete / Image preview) — confirm identical to #84
- [ ] Hover every button — confirm hover affordances still fire (yellow / green / red / blue)
- [ ] Tick a checkbox — confirm yellow + black tick still works (#86)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)