### PR TITLE
fix(reader): nothrow audit on section-rebuild path (no more bad_alloc panic)

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -588,6 +588,10 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
     lineWords.back().push_back('-');
   }
 
-  processLine(
-      std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles), blockStyle));
+  // make_shared throws bad_alloc on OOM, which the firmware build can't
+  // catch (exceptions disabled) and panics. Use the explicit form so the
+  // call returns a null shared_ptr that processLine handles cleanly.
+  auto* rawBlock =
+      new (std::nothrow) TextBlock(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles), blockStyle);
+  processLine(std::shared_ptr<TextBlock>(rawBlock));
 }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -144,9 +144,16 @@ void ChapterHtmlSlimParser::bindPendingAnchorsToCurrentPage() {
   if (pendingAnchors.empty()) {
     return;
   }
+  if (parseFailed) return;
 
   if (!currentPage) {
-    currentPage.reset(new Page());
+    currentPage.reset(new (std::nothrow) Page());
+    if (!currentPage) {
+      LOG_DIAG("EHP", "OOM new Page (bindPendingAnchors) free=%u largest=%u", (unsigned)ESP.getFreeHeap(),
+               (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+      parseFailed = true;
+      return;
+    }
     currentPageNextY = 0;
   }
 
@@ -173,8 +180,14 @@ void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
 
     makePages();
   }
-  currentTextBlock.reset(new ParsedText(extraParagraphSpacingLevel != 0, hyphenationEnabled, blockStyle,
-                                        wordSpacingPercent, firstLineIndentMode, usePublisherStyles));
+  currentTextBlock.reset(new (std::nothrow) ParsedText(extraParagraphSpacingLevel != 0, hyphenationEnabled, blockStyle,
+                                                       wordSpacingPercent, firstLineIndentMode, usePublisherStyles));
+  if (!currentTextBlock) {
+    LOG_DIAG("EHP", "OOM new ParsedText free=%u largest=%u min=%u", (unsigned)ESP.getFreeHeap(),
+             (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT), (unsigned)ESP.getMinFreeHeap());
+    parseFailed = true;
+    return;
+  }
   wordsExtractedInBlock = 0;
 }
 
@@ -303,20 +316,33 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
 
               LOG_DBG("EHP", "Display size: %dx%d (scale %.2f)", displayWidth, displayHeight, scale);
 
-              // Create page for image - only break if image won't fit remaining space
+              // Create page for image - only break if image won't fit remaining space.
+              // The pre-existing `new Page()` calls below were bare and would
+              // throw bad_alloc on a fragmented heap; with exceptions disabled
+              // in the firmware build that aborts. Switch to nothrow and treat
+              // a null result as a parse-aborting OOM (poll the flag from the
+              // outer parse loop to bail with the standard cleanup path).
               if (self->currentPage && !self->currentPage->elements.empty() &&
                   (self->currentPageNextY + displayHeight > self->viewportHeight)) {
                 self->completeCurrentPage();
-                self->currentPage.reset(new Page());
+                self->currentPage.reset(new (std::nothrow) Page());
                 if (!self->currentPage) {
-                  LOG_ERR("EHP", "Failed to create new page");
+                  LOG_DIAG("EHP", "OOM new Page (image overflow) free=%u largest=%u min=%u",
+                           (unsigned)ESP.getFreeHeap(),
+                           (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT),
+                           (unsigned)ESP.getMinFreeHeap());
+                  self->parseFailed = true;
                   return;
                 }
                 self->currentPageNextY = 0;
               } else if (!self->currentPage) {
-                self->currentPage.reset(new Page());
+                self->currentPage.reset(new (std::nothrow) Page());
                 if (!self->currentPage) {
-                  LOG_ERR("EHP", "Failed to create initial page");
+                  LOG_DIAG("EHP", "OOM new Page (image initial) free=%u largest=%u min=%u",
+                           (unsigned)ESP.getFreeHeap(),
+                           (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT),
+                           (unsigned)ESP.getMinFreeHeap());
+                  self->parseFailed = true;
                   return;
                 }
                 self->currentPageNextY = 0;
@@ -324,18 +350,29 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
 
               self->bindPendingAnchorsToCurrentPage();
 
-              // Create ImageBlock and add to page
-              auto imageBlock = std::make_shared<ImageBlock>(cachedImagePath, displayWidth, displayHeight);
-              if (!imageBlock) {
-                LOG_ERR("EHP", "Failed to create ImageBlock");
+              // Create ImageBlock and add to page. make_shared without nothrow
+              // throws bad_alloc on heap exhaustion → ESP32 panic. Use the
+              // explicit shared_ptr(new (nothrow) ...) form so we can detect
+              // and bail.
+              auto* rawImageBlock = new (std::nothrow) ImageBlock(cachedImagePath, displayWidth, displayHeight);
+              if (!rawImageBlock) {
+                LOG_DIAG("EHP", "OOM new ImageBlock free=%u largest=%u",
+                         (unsigned)ESP.getFreeHeap(),
+                         (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+                self->parseFailed = true;
                 return;
               }
+              std::shared_ptr<ImageBlock> imageBlock(rawImageBlock);
               int xPos = (self->viewportWidth - displayWidth) / 2;
-              auto pageImage = std::make_shared<PageImage>(imageBlock, xPos, self->currentPageNextY);
-              if (!pageImage) {
-                LOG_ERR("EHP", "Failed to create PageImage");
+              auto* rawPageImage = new (std::nothrow) PageImage(imageBlock, xPos, self->currentPageNextY);
+              if (!rawPageImage) {
+                LOG_DIAG("EHP", "OOM new PageImage free=%u largest=%u",
+                         (unsigned)ESP.getFreeHeap(),
+                         (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+                self->parseFailed = true;
                 return;
               }
+              std::shared_ptr<PageImage> pageImage(rawPageImage);
               self->currentPage->elements.push_back(pageImage);
               self->currentPageNextY += displayHeight;
 
@@ -880,6 +917,18 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
       file.close();
       return false;
     }
+    // A `new (nothrow) Page()` inside a callback may have set parseFailed.
+    // expat callbacks are void-returning so the only way to short-circuit
+    // is to poll the flag here and bail with the same cleanup as the
+    // XML_GetBuffer / XML_ParseBuffer error paths.
+    if (parseFailed) {
+      XML_StopParser(parser, XML_FALSE);
+      XML_SetElementHandler(parser, nullptr, nullptr);
+      XML_SetCharacterDataHandler(parser, nullptr);
+      XML_ParserFree(parser);
+      file.close();
+      return false;
+    }
   } while (!done);
 
   XML_StopParser(parser, XML_FALSE);                // Stop any pending processing
@@ -903,21 +952,51 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
     currentPage.reset();
   }
 
+  // Final makePages() call above may have hit OOM after the parse loop
+  // already exited cleanly. Surface the failure to the caller.
+  if (parseFailed) {
+    return false;
+  }
+
   return true;
 }
 
 void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
+  if (parseFailed) return;
+  // ParsedText signals an OOM during TextBlock construction by passing
+  // a null shared_ptr through the processLine callback. Treat that the
+  // same as our own internal allocation failures.
+  if (!line) {
+    LOG_DIAG("EHP", "OOM upstream null TextBlock free=%u largest=%u min=%u fontId=%d", (unsigned)ESP.getFreeHeap(),
+             (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT), (unsigned)ESP.getMinFreeHeap(), fontId);
+    parseFailed = true;
+    return;
+  }
   const int baseLineHeight = renderer.getLineHeight(fontId) * lineCompression;
   const int lineHeight = line->getBlockStyle().resolveLineHeight(baseLineHeight);
 
   if (!currentPage) {
-    currentPage.reset(new Page());
+    currentPage.reset(new (std::nothrow) Page());
+    if (!currentPage) {
+      LOG_DIAG("EHP", "OOM new Page (addLineToPage entry) free=%u largest=%u min=%u fontId=%d",
+               (unsigned)ESP.getFreeHeap(), (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT),
+               (unsigned)ESP.getMinFreeHeap(), fontId);
+      parseFailed = true;
+      return;
+    }
     currentPageNextY = 0;
   }
 
   if (currentPageNextY + lineHeight > viewportHeight) {
     completeCurrentPage();
-    currentPage.reset(new Page());
+    currentPage.reset(new (std::nothrow) Page());
+    if (!currentPage) {
+      LOG_DIAG("EHP", "OOM new Page (addLineToPage overflow) free=%u largest=%u min=%u fontId=%d",
+               (unsigned)ESP.getFreeHeap(), (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT),
+               (unsigned)ESP.getMinFreeHeap(), fontId);
+      parseFailed = true;
+      return;
+    }
     currentPageNextY = 0;
   }
 
@@ -934,18 +1013,33 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
 
   // Apply horizontal left inset (margin + padding) as x position offset
   const int16_t xOffset = line->getBlockStyle().leftInset();
-  currentPage->elements.push_back(std::make_shared<PageLine>(line, xOffset, currentPageNextY));
+  auto* rawPageLine = new (std::nothrow) PageLine(line, xOffset, currentPageNextY);
+  if (!rawPageLine) {
+    LOG_DIAG("EHP", "OOM new PageLine free=%u largest=%u min=%u fontId=%d", (unsigned)ESP.getFreeHeap(),
+             (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT), (unsigned)ESP.getMinFreeHeap(), fontId);
+    parseFailed = true;
+    return;
+  }
+  currentPage->elements.push_back(std::shared_ptr<PageLine>(rawPageLine));
   currentPageNextY += lineHeight;
 }
 
 void ChapterHtmlSlimParser::makePages() {
+  if (parseFailed) return;
   if (!currentTextBlock) {
     LOG_ERR("EHP", "!! No text block to make pages for !!");
     return;
   }
 
   if (!currentPage) {
-    currentPage.reset(new Page());
+    currentPage.reset(new (std::nothrow) Page());
+    if (!currentPage) {
+      LOG_DIAG("EHP", "OOM new Page (makePages entry) free=%u largest=%u min=%u fontId=%d",
+               (unsigned)ESP.getFreeHeap(), (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT),
+               (unsigned)ESP.getMinFreeHeap(), fontId);
+      parseFailed = true;
+      return;
+    }
     currentPageNextY = 0;
   }
 

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -40,6 +40,14 @@ class ChapterHtmlSlimParser {
   std::unique_ptr<ParsedText> currentTextBlock = nullptr;
   std::unique_ptr<Page> currentPage = nullptr;
   int16_t currentPageNextY = 0;
+  // Sticky OOM flag. Set when a `new (nothrow) Page()` returns null
+  // inside one of the parse callbacks, where we can't propagate a
+  // return value through expat. The parse loop polls this between
+  // XML_ParseBuffer calls and bails to the cleanup-and-return-false
+  // branch as if the buffer alloc itself had failed. Without this, the
+  // pre-PR-#97 code used bare `new Page()` and let bad_alloc panic the
+  // ESP32 (no exceptions enabled in firmware build).
+  bool parseFailed = false;
   int fontId;
   float lineCompression;
   uint8_t extraParagraphSpacingLevel;


### PR DESCRIPTION
## Context

Hardware capture reproduced a firmware crash from this user flow:

> changed the line spacing and the size one size up — firmware crashed

This was on a built-in font (Vollkorn / Bookerly), so PR #95/#96 custom-font work isn't the root cause. Three audits in the planning round identified the actual bug.

## Root cause

When the user changes any setting that's part of the section-cache key (`fontId`, `lineCompression`), the `.bin` validation fails (Section.cpp:192-199) and `Section::createSectionFile` rebuilds from scratch. The rebuild walks chapter HTML through expat and creates `Page` / `TextBlock` / `ImageBlock` / `PageImage` / `PageLine` / `ParsedText` objects. Every one of these allocations was either bare `new ClassName()` or `make_shared`. Both throw `std::bad_alloc` on OOM. The firmware build disables exceptions → `bad_alloc` aborts the device.

The pre-flight gate from PR #95 cannot save this path because the OOM happens *deep inside* the parse callbacks, after the gate already passed — the heap is chipped down across hundreds of small allocations during a single rebuild.

## Fix

Adds a sticky `parseFailed` flag on `ChapterHtmlSlimParser`. Every allocation site in the rebuild hot path now uses `new (std::nothrow)` (or the explicit `shared_ptr<T>(new (std::nothrow) T(...))` form, since `make_shared` has no nothrow variant). On null:

- Set `parseFailed = true`
- Emit a `LOG_DIAG` with `free=`, `largest=`, `min=`, `fontId=` for soak triage
- Return without writing a partial page

Expat callbacks are `void`-returning, so the parse loop polls the flag between `XML_ParseBuffer` calls and bails through the existing cleanup-and-return-false path — exactly the recovery flow PR #95 already wired into `ensureSectionLoaded`. The retry-once + auto-revert + recovery-dialog cascade now catches what was previously a hard crash.

For `ParsedText` (no own flag, shared between parsers) the new (nothrow) result is passed through `processLine` as a potentially null `shared_ptr`; `addLineToPage` detects it and sets `parseFailed` on the parser.

## Sites converted

- `lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp:149` (bindPendingAnchors)
- `lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp:176` (startNewTextBlock — `new ParsedText`)
- `lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp:310, 317` (image path — `new Page`)
- `lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp:328, 334` (`make_shared<ImageBlock>`, `make_shared<PageImage>`)
- `lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp:914, 920, 948` (line-layout `new Page`)
- `lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp:970` (`make_shared<PageLine>`)
- `lib/Epub/Epub/ParsedText.cpp:592` (`make_shared<TextBlock>`)

## Hardware verification

- Reflashed debug build, opened a book with Vollkorn, changed line spacing + bumped reader font size one step.
- Result: no crash. Recovery dialog ("Low memory / tap any key to retry") fires when the rebuild does hit OOM mid-layout, exactly per the PR #95 contract.
- Pre-fix: hard reboot.

## Out of scope

- Bare `new` in book-open paths (`Epub.cpp:441,443,598,630`, `ImageDecoderFactory`) — not on the settings-change rebuild hot path. Audit when scope reopens.
- Mid-render font glyph decompression OOM (`FontDecompressor` `hot group` failure) — separate consumer of the same fragmented heap, addressed in PR #98 / #99.

## Test plan

- [x] Hardware: line-spacing + size change with Vollkorn — no crash
- [ ] CI build green on `default`
- [ ] Hardware: same with Bookerly + Charter
- [ ] Hardware: same with Roboto-Condensed (custom font path) — should also be safer
- [ ] Hardware: open a small book, multi-step settings change in rapid succession — verify no abort even on hammered heap

🤖 Generated with [Claude Code](https://claude.com/claude-code)