### PR TITLE
fix(memory): hashed CSS index + cached recents percent + heap-aware page prefetch

### DIFF
--- a/lib/EpdFont/EpdBinFontLoader.cpp
+++ b/lib/EpdFont/EpdBinFontLoader.cpp
@@ -110,12 +110,9 @@ namespace {
 // success.
 }  // namespace
 
-bool EpdBinFontLoader::openFromFile(const std::string& path) {
-  return openFromFileExternalBuf(path, nullptr, 0);
-}
+bool EpdBinFontLoader::openFromFile(const std::string& path) { return openFromFileExternalBuf(path, nullptr, 0); }
 
-bool EpdBinFontLoader::openFromFileExternalBuf(const std::string& path, uint8_t* externalBuf,
-                                               uint32_t externalBufCap) {
+bool EpdBinFontLoader::openFromFileExternalBuf(const std::string& path, uint8_t* externalBuf, uint32_t externalBufCap) {
   release();
 
   HalFile f;

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cstring>
 #include <string_view>
 
 namespace {
@@ -48,6 +49,20 @@ constexpr size_t MIN_FREE_HEAP_FOR_CSS = 48 * 1024;
 // Maximum length for a single selector string
 // Prevents parsing of extremely long or malformed selectors
 constexpr size_t MAX_SELECTOR_LENGTH = 256;
+
+// FNV-1a 32-bit hash. Cheap to compute, good enough distribution for the
+// short ASCII selectors EPUB stylesheets contain in practice. Used to
+// build the in-RAM CSS selector index without storing the strings
+// themselves (~30 KB savings on books with hundreds of rules).
+inline uint32_t fnv1aHash(const char* data, size_t len) {
+  uint32_t h = 2166136261u;
+  for (size_t i = 0; i < len; ++i) {
+    h ^= static_cast<uint8_t>(data[i]);
+    h *= 16777619u;
+  }
+  return h;
+}
+inline uint32_t fnv1aHash(const std::string& s) { return fnv1aHash(s.data(), s.size()); }
 
 // Check if character is CSS whitespace
 bool isCssWhitespace(const char c) { return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f'; }
@@ -563,7 +578,7 @@ CssStyle CssParser::resolveStyle(const std::string& tagName, const std::string& 
 
   // Helper: look up a selector and merge its style into `into`.
   // Transparently handles both RAM mode (rulesBySelector_ populated, e.g. during
-  // build before cache is written) and disk-paged mode (offsetsBySelector_
+  // build before cache is written) and disk-paged mode (hashedIndex_
   // populated, styles read from cache file on demand).
   const auto applySelectorInto = [this](const std::string& key, CssStyle& into) {
     if (!rulesBySelector_.empty()) {
@@ -578,12 +593,12 @@ CssStyle CssParser::resolveStyle(const std::string& tagName, const std::string& 
       into.applyOver(cached);
       return;
     }
-    const auto off = offsetsBySelector_.find(key);
-    if (off == offsetsBySelector_.end()) {
+    uint32_t styleOffset = 0;
+    if (!findStyleOffsetForSelector(key, styleOffset)) {
       return;
     }
     CssStyle fromDisk;
-    if (readStyleAtOffset(off->second, fromDisk)) {
+    if (readStyleAtOffset(styleOffset, fromDisk)) {
       lruPut(key, fromDisk);
       into.applyOver(fromDisk);
     }
@@ -770,6 +785,43 @@ bool CssParser::readStyleAtOffset(uint32_t offset, CssStyle& out) const {
   return true;
 }
 
+bool CssParser::findStyleOffsetForSelector(const std::string& key, uint32_t& styleOffsetOut) const {
+  if (!cacheFileOpen_ || hashedIndex_.empty()) {
+    return false;
+  }
+  const uint32_t needle = fnv1aHash(key);
+
+  // Binary-search to the first entry with this hash, then walk the (typically
+  // length-1) collision chain forward.
+  auto lo = std::lower_bound(hashedIndex_.begin(), hashedIndex_.end(), needle,
+                             [](const HashedOffset& e, uint32_t v) { return e.hash < v; });
+
+  for (auto it = lo; it != hashedIndex_.end() && it->hash == needle; ++it) {
+    cacheFile_.seek(it->record);
+    uint16_t selectorLen = 0;
+    if (cacheFile_.read(&selectorLen, sizeof(selectorLen)) != sizeof(selectorLen)) {
+      return false;
+    }
+    if (selectorLen != key.size() || selectorLen > MAX_SELECTOR_LENGTH) {
+      // Length differs -> can't be the same selector. Skip past this record
+      // and continue scanning the collision chain.
+      continue;
+    }
+    char buf[MAX_SELECTOR_LENGTH];
+    if (cacheFile_.read(buf, selectorLen) != selectorLen) {
+      return false;
+    }
+    if (std::memcmp(buf, key.data(), selectorLen) != 0) {
+      // Hash collision with a different selector. Continue to next entry.
+      continue;
+    }
+    // Verified match: style payload is right after the selector.
+    styleOffsetOut = it->record + sizeof(uint16_t) + selectorLen;
+    return true;
+  }
+  return false;
+}
+
 bool CssParser::lruGet(const std::string& key, CssStyle& out) const {
   for (auto it = lru_.begin(); it != lru_.end(); ++it) {
     if (it->first == key) {
@@ -806,7 +858,8 @@ void CssParser::lruPut(const std::string& key, const CssStyle& value) const {
 
 void CssParser::clear() {
   rulesBySelector_.clear();
-  offsetsBySelector_.clear();
+  hashedIndex_.clear();
+  hashedIndex_.shrink_to_fit();
   lru_.clear();
   if (cacheFileOpen_) {
     cacheFile_.close();
@@ -843,34 +896,50 @@ bool CssParser::loadFromCache() {
     return false;
   }
 
-  // Pre-size the hash map to avoid repeated rehashes; a few rehashes at 470+
-  // entries are enough to fragment the tight heap we're trying to conserve.
-  offsetsBySelector_.reserve(ruleCount);
+  // Reserve the index up-front. 8 bytes per entry; even at MAX_RULES the
+  // total is ~12 KB and a single contiguous allocation -- comfortably below
+  // any heap-floor that allows the section build to proceed at all.
+  hashedIndex_.reserve(ruleCount);
 
-  // Walk each rule, record selector→offset-of-style mapping, skip past the
-  // serialized style without deserializing it. Style bytes stay on SD and are
-  // read on demand in resolveStyle.
+  // Stack buffer for reading selector bytes during index build. We don't
+  // need to keep the selector strings around -- the original record stays
+  // on disk and can be re-read for collision verification at lookup time.
+  char selectorBuf[MAX_SELECTOR_LENGTH];
+
   for (uint16_t i = 0; i < ruleCount; ++i) {
+    const uint32_t recordOffset = static_cast<uint32_t>(cacheFile_.position());
+
     uint16_t selectorLen = 0;
     if (cacheFile_.read(&selectorLen, sizeof(selectorLen)) != sizeof(selectorLen)) {
       clear();
       return false;
     }
-
-    std::string selector;
-    selector.resize(selectorLen);
-    if (selectorLen > 0 && cacheFile_.read(&selector[0], selectorLen) != selectorLen) {
+    if (selectorLen > MAX_SELECTOR_LENGTH) {
+      // Cache file is corrupt or from an older format with no length cap.
+      // Bail rather than over-read into the next record.
+      LOG_DBG("CSS", "Selector length %u exceeds cap %u at rule %u", (unsigned)selectorLen,
+              (unsigned)MAX_SELECTOR_LENGTH, (unsigned)i);
+      clear();
+      return false;
+    }
+    if (selectorLen > 0 && cacheFile_.read(selectorBuf, selectorLen) != selectorLen) {
       clear();
       return false;
     }
 
-    const uint32_t styleOffset = static_cast<uint32_t>(cacheFile_.position());
-    // Skip style payload (fixed size in v4 format).
-    cacheFile_.seek(styleOffset + CSS_STYLE_SERIALIZED_SIZE);
+    const uint32_t hash = fnv1aHash(selectorBuf, selectorLen);
+    hashedIndex_.push_back({hash, recordOffset});
 
-    offsetsBySelector_.emplace(std::move(selector), styleOffset);
+    // Skip style payload (fixed size in v4 format).
+    cacheFile_.seek(static_cast<uint32_t>(cacheFile_.position()) + CSS_STYLE_SERIALIZED_SIZE);
   }
 
-  LOG_DBG("CSS", "Indexed %u rules from cache (disk-paged)", ruleCount);
+  // Sort by hash so lookup is a binary search. One-time O(N log N) cost on
+  // 470 entries is sub-millisecond.
+  std::sort(hashedIndex_.begin(), hashedIndex_.end(),
+            [](const HashedOffset& a, const HashedOffset& b) { return a.hash < b.hash; });
+
+  LOG_DBG("CSS", "Indexed %u rules from cache (hashed disk-paged, %u bytes)", ruleCount,
+          (unsigned)(hashedIndex_.size() * sizeof(HashedOffset)));
   return true;
 }

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -126,8 +126,8 @@ class CssParser {
   // record + one read of the style payload (same I/O as before, just no
   // in-RAM string copies). The on-disk cache format is unchanged.
   struct HashedOffset {
-    uint32_t hash;     // FNV-1a of normalized selector
-    uint32_t record;   // Byte offset of selectorLen field in the cache file
+    uint32_t hash;    // FNV-1a of normalized selector
+    uint32_t record;  // Byte offset of selectorLen field in the cache file
   };
   std::vector<HashedOffset> hashedIndex_;
 

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -66,13 +66,13 @@ class CssParser {
   /**
    * Check if any rules have been loaded (RAM map or disk-paged index)
    */
-  [[nodiscard]] bool empty() const { return rulesBySelector_.empty() && offsetsBySelector_.empty(); }
+  [[nodiscard]] bool empty() const { return rulesBySelector_.empty() && hashedIndex_.empty(); }
 
   /**
    * Get count of loaded rule sets
    */
   [[nodiscard]] size_t ruleCount() const {
-    return rulesBySelector_.empty() ? offsetsBySelector_.size() : rulesBySelector_.size();
+    return rulesBySelector_.empty() ? hashedIndex_.size() : rulesBySelector_.size();
   }
 
   /**
@@ -110,11 +110,26 @@ class CssParser {
   // loadFromCache. Not used during rendering.
   std::unordered_map<std::string, CssStyle> rulesBySelector_;
 
-  // Render-time disk-paged index: maps normalized selector -> file offset of
-  // its serialized CssStyle inside the CSS cache file. Populated by
-  // loadFromCache; styles are fetched on demand via readStyleAtOffset.
-  // Dramatically reduces RAM pressure on books with hundreds of CSS rules.
-  std::unordered_map<std::string, uint32_t> offsetsBySelector_;
+  // Render-time disk-paged index: a sorted vector of (selector hash, byte
+  // offset of selector record in the CSS cache file). Replaces the prior
+  // unordered_map<string, uint32_t> which cost ~70 bytes per entry (string
+  // copy + node + bucket). At 470 rules that map was ~33 KB persistent
+  // heap -- more than the largest contiguous free block on this device
+  // after custom-font activation fragments memory, blocking section
+  // rebuild for big books like Wolfe.
+  //
+  // New cost: 8 bytes per entry (~3.76 KB at 470 rules). Lookup is hash +
+  // binary-search on the sorted vector; on hash hit the original selector
+  // is read back from disk and strcmp'd to disambiguate collisions.
+  // Collisions are rare for short ASCII selectors so the typical lookup
+  // does one binary-search probe + one SD seek to read the verified
+  // record + one read of the style payload (same I/O as before, just no
+  // in-RAM string copies). The on-disk cache format is unchanged.
+  struct HashedOffset {
+    uint32_t hash;     // FNV-1a of normalized selector
+    uint32_t record;   // Byte offset of selectorLen field in the cache file
+  };
+  std::vector<HashedOffset> hashedIndex_;
 
   // Kept open for the life of loaded cache so resolveStyle can seek+read.
   // Closed by clear().
@@ -130,6 +145,11 @@ class CssParser {
 
   // Internal disk-paged helpers
   [[nodiscard]] bool readStyleAtOffset(uint32_t offset, CssStyle& out) const;
+  // Resolve a selector to the file offset of its style payload, or return
+  // false if no matching rule exists. Hashes the key, binary-searches
+  // hashedIndex_, and verifies any hits by re-reading the selector record
+  // off disk to handle hash collisions correctly.
+  [[nodiscard]] bool findStyleOffsetForSelector(const std::string& key, uint32_t& styleOffsetOut) const;
   [[nodiscard]] bool lruGet(const std::string& key, CssStyle& out) const;
   void lruPut(const std::string& key, const CssStyle& value) const;
 

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -328,8 +328,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                 self->currentPage.reset(new (std::nothrow) Page());
                 if (!self->currentPage) {
                   LOG_DIAG("EHP", "OOM new Page (image overflow) free=%u largest=%u min=%u",
-                           (unsigned)ESP.getFreeHeap(),
-                           (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT),
+                           (unsigned)ESP.getFreeHeap(), (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT),
                            (unsigned)ESP.getMinFreeHeap());
                   self->parseFailed = true;
                   return;
@@ -338,10 +337,8 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
               } else if (!self->currentPage) {
                 self->currentPage.reset(new (std::nothrow) Page());
                 if (!self->currentPage) {
-                  LOG_DIAG("EHP", "OOM new Page (image initial) free=%u largest=%u min=%u",
-                           (unsigned)ESP.getFreeHeap(),
-                           (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT),
-                           (unsigned)ESP.getMinFreeHeap());
+                  LOG_DIAG("EHP", "OOM new Page (image initial) free=%u largest=%u min=%u", (unsigned)ESP.getFreeHeap(),
+                           (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT), (unsigned)ESP.getMinFreeHeap());
                   self->parseFailed = true;
                   return;
                 }
@@ -356,8 +353,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
               // and bail.
               auto* rawImageBlock = new (std::nothrow) ImageBlock(cachedImagePath, displayWidth, displayHeight);
               if (!rawImageBlock) {
-                LOG_DIAG("EHP", "OOM new ImageBlock free=%u largest=%u",
-                         (unsigned)ESP.getFreeHeap(),
+                LOG_DIAG("EHP", "OOM new ImageBlock free=%u largest=%u", (unsigned)ESP.getFreeHeap(),
                          (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
                 self->parseFailed = true;
                 return;
@@ -366,8 +362,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
               int xPos = (self->viewportWidth - displayWidth) / 2;
               auto* rawPageImage = new (std::nothrow) PageImage(imageBlock, xPos, self->currentPageNextY);
               if (!rawPageImage) {
-                LOG_DIAG("EHP", "OOM new PageImage free=%u largest=%u",
-                         (unsigned)ESP.getFreeHeap(),
+                LOG_DIAG("EHP", "OOM new PageImage free=%u largest=%u", (unsigned)ESP.getFreeHeap(),
                          (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
                 self->parseFailed = true;
                 return;
@@ -1034,9 +1029,8 @@ void ChapterHtmlSlimParser::makePages() {
   if (!currentPage) {
     currentPage.reset(new (std::nothrow) Page());
     if (!currentPage) {
-      LOG_DIAG("EHP", "OOM new Page (makePages entry) free=%u largest=%u min=%u fontId=%d",
-               (unsigned)ESP.getFreeHeap(), (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT),
-               (unsigned)ESP.getMinFreeHeap(), fontId);
+      LOG_DIAG("EHP", "OOM new Page (makePages entry) free=%u largest=%u min=%u fontId=%d", (unsigned)ESP.getFreeHeap(),
+               (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT), (unsigned)ESP.getMinFreeHeap(), fontId);
       parseFailed = true;
       return;
     }

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -864,6 +864,7 @@ bool JsonSettingsIO::saveRecentBooks(const RecentBooksStore& store, const char* 
     obj["author"] = book.author;
     obj["coverBmpPath"] = book.coverBmpPath;
     obj["boldSwap"] = book.boldSwap;
+    obj["percent"] = book.percent;
   }
 
   String json;
@@ -890,6 +891,9 @@ bool JsonSettingsIO::loadRecentBooks(RecentBooksStore& store, const char* json) 
     book.coverBmpPath = obj["coverBmpPath"] | std::string("");
     // Missing field (older recent.json) -> default OFF.
     book.boldSwap = (obj["boldSwap"] | (uint8_t)0) != 0 ? 1 : 0;
+    // Missing field (older recent.json) -> -1 = unknown; first read while
+    // book is open will populate it.
+    book.percent = static_cast<int8_t>(obj["percent"] | -1);
     store.recentBooks.push_back(book);
   }
 

--- a/src/RecentBooksStore.cpp
+++ b/src/RecentBooksStore.cpp
@@ -127,6 +127,18 @@ void RecentBooksStore::updateBook(const std::string& path, const std::string& ti
   }
 }
 
+void RecentBooksStore::setPercent(const std::string& path, int percent) {
+  const std::string normalizedKey = makeRecentPathKey(normalizeRecentPath(path));
+  auto it = std::find_if(recentBooks.begin(), recentBooks.end(),
+                         [&](const RecentBook& book) { return makeRecentPathKey(book.path) == normalizedKey; });
+  if (it == recentBooks.end()) return;
+  // Clamp to int8_t range; -1 means unknown, 0-100 are valid percents.
+  const int clamped = (percent < 0) ? -1 : (percent > 100 ? 100 : percent);
+  if (it->percent == clamped) return;  // No change, skip the disk write.
+  it->percent = static_cast<int8_t>(clamped);
+  saveToFile();
+}
+
 void RecentBooksStore::removeBook(const std::string& path) {
   const std::string normalizedPath = normalizeRecentPath(path);
   const std::string normalizedKey = makeRecentPathKey(normalizedPath);

--- a/src/RecentBooksStore.h
+++ b/src/RecentBooksStore.h
@@ -13,6 +13,13 @@ struct RecentBook {
   // affects the book it was toggled on.
   uint8_t boldSwap = 0;
 
+  // Cached reading progress (0-100, or -1 = unknown). Stored here so the
+  // home screen can render the per-book percent without opening the EPUB
+  // (which previously cost a spine+TOC parse per recent on every home
+  // entry, fragmenting the heap badly enough to block large books from
+  // opening). Updated on book exit / page turn from the reader.
+  int8_t percent = -1;
+
   bool operator==(const RecentBook& other) const { return path == other.path; }
 };
 
@@ -41,6 +48,10 @@ class RecentBooksStore {
 
   void updateBook(const std::string& path, const std::string& title, const std::string& author,
                   const std::string& coverBmpPath);
+  // Update only the cached reading percent for a book; no-op if the book is
+  // not registered. Used by the reader on exit / progress save so the home
+  // screen can show progress without re-opening every recent EPUB.
+  void setPercent(const std::string& path, int percent);
   void removeBook(const std::string& path);
 
   // Move a book file (and its QUOTES sidecar) to /recents/.

--- a/src/activities/Activity.cpp
+++ b/src/activities/Activity.cpp
@@ -11,9 +11,7 @@ namespace {
 // 8 KB render-task stack + ~4 KB margin for trampoline / FreeRTOS bookkeeping.
 constexpr size_t kRenderTaskMinLargestBlock = 12 * 1024;
 
-bool hasRoomForRenderTask() {
-  return heap_caps_get_largest_free_block(MALLOC_CAP_8BIT) >= kRenderTaskMinLargestBlock;
-}
+bool hasRoomForRenderTask() { return heap_caps_get_largest_free_block(MALLOC_CAP_8BIT) >= kRenderTaskMinLargestBlock; }
 }  // namespace
 
 void Activity::renderTaskTrampoline(void* param) {

--- a/src/activities/ActivityWithSubactivity.cpp
+++ b/src/activities/ActivityWithSubactivity.cpp
@@ -75,7 +75,7 @@ void ActivityWithSubactivity::enterNewActivity(Activity* activity) {
     exitActivity();
     return;
   }
-  oom->setOnDismiss([this] { this->exitActivity(); });
+  oom->setOnDismiss([this] { this->onSubactivityEntryFailedFatally(); });
   mappedInput.suppressUntilAllReleased();
   subActivity.reset(oom);
   subActivity->onEnter();

--- a/src/activities/ActivityWithSubactivity.h
+++ b/src/activities/ActivityWithSubactivity.h
@@ -9,6 +9,14 @@ class ActivityWithSubactivity : public Activity {
   void exitActivity();
   void enterNewActivity(Activity* activity);
   [[noreturn]] void renderTaskLoop() override;
+  // Hook fired when the OOM screen swapped in by enterNewActivity (after a
+  // subactivity entry failure) is dismissed by the user. Default behavior
+  // just tears down the OOM screen and restores the parent render task,
+  // which leaves the user staring at a blank parent — fine for trivial
+  // parents but a dead-end for ReaderActivity (no chrome of its own).
+  // Subclasses override to route the user somewhere navigable (library,
+  // home, etc.) after the dismissal.
+  virtual void onSubactivityEntryFailedFatally() { exitActivity(); }
 
  public:
   explicit ActivityWithSubactivity(std::string name, GfxRenderer& renderer, MappedInputManager& mappedInput)

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -123,8 +123,21 @@ void HomeActivity::loadRecentBooks(int maxBooks) {
     eligibleCount++;
     RecentBook entry = book;
     if (isClassic) {
-      const auto percent = BookProgress::getPercent(book.path);
-      entry.title = "[" + (percent.has_value() ? std::to_string(percent.value()) : "0") + "%]  " + book.title;
+      // Use the cached percent from RecentBooksStore (updated by the
+      // reader on book exit / progress save). Avoids opening every recent
+      // EPUB at home entry, which previously cost a spine+TOC parse per
+      // book and fragmented the heap badly enough to block large books
+      // from opening at all.
+      //
+      // When percent < 0 the value has not been cached on this firmware
+      // yet (book hasn't been opened since the cache field was added).
+      // Show the title without a percent prefix rather than a misleading
+      // "0%". Reading actual position lives in progress.bin on SD; the
+      // first page-turn after opening will populate the cache and the
+      // prefix will appear thereafter.
+      if (book.percent >= 0) {
+        entry.title = "[" + std::to_string(book.percent) + "%]  " + book.title;
+      }
       // Classic mode should never attempt to load/render cover images.
       entry.coverBmpPath.clear();
     }

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -60,8 +60,11 @@ void RecentBooksActivity::loadRecentBooks() {
     if (!Storage.exists(book.path.c_str())) {
       continue;
     }
-    const auto percent = BookProgress::getPercent(book.path);
-    if (!percent.has_value() || percent.value() <= 2) {
+    // Use cached percent (updated by the reader on book exit / progress
+    // save) so we don't open every recent EPUB just to render this list.
+    // Books we've never opened on this firmware show percent=-1 -> skip
+    // until the user opens them once and we cache the real value.
+    if (book.percent <= 2) {
       continue;
     }
 
@@ -72,7 +75,7 @@ void RecentBooksActivity::loadRecentBooks() {
     RecentBook decorated = book;
     const std::string initials = buildAuthorInitials(book.author);
     const std::string titleWithAuthor = initials.empty() ? book.title : (book.title + " by " + initials);
-    decorated.title = "[" + std::to_string(percent.value()) + "%]  " + titleWithAuthor;
+    decorated.title = "[" + std::to_string(book.percent) + "%]  " + titleWithAuthor;
     recentBooks.push_back(std::move(decorated));
   }
 }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -281,7 +281,16 @@ namespace {
 // mid-layout malloc failure cleanly, so a 20 KB floor optimizes for "try
 // and let the failure path catch it" over "block proactively".
 constexpr size_t kMinLargestBlockForLayout = 48 * 1024;
-constexpr size_t kMinLargestBlockHardFloor = 20 * 1024;
+// Hard floor for attempting a section *rebuild*. Below this, the parser
+// pipeline will reliably hit bad_alloc deep inside expat callbacks and
+// terminate(). Hardware testing on Wolfe (216-spine, dense prose) shows
+// rebuilds at largest=25588 still overflow on big sections; 28 KB is the
+// observed safe boundary where books known to fit (Lydia Davis 53 pages,
+// Shadow Slave 18 pages) all open and known-too-big books (Wolfe section
+// 26) get the recovery screen instead of a reset. Future work: streaming
+// section build that doesn't hold full per-page elements in heap during
+// parseAndBuildPages -- that fix lifts this floor back down.
+constexpr size_t kMinLargestBlockHardFloor = 28 * 1024;
 }  // namespace
 
 void EpubReaderActivity::releaseMaxResources() {
@@ -1816,6 +1825,19 @@ void EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageC
                                                static_cast<int32_t>(pageCount)};
   progressSink_.write(pos);
   progress_.seed(pos);
+
+  // Cache the percent in RecentBooksStore so the home screen can render it
+  // without re-opening the EPUB. Computation mirrors getEpubPercent in
+  // util/BookProgress.cpp -- chapterProgress is currentPage / pageCount,
+  // then Epub::calculateProgress folds in spine sizes for the absolute
+  // percent. We already have epub + spine + page + count here, so this is
+  // ~free vs the cost of loading the EPUB at home entry.
+  if (epub && pageCount > 0) {
+    const int safePage = (currentPage < 0) ? 0 : (currentPage >= pageCount ? pageCount - 1 : currentPage);
+    const float chapterProgress = static_cast<float>(safePage) / static_cast<float>(pageCount);
+    const int percent = static_cast<int>(epub->calculateProgress(spineIndex, chapterProgress) * 100.0f + 0.5f);
+    RECENT_BOOKS.setPercent(epub->getPath(), percent);
+  }
 }
 void EpubReaderActivity::flushProgressIfNeeded(const bool force) {
   if (!epub || !section || section->pageCount == 0) {
@@ -1826,6 +1848,16 @@ void EpubReaderActivity::flushProgressIfNeeded(const bool force) {
                      static_cast<int32_t>(section->pageCount)},
                     now);
   progress_.flush(now, force);
+
+  // Keep the home-screen percent cache fresh. setPercent is a no-op when
+  // the value hasn't changed (no SD write), so this is cheap on every
+  // page turn and only persists when the percent actually advances.
+  const int safePage = (section->currentPage < 0)                       ? 0
+                       : (section->currentPage >= section->pageCount)   ? section->pageCount - 1
+                                                                        : section->currentPage;
+  const float chapterProgress = static_cast<float>(safePage) / static_cast<float>(section->pageCount);
+  const int percent = static_cast<int>(epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f + 0.5f);
+  RECENT_BOOKS.setPercent(epub->getPath(), percent);
 }
 
 void EpubReaderActivity::addSessionPagesRead(const uint32_t amount) { APP_STATE.sessionPagesRead += amount; }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1852,9 +1852,9 @@ void EpubReaderActivity::flushProgressIfNeeded(const bool force) {
   // Keep the home-screen percent cache fresh. setPercent is a no-op when
   // the value hasn't changed (no SD write), so this is cheap on every
   // page turn and only persists when the percent actually advances.
-  const int safePage = (section->currentPage < 0)                       ? 0
-                       : (section->currentPage >= section->pageCount)   ? section->pageCount - 1
-                                                                        : section->currentPage;
+  const int safePage = (section->currentPage < 0)                     ? 0
+                       : (section->currentPage >= section->pageCount) ? section->pageCount - 1
+                                                                      : section->currentPage;
   const float chapterProgress = static_cast<float>(safePage) / static_cast<float>(section->pageCount);
   const int percent = static_cast<int>(epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f + 0.5f);
   RECENT_BOOKS.setPercent(epub->getPath(), percent);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -106,6 +106,25 @@ void EpubReaderActivity::onEnter() {
     return;
   }
 
+  // PR #101: ReaderActivity::loadEpub now always skips CSS, so the heap is
+  // still fat when the base class's xTaskCreate runs. Pull the CSS index in
+  // here, after the 8 KB stack is acquired. For USER style mode the CSS
+  // rules aren't consulted, so we skip the work entirely. ensureCssCache
+  // failure is non-fatal — Section.cpp will fall back to layout without
+  // CSS rules and the user gets a stylistically degraded but readable page.
+  if (didEntryFail()) {
+    return;
+  }
+  if (SETTINGS.readerStyleMode != CrossPointSettings::READER_STYLE_USER) {
+    LOG_DBG("HEAP", "EPUB onEnter:before-css free=%u largest=%u", (unsigned)ESP.getFreeHeap(),
+            (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+    if (!epub->ensureCssCache(nullptr)) {
+      LOG_ERR("EPUB", "Deferred CSS cache load failed — book renders without CSS");
+    }
+    LOG_DBG("HEAP", "EPUB onEnter:after-css free=%u largest=%u", (unsigned)ESP.getFreeHeap(),
+            (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+  }
+
   // Full refresh on book enter. The v1.2.0 experiment downgraded this to
   // requestHalfRefresh() to shave ~1 s off open time, but hardware capture
   // 2026-04-24 caught the failure mode the original author warned about:

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -57,7 +57,15 @@ std::unique_ptr<Epub> ReaderActivity::loadEpub(const std::string& path) {
 
   LOG_DBG("HEAP", "READER loadEpub:before free=%u largest=%u min=%u", (unsigned)ESP.getFreeHeap(),
           (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT), (unsigned)ESP.getMinFreeHeap());
-  if (epub->load(true, readerStyleMode == CrossPointSettings::READER_STYLE_USER)) {
+  // Always skip CSS load here. Loading the CSS index eagerly (Wolfe = 33 KB)
+  // before the EpubReaderActivity render task is even spawned was the source
+  // of the post-PR-#100 OOM screen on heavy books: by the time xTaskCreate
+  // runs, largest_free_block has already collapsed below the 8 KB stack.
+  // EpubReaderActivity::onEnter calls ensureCssCache() after acquiring its
+  // task, so the 33 KB pressure is sequential with the stack alloc rather
+  // than simultaneous.
+  (void)readerStyleMode;
+  if (epub->load(true, /*skipLoadingCss=*/true)) {
     LOG_DBG("HEAP", "READER loadEpub:after-ok free=%u largest=%u min=%u", (unsigned)ESP.getFreeHeap(),
             (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT), (unsigned)ESP.getMinFreeHeap());
     return epub;

--- a/src/activities/reader/ReaderActivity.h
+++ b/src/activities/reader/ReaderActivity.h
@@ -37,4 +37,15 @@ class ReaderActivity final : public ActivityWithSubactivity {
         onGoToLibrary(onGoToLibrary) {}
   void onEnter() override;
   bool isReaderActivity() const override { return true; }
+
+ protected:
+  // Override: when an inner reader subactivity (Epub/Xtc/Txt/Quotes) cannot
+  // bring itself up and is replaced by the OOM screen, the user dismissing
+  // that screen needs to land somewhere navigable. ReaderActivity has no
+  // chrome of its own, so dropping back to the library at the failing
+  // book's folder is the right escape hatch.
+  void onSubactivityEntryFailedFatally() override {
+    exitActivity();
+    goToLibrary(currentBookPath);
+  }
 };

--- a/src/activities/reader/SectionPageCache.h
+++ b/src/activities/reader/SectionPageCache.h
@@ -1,3 +1,7 @@
+#pragma once
+
+#include <esp_heap_caps.h>
+
 /**
  * @file SectionPageCache.h
  * @brief 3-page sliding window + pending-nav bundle for the reader.
@@ -17,7 +21,6 @@
  * Not wired into EpubReaderActivity in this stage. Stage 4 integrates
  * behind READER_V2 gate with V1 parallel.
  */
-#pragma once
 
 #include <array>
 #include <cstddef>
@@ -124,11 +127,24 @@ class SectionPageCache {
   // is invoked.
   //
   // If centerPage is out of bounds, cache is cleared.
+  //
+  // When the largest contiguous heap block is below kPrefetchHeapFloor at
+  // window-build time, the prev/next slots are skipped and only the
+  // current page is cached. This sacrifices fast page-turns on big books
+  // (each turn re-reads from the section cache file, ~200-500 ms) in
+  // exchange for ~6-10 KB of contiguous heap headroom -- enough to let
+  // the next section build run on heavy books like Wolfe that previously
+  // hit the layout pre-flight floor and could not open at all. When heap
+  // recovers (e.g. after a back-to-home cycle), the next refreshWindow
+  // call re-enables full prefetch automatically.
   void refreshWindow(int centerPage, PagePtr currentPage, int sectionPageCount, const PageLoader& loader) {
     if (centerPage < 0 || centerPage >= sectionPageCount) {
       clearEntries_();
       return;
     }
+
+    constexpr size_t kPrefetchHeapFloor = 30 * 1024;
+    const bool prefetchOk = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT) >= kPrefetchHeapFloor;
 
     std::array<Entry, kWindow> next{};
     const int targets[kWindow] = {centerPage - 1, centerPage, centerPage + 1};
@@ -140,6 +156,10 @@ class SectionPageCache {
       PagePtr p;
       if (t == centerPage) {
         p = currentPage;
+      } else if (!prefetchOk) {
+        // Heap-pressured: leave the prev/next slot empty.  Subsequent
+        // page-turns will load on demand.
+        continue;
       } else {
         p = getRaw_(t);
         if (!p && loader) p = loader(t);

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -447,10 +447,9 @@ void CrossPointWebServer::handleI18nDict() const {
   const WebI18nBlob blob = getWebI18nBlob(lang);
   server->sendHeader("Content-Encoding", "gzip");
   server->sendHeader("Cache-Control", "no-cache");
-  server->send_P(200, "application/json",
-                 reinterpret_cast<const char*>(blob.data), blob.size);
-  LOG_DBG("WEB", "Served /api/i18n.json (lang=%u, %u B gz)",
-          static_cast<unsigned>(lang), static_cast<unsigned>(blob.size));
+  server->send_P(200, "application/json", reinterpret_cast<const char*>(blob.data), blob.size);
+  LOG_DBG("WEB", "Served /api/i18n.json (lang=%u, %u B gz)", static_cast<unsigned>(lang),
+          static_cast<unsigned>(blob.size));
 }
 
 void CrossPointWebServer::stop() {


### PR DESCRIPTION
Stacks on top of #100. Consolidates this session's memory-pressure fixes targeting the regression introduced in `8671e42` (BDF→CPBN custom font swap, 2026-04-25) where books with large CSS files could no longer open after custom-font activation fragmented the heap.

## What landed

### 1) Hashed disk-paged CSS index — `lib/Epub/Epub/css/CssParser.{h,cpp}`

Replaces `unordered_map<string, uint32_t> offsetsBySelector_` with a sorted `vector<{uint32_t hash, uint32_t recordOffset}>`. At 470 rules (Wolfe) the in-RAM cost drops from **~33 KB → 3.76 KB** persistent. Lookup hashes the selector with FNV-1a, binary-searches the sorted vector, then re-reads the selector record from disk to verify hash collisions.

On-disk cache format unchanged. `CSS_CACHE_VERSION` stays at 4. Existing caches load directly.

### 2) Cached reading-percent in RecentBooksStore

Adds `RecentBook::percent` (`int8_t`, `-1` = unknown) persisted in `recent.json`. Home and recent-books activities read this directly instead of opening every recent EPUB at home entry to compute the percent fresh. Previously each entry triggered `Epub::load(false, true)` → spine + TOC parse → destructor frees, on **8 books per home entry** — alloc/free pattern that left heap fragmented enough to block big-book opens. Reader pushes the live percent into the cache from `saveProgress` and `flushProgressIfNeeded`, so the value stays fresh without any home-entry EPUB I/O. Books not yet opened on this firmware show no percent prefix instead of a misleading "0%".

### 3) Heap-aware page prefetch — `src/activities/reader/SectionPageCache.h`

`refreshWindow` now skips populating prev/next slots when largest contiguous heap < 30 KB; only the current page is cached. Saves 6-10 KB of contiguous heap on heavy books (each cached `Page` holds its `PageLine` + `TextBlock` element graph). Trade-off: one extra section-cache disk read per page-turn at ~200-500 ms on big books — acceptable on a device that previously could not open them at all.

### 4) Pre-flight floor restored to 28 KB — `EpubReaderActivity.cpp`

Hardware testing on Wolfe shows the section *rebuild* itself peaks too high for `largest=25588`. The build throws `bad_alloc` deep in the parser pipeline, and on this Arduino-ESP32 build the OOM cannot be caught (`__cxa_throw` needs heap to allocate the exception object → falls through to `__cxxabiv1::__terminate` → abort, verified via `addr2line` on PC `0x4216923f` and `0x42166d51`, both `eh_terminate.cc:44`). 28 KB is the observed safe boundary — known-fitting books pass the gate, known-too-big sections get the recovery screen instead of a reset.

Earlier in this session a `-fexceptions` + try/catch approach was attempted (`lib/Epub/library.json`, `lib/expat/library.json` with unwind tables, try/catch around section build). Dropped — the fundamental OOM-can't-throw constraint dead-ends every variant. Reverted cleanly.

## Verified on hardware

| Book | Outcome |
|---|---|
| Lydia Davis (213 spine, 55 CSS rules) | Opens, full CSS, section build runs end-to-end |
| Shadow Slave (1004 spine, 0 CSS rules) | Opens from cached section |
| Bossypants, Selected Poems, Mugger, Pocket Oracle | Open with cached section + full CSS |
| **Wolfe** (216 spine, 470 CSS rules, dense per-section prose) | **Recovery screen** at section rebuild; **no crash, no data loss** |

## What does not yet work

Wolfe specifically still cannot complete a section rebuild on this device's fragmented heap. Pre-flight gate at 28 KB blocks the attempt → low-memory recovery screen → user navigates back to library. `progress.bin` on SD untouched, no progress lost.

## Next steps (future PRs, scoped out of this one)

### Immediate next: streaming section build

The remaining peak is inside `Section::createSectionFile` → `parseAndBuildPages` where each completed `Page` holds its full element graph (`PageLine` + `TextBlock` per line) in heap until the per-page lambda serializes it. For a Wolfe section with 30+ dense pages each carrying ~50 lines, the per-page peak overshoots even at `largest=25 KB`.

Approach: refactor `parseAndBuildPages` to write per-page element data + LUT entries to a sidecar file (`.tmp_section.partial`) immediately on `completeCurrentPage`, splice into the final section file at parse end. `currentPage` resets after each spill. Estimated savings: 8-15 KB peak. Wolfe should complete after this lands.

Estimate: 3-4 hours of careful work + on-device verification.

### Then: custom-font fragmentation audit

Regression source `8671e42` (BDF → CPBN font pipeline swap) introduced a `CustomBinFontManager::activate` lifecycle that fragments the heap before book open. CPBN tables themselves go to BSS (no heap impact per existing memory note), but the activation path's working buffers are the suspect. Need to instrument and identify which step holds heap across the activate/deactivate boundary.

If the activation cost can be deferred or coalesced, the post-activate baseline would lift from `largest=25 KB` back toward the pre-regression `largest=60+ KB`, restoring full reliability for Wolfe-class books even without the streaming layout work.

### Wider memory + reading-quality audit

Per the user's directive, a follow-up survey of every firmware feature that competes with the layout heap budget — even when not actively used. Candidates flagged for measurement:

- BLE / Bluetooth gamepad support (compiled in, never used on this device)
- OTG host support
- Embedded web server (already verified: only runs while in file-transfer activity, drops cleanly on exit — **not** the suspect)
- KOReader sync
- Sleep wallpaper subsystem
- Custom-font CPBN cache strategy (overlap with the audit above)
- Recents bar metadata pre-load (addressed in this PR — kept here as the template for "remove silent heap costs")

Each gets a heap measurement + a one-line keep / move-to-opt-in / remove recommendation. Goal: lift the post-init baseline so even the largest books open reliably.

## Test plan

- [x] `pio run -e debug` — green
- [x] `pio run -e default` — green
- [x] Hardware: Lydia Davis opens with full CSS, section rebuild succeeds (53+ pages built end-to-end)
- [x] Hardware: Shadow Slave opens from cache
- [x] Hardware: Wolfe shows recovery screen on section rebuild attempt (no crash, no data loss)
- [x] Hardware: home screen shows cached percent for opened books, no prefix for un-opened books
- [x] Hardware: opening a book and turning a page populates the cache, reflected on next home entry
- [ ] Soak: confirm no regression on a session of mixed-book use over 30+ minutes
- [ ] Confirm migration: existing `recent.json` without `percent` field loads cleanly with `-1` defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)