### PR TITLE
chore(web): always-on LOG_DIAG so crash route lands in crash_report.txt

### DIFF
--- a/lib/Logging/Logging.h
+++ b/lib/Logging/Logging.h
@@ -55,6 +55,12 @@ void logPrintf(const char* level, const char* origin, const char* format, ...);
 #define LOG_INF(origin, format, ...)
 #endif
 
+// LOG_DIAG: always-on diagnostic line, ignores ENABLE_SERIAL_LOG / LOG_LEVEL.
+// Writes to the RTC ring buffer in every build so the entry is preserved in
+// /crash_report.txt after a panic, even on production firmware. Use sparingly:
+// the ring is only 16 lines, so unconditional logging crowds out other context.
+#define LOG_DIAG(origin, format, ...) logPrintf("DIAG", origin, format "\n", ##__VA_ARGS__)
+
 std::string getLastLogs();
 void clearLastLogs();
 // Validates the RTC log state (magic word + logHead range). Returns true if

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -680,7 +680,7 @@ void CrossPointWebServer::handleFileList() const {
 }
 
 void CrossPointWebServer::handleFileListData() const {
-  LOG_DBG("WEB", "[diag] /api/files entry, free=%u min=%u", ESP.getFreeHeap(), ESP.getMinFreeHeap());
+  LOG_DIAG("WEB", "/api/files entry, free=%u min=%u", ESP.getFreeHeap(), ESP.getMinFreeHeap());
   // Get current path from query string (default to root)
   String currentPath = "/";
   if (server->hasArg("path")) {
@@ -868,8 +868,8 @@ void CrossPointWebServer::handleDownload() const {
 }
 
 void CrossPointWebServer::handlePreview() const {
-  LOG_DBG("WEB", "[diag] /preview entry, free=%u min=%u path=%s", ESP.getFreeHeap(), ESP.getMinFreeHeap(),
-          server->hasArg("path") ? server->arg("path").c_str() : "(none)");
+  LOG_DIAG("WEB", "/preview entry, free=%u min=%u path=%s", ESP.getFreeHeap(), ESP.getMinFreeHeap(),
+           server->hasArg("path") ? server->arg("path").c_str() : "(none)");
   if (!server->hasArg("path")) {
     server->send(400, "text/plain", "Missing path");
     return;
@@ -1092,7 +1092,7 @@ void CrossPointWebServer::handleUpload(UploadState& state) const {
 }
 
 void CrossPointWebServer::handleUploadPost(UploadState& state) const {
-  LOG_DBG("WEB", "[diag] /upload POST entry, free=%u min=%u", ESP.getFreeHeap(), ESP.getMinFreeHeap());
+  LOG_DIAG("WEB", "/upload POST entry, free=%u min=%u", ESP.getFreeHeap(), ESP.getMinFreeHeap());
   if (state.success) {
     server->send(200, "text/plain", "File uploaded successfully: " + state.fileName);
   } else {
@@ -1477,7 +1477,7 @@ void CrossPointWebServer::handleFontsPage() const {
 }
 
 void CrossPointWebServer::handleGetFonts() const {
-  LOG_DBG("WEB", "[diag] /api/fonts entry, free=%u min=%u", ESP.getFreeHeap(), ESP.getMinFreeHeap());
+  LOG_DIAG("WEB", "/api/fonts entry, free=%u min=%u", ESP.getFreeHeap(), ESP.getMinFreeHeap());
   const auto& mgr = crosspoint::fonts::CustomBinFontManager::instance();
   server->setContentLength(CONTENT_LENGTH_UNKNOWN);
   server->send(200, "application/json", "");


### PR DESCRIPTION
## Summary
- Add `LOG_DIAG` macro: unconditional `logPrintf` call, ignores `ENABLE_SERIAL_LOG` / `LOG_LEVEL`
- Switch the 4 web-handler entry diagnostics from `LOG_DBG` to `LOG_DIAG` so the route + heap budget land in `/crash_report.txt` on **production** firmware too

## Why
PR #91 just merged the diagnostic lines on the heavy webserver handlers, but `LOG_DBG` compiles to a no-op in the `default` (production) env (`ENABLE_SERIAL_LOG` is off there). The v1.3.1 abort with a `.bmp` in the stack came from a production user — those diag lines never made it to the RTC ring buffer, never made it to `/crash_report.txt`, didn't help.

`LOG_DIAG` always calls `logPrintf`, which always writes to the RTC ring. After a panic, `HalSystem::checkPanic()` dumps that ring to `/crash_report.txt` on next boot. So the next production `.bmp` crash report will name the offending route + show the heap budget at handler entry.

## Cost in production
- 4 call sites, each one `logPrintf` → RTC ring buffer write (~80 bytes)
- Serial print path skipped at runtime (`logSerial` evaluates false when no USB attached)
- No other `LOG_DIAG` callers in the tree — ring buffer (16 lines × 256 B) still has room for `LOG_ERR` / `LOG_INF` context preceding the crash

## Build
- `pio run -e default` → SUCCESS
- Flash: 85.5% (unchanged from before #91)
- RAM: 43.7%

## Test plan
- [ ] Trigger a deliberate crash in a webserver handler (e.g. force `abort()` inside `handleFileListData`)
- [ ] Reboot, read `/crash_report.txt` from SD
- [ ] Confirm last log line is `[DIAG] [WEB] /api/files entry, free=... min=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)