### PR TITLE
chore(web): Phase 4 audit — Cache-Control on jszip.min.js

### DIFF
--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -494,6 +494,7 @@ void CrossPointWebServer::pumpWsDownload() {
 
 void CrossPointWebServer::handleJszip() const {
   server->sendHeader("Content-Encoding", "gzip");
+  server->sendHeader("Cache-Control", "public, max-age=86400");
   server->send_P(200, "application/javascript", jszip_minJs, jszip_minJsCompressedSize);
   LOG_DBG("WEB", "Served jszip.min.js");
 }


### PR DESCRIPTION
## Summary
Final phase of the brutalist web redesign rollout (per [docs/web-redesign-plan.md](docs/web-redesign-plan.md)).

Single code change: `handleJszip()` in `CrossPointWebServer.cpp` now sends
`Cache-Control: public, max-age=86400` alongside the existing
`Content-Encoding: gzip` header.

## Why
The 90 KB jszip payload was re-fetched on every Files-page load on weak Wi-Fi.
`/css/brutalist.css` (PR #79) already had this header — this brings the JS
blob in line.

## Out of scope (manual device tests, no code)
- Free-heap measurement with web mode + page load on weak signal vs. baseline
- Mobile-width sanity check at 320 / 375 / 820 / 1280 px on all four pages
- Lighthouse pass

## Test plan
- [ ] Flash, open Files page in fresh browser, devtools Network → confirm 200 OK with `cache-control: public, max-age=86400` on `/js/jszip.min.js`
- [ ] Refresh — confirm 304 / disk-cache hit on second load

🤖 Generated with [Claude Code](https://claude.com/claude-code)