### PR TITLE
chore(memory): drop vector capacity after one-shot loads

### DIFF
--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -43,8 +43,11 @@ void OpdsBookBrowserActivity::onExit() {
   // Turn off WiFi when exiting
   WiFi.mode(WIFI_OFF);
 
-  entries.clear();
-  navigationHistory.clear();
+  // Drop allocated capacity, not just size — large OPDS feeds can leave
+  // 5-10 KB of unused vector capacity per browse session that the next
+  // activity can't use until the next browse overwrites it.
+  std::vector<OpdsEntry>().swap(entries);
+  std::vector<std::string>().swap(navigationHistory);
 }
 
 void OpdsBookBrowserActivity::loop() {

--- a/src/activities/reader/QuotesViewerActivity.cpp
+++ b/src/activities/reader/QuotesViewerActivity.cpp
@@ -110,6 +110,11 @@ void QuotesViewerActivity::loadQuotes() {
     if (!entry.text.empty()) quotes.push_back(std::move(entry));
     if (sep == std::string::npos) break;
   }
+  // The whole-file buffer (up to ~65 KB) lingers in heap until the next
+  // loadQuotes overwrites it, even though we only needed it during the
+  // parse loop above. Free its capacity now so subsequent activity
+  // transitions or book opens see the real heap state.
+  std::string().swap(buf);
 }
 
 bool QuotesViewerActivity::saveQuotes() const {


### PR DESCRIPTION
## Context

Phase 2 of the memory protection plan (#96 / #97 / this / #99). Audit found two transient buffers holding their full capacity well past the point they were useful, costing ~75 KB of contiguous heap that nothing else could use until the buffer's owner happened to reload.

## Changes

**`QuotesViewerActivity::loadQuotes`** — reads up to ~65 KB of quotes file into a `std::string buf` for parsing, then never frees its capacity. The string lives until the next `loadQuotes` overwrites it. A user who opens the quotes viewer once, returns to the home screen, and then opens a book sees the reader inheriting that 65 KB drag. Swap-with-empty after the parse loop drops it immediately.

**`OpdsBookBrowserActivity::onExit`** — `entries` (vector<OpdsEntry>) and `navigationHistory` (vector<string>) get `.clear()`'d but the underlying allocations stick. Browsing a large OPDS feed leaves 5-10 KB across the activity boundary. Same swap-with-empty pattern.

## What was rejected

The plan also flagged `CssParser::offsetsBySelector_` for early release after the LRU is primed, claimed to save 50-100 KB. Reading `resolveStyle` shows the LRU only short-circuits *after* an offsets lookup hits — the index is the load-bearing render-time data structure, not a warm-up cache. Dropping it would break style lookups. Left alone.

## What this fixes (and what it doesn't)

This raises the floor of contiguous heap available across activity transitions, which is part of the cumulative work to keep books openable on a fragmented device. It does **not** address the mid-render FontDecompressor OOM the user is hitting on the current build — that's PR #99 (heap-fail callback) where the right tool is to release caches synchronously when an allocation fails inside `getBitmap`.

## Test plan

- [x] CI build green
- [ ] Hardware: open quotes viewer, exit, open a book, capture `largest_free_block` before/after — expect a >40 KB delta vs prior build
- [ ] Hardware: browse OPDS feed, exit, open a book — same measurement

🤖 Generated with [Claude Code](https://claude.com/claude-code)