### PR TITLE
fix(memory): unfragment heap by capping in-RAM sleep playlist; DIAG instrumentation

### DIFF
--- a/src/CrossPointState.h
+++ b/src/CrossPointState.h
@@ -20,7 +20,23 @@ class CrossPointState {
  public:
   // Collections larger than this threshold are handled without a full in-memory
   // playlist; only the last-shown filename is persisted in that case.
-  static constexpr size_t SLEEP_PLAYLIST_MAX_PERSIST = 500;
+  // Why 30: each persisted entry is one std::string heap allocation
+  // (~30-50 bytes) plus an ArduinoJson JsonVariant during deserialize.
+  // At 500 the boot-time deserialize of state.json scattered ~270 small
+  // blocks across the heap, splitting the largest contiguous block from
+  // ~63 KB to ~17 KB — small enough that every book open hit the
+  // pre-flight gate. Capping at 30 keeps shuffle UX for small wallpaper
+  // collections; bigger collections fall through to the sequential
+  // lastShownSleepFilename path which never holds the playlist in RAM.
+  static constexpr size_t SLEEP_PLAYLIST_MAX_PERSIST = 30;
+
+  // User-facing cap on protected ([F]-suffixed) sleep wallpapers.
+  // Counted from disk in countProtectedSleepFavorites(), so this does
+  // not pressure the heap the way the in-memory playlist does. Kept at
+  // the historical 500 so users who already curated large favorite
+  // collections do not see "Sleep favorites full" after the playlist
+  // cap was lowered.
+  static constexpr size_t SLEEP_FAVORITES_MAX = 500;
 
   std::string openEpubPath;
   uint8_t lastSleepImage = UINT8_MAX;  // UINT8_MAX = unset sentinel

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -291,8 +291,8 @@ static bool safeWriteFile(const char* path, const String& json) {
       return false;
     }
   }
-  LOG_DIAG("JSN", "safeWriteFile step3 primary_exists_after=%d bak_exists_after=%d",
-           Storage.exists(path) ? 1 : 0, Storage.exists(bakPath) ? 1 : 0);
+  LOG_DIAG("JSN", "safeWriteFile step3 primary_exists_after=%d bak_exists_after=%d", Storage.exists(path) ? 1 : 0,
+           Storage.exists(bakPath) ? 1 : 0);
 
   // 4. Promote tmp to current
   if (!Storage.rename(activeTmp, path)) {
@@ -309,8 +309,7 @@ static bool safeWriteFile(const char* path, const String& json) {
     }
     return false;
   }
-  LOG_DIAG("JSN", "safeWriteFile step4 promoted tmp->%s ok primary_exists=%d", path,
-           Storage.exists(path) ? 1 : 0);
+  LOG_DIAG("JSN", "safeWriteFile step4 promoted tmp->%s ok primary_exists=%d", path, Storage.exists(path) ? 1 : 0);
 
   return true;
 }
@@ -357,9 +356,9 @@ String JsonSettingsIO::safeReadFile(const char* path) {
 // ---- CrossPointSettings ----
 
 bool JsonSettingsIO::saveSettings(const CrossPointSettings& s, const char* path) {
-  LOG_DIAG("CPS", "saveSettings: enter ff=%u fs=%u lsp=%u customFont='%s' cfsPt=%u path=%s",
-           (unsigned)s.fontFamily, (unsigned)s.fontSize, (unsigned)s.lineSpacingPercent,
-           s.customFontName.c_str(), (unsigned)s.customFontSizePt, path);
+  LOG_DIAG("CPS", "saveSettings: enter ff=%u fs=%u lsp=%u customFont='%s' cfsPt=%u path=%s", (unsigned)s.fontFamily,
+           (unsigned)s.fontSize, (unsigned)s.lineSpacingPercent, s.customFontName.c_str(), (unsigned)s.customFontSizePt,
+           path);
   JsonDocument doc;
 
   doc["homeLayout"] = s.homeLayout;
@@ -456,8 +455,8 @@ bool JsonSettingsIO::saveSettings(const CrossPointSettings& s, const char* path)
   String json;
   serializeJson(doc, json);
   const bool ok = safeWriteFile(path, json);
-  LOG_DIAG("CPS", "saveSettings: exit ok=%d ff=%u fs=%u lsp=%u path=%s", ok ? 1 : 0,
-           (unsigned)s.fontFamily, (unsigned)s.fontSize, (unsigned)s.lineSpacingPercent, path);
+  LOG_DIAG("CPS", "saveSettings: exit ok=%d ff=%u fs=%u lsp=%u path=%s", ok ? 1 : 0, (unsigned)s.fontFamily,
+           (unsigned)s.fontSize, (unsigned)s.lineSpacingPercent, path);
   return ok;
 }
 
@@ -671,8 +670,8 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
   s.fontFamily = clampEnum(doc["fontFamily"] | (uint8_t)S::CHAREINK, S::FONT_FAMILY_COUNT, S::CHAREINK);
   const uint8_t ffClamped = s.fontFamily;
   s.fontFamily = S::normalizeFontFamily(s.fontFamily);
-  LOG_DIAG("CPS", "loadSettings: ff_present=%d ff_raw=%d ff_clamped=%u ff_normalized=%u", ffPresent ? 1 : 0,
-           ffRaw, (unsigned)ffClamped, (unsigned)s.fontFamily);
+  LOG_DIAG("CPS", "loadSettings: ff_present=%d ff_raw=%d ff_clamped=%u ff_normalized=%u", ffPresent ? 1 : 0, ffRaw,
+           (unsigned)ffClamped, (unsigned)s.fontFamily);
   s.fontSize = clampEnum(doc["fontSize"] | (uint8_t)S::SIZE_16, S::FONT_SIZE_COUNT, S::SIZE_16);
   s.fontSize = S::normalizeFontSizeForFamily(s.fontFamily, s.fontSize);
   // customFontName is optional; absent → empty (old settings.json migrates
@@ -783,9 +782,9 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
     if (!pass.empty() && needsResave) *needsResave = true;
   }
   StringUtils::safeStrncpy(s.opdsPassword, pass.c_str());
-  LOG_DIAG("CPS", "loadSettings: ff=%u fs=%u lsp=%u customFont='%s' cfsPt=%u",
-           (unsigned)s.fontFamily, (unsigned)s.fontSize, (unsigned)s.lineSpacingPercent,
-           s.customFontName.c_str(), (unsigned)s.customFontSizePt);
+  LOG_DIAG("CPS", "loadSettings: ff=%u fs=%u lsp=%u customFont='%s' cfsPt=%u", (unsigned)s.fontFamily,
+           (unsigned)s.fontSize, (unsigned)s.lineSpacingPercent, s.customFontName.c_str(),
+           (unsigned)s.customFontSizePt);
   return true;
 }
 

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -273,6 +273,7 @@ static bool safeWriteFile(const char* path, const String& json) {
     LOG_ERR("JSN", "safeWriteFile: failed to write tmp %s", activeTmp);
     return false;
   }
+  LOG_DIAG("JSN", "safeWriteFile step1 wrote tmp=%s bytes=%u", activeTmp, (unsigned)json.length());
 
   // 2. Remove stale backup
   if (Storage.exists(bakPath)) {
@@ -280,6 +281,7 @@ static bool safeWriteFile(const char* path, const String& json) {
       LOG_ERR("JSN", "safeWriteFile: failed to remove stale bak %s", bakPath);
     }
   }
+  LOG_DIAG("JSN", "safeWriteFile step2 bak_exists_after=%d", Storage.exists(bakPath) ? 1 : 0);
 
   // 3. Rotate current to backup
   if (Storage.exists(path)) {
@@ -289,6 +291,8 @@ static bool safeWriteFile(const char* path, const String& json) {
       return false;
     }
   }
+  LOG_DIAG("JSN", "safeWriteFile step3 primary_exists_after=%d bak_exists_after=%d",
+           Storage.exists(path) ? 1 : 0, Storage.exists(bakPath) ? 1 : 0);
 
   // 4. Promote tmp to current
   if (!Storage.rename(activeTmp, path)) {
@@ -305,6 +309,8 @@ static bool safeWriteFile(const char* path, const String& json) {
     }
     return false;
   }
+  LOG_DIAG("JSN", "safeWriteFile step4 promoted tmp->%s ok primary_exists=%d", path,
+           Storage.exists(path) ? 1 : 0);
 
   return true;
 }
@@ -314,7 +320,10 @@ static bool safeWriteFile(const char* path, const String& json) {
 String JsonSettingsIO::safeReadFile(const char* path) {
   if (Storage.exists(path)) {
     String json = Storage.readFile(path);
-    if (!json.isEmpty()) return json;
+    if (!json.isEmpty()) {
+      LOG_DIAG("JSN", "safeReadFile: source=primary path=%s bytes=%u", path, (unsigned)json.length());
+      return json;
+    }
   }
 
   // Primary failed/empty. Try backup (which means crash happened during step 4
@@ -324,7 +333,7 @@ String JsonSettingsIO::safeReadFile(const char* path) {
   if (Storage.exists(bakPath)) {
     String json = Storage.readFile(bakPath);
     if (!json.isEmpty()) {
-      LOG_DBG("JSN", "safeReadFile: Recovered %s from .bak", path);
+      LOG_DIAG("JSN", "safeReadFile: source=bak path=%s bytes=%u", bakPath, (unsigned)json.length());
       return json;
     }
   }
@@ -336,17 +345,21 @@ String JsonSettingsIO::safeReadFile(const char* path) {
   if (Storage.exists(tmpPath)) {
     String json = Storage.readFile(tmpPath);
     if (!json.isEmpty()) {
-      LOG_DBG("JSN", "safeReadFile: Recovered %s from .tmp", path);
+      LOG_DIAG("JSN", "safeReadFile: source=tmp path=%s bytes=%u", tmpPath, (unsigned)json.length());
       return json;
     }
   }
 
+  LOG_DIAG("JSN", "safeReadFile: source=none path=%s (no readable source)", path);
   return "";
 }
 
 // ---- CrossPointSettings ----
 
 bool JsonSettingsIO::saveSettings(const CrossPointSettings& s, const char* path) {
+  LOG_DIAG("CPS", "saveSettings: enter ff=%u fs=%u lsp=%u customFont='%s' cfsPt=%u path=%s",
+           (unsigned)s.fontFamily, (unsigned)s.fontSize, (unsigned)s.lineSpacingPercent,
+           s.customFontName.c_str(), (unsigned)s.customFontSizePt, path);
   JsonDocument doc;
 
   doc["homeLayout"] = s.homeLayout;
@@ -442,7 +455,10 @@ bool JsonSettingsIO::saveSettings(const CrossPointSettings& s, const char* path)
 
   String json;
   serializeJson(doc, json);
-  return safeWriteFile(path, json);
+  const bool ok = safeWriteFile(path, json);
+  LOG_DIAG("CPS", "saveSettings: exit ok=%d ff=%u fs=%u lsp=%u path=%s", ok ? 1 : 0,
+           (unsigned)s.fontFamily, (unsigned)s.fontSize, (unsigned)s.lineSpacingPercent, path);
+  return ok;
 }
 
 bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool* needsResave) {
@@ -650,8 +666,13 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
   s.frontButtonRight = clampEnum(doc["frontButtonRight"] | (uint8_t)S::FRONT_HW_RIGHT, S::FRONT_BUTTON_HARDWARE_COUNT,
                                  S::FRONT_HW_RIGHT);
   CrossPointSettings::validateFrontButtonMapping(s);
+  const bool ffPresent = !doc["fontFamily"].isNull();
+  const int ffRaw = ffPresent ? (int)(doc["fontFamily"] | (uint8_t)S::CHAREINK) : -1;
   s.fontFamily = clampEnum(doc["fontFamily"] | (uint8_t)S::CHAREINK, S::FONT_FAMILY_COUNT, S::CHAREINK);
+  const uint8_t ffClamped = s.fontFamily;
   s.fontFamily = S::normalizeFontFamily(s.fontFamily);
+  LOG_DIAG("CPS", "loadSettings: ff_present=%d ff_raw=%d ff_clamped=%u ff_normalized=%u", ffPresent ? 1 : 0,
+           ffRaw, (unsigned)ffClamped, (unsigned)s.fontFamily);
   s.fontSize = clampEnum(doc["fontSize"] | (uint8_t)S::SIZE_16, S::FONT_SIZE_COUNT, S::SIZE_16);
   s.fontSize = S::normalizeFontSizeForFamily(s.fontFamily, s.fontSize);
   // customFontName is optional; absent → empty (old settings.json migrates
@@ -762,7 +783,9 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
     if (!pass.empty() && needsResave) *needsResave = true;
   }
   StringUtils::safeStrncpy(s.opdsPassword, pass.c_str());
-  LOG_DBG("CPS", "Settings loaded from file");
+  LOG_DIAG("CPS", "loadSettings: ff=%u fs=%u lsp=%u customFont='%s' cfsPt=%u",
+           (unsigned)s.fontFamily, (unsigned)s.fontSize, (unsigned)s.lineSpacingPercent,
+           s.customFontName.c_str(), (unsigned)s.customFontSizePt);
   return true;
 }
 

--- a/src/activities/Activity.cpp
+++ b/src/activities/Activity.cpp
@@ -69,6 +69,8 @@ void Activity::onEnter() {
     return;
   }
   LOG_DBG("ACT", "Entering activity: %s", name.c_str());
+  LOG_DIAG("ACT", "heap on enter '%s': free=%u largest=%u min=%u", name.c_str(), (unsigned)ESP.getFreeHeap(),
+           (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT), (unsigned)ESP.getMinFreeHeap());
 }
 
 void Activity::onExit() {
@@ -85,6 +87,8 @@ void Activity::onExit() {
   }
 
   LOG_DBG("ACT", "Exiting activity: %s", name.c_str());
+  LOG_DIAG("ACT", "heap on exit '%s': free=%u largest=%u min=%u", name.c_str(), (unsigned)ESP.getFreeHeap(),
+           (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT), (unsigned)ESP.getMinFreeHeap());
 }
 
 void Activity::requestUpdate() {

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -78,7 +78,7 @@ void HomeActivity::refreshSleepFavoriteWarning() {
   // Use the count cached by trimSleepFolderToLimit() (called in onGoHome)
   // instead of re-scanning the /sleep directory.
   protectedSleepFavoriteCount = SleepActivity::cachedSleepFavoriteCount();
-  sleepFavoritesFull = protectedSleepFavoriteCount >= CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST;
+  sleepFavoritesFull = protectedSleepFavoriteCount >= CrossPointState::SLEEP_FAVORITES_MAX;
 }
 
 void HomeActivity::loadRecentBooks(int maxBooks) {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -281,16 +281,20 @@ namespace {
 // mid-layout malloc failure cleanly, so a 20 KB floor optimizes for "try
 // and let the failure path catch it" over "block proactively".
 constexpr size_t kMinLargestBlockForLayout = 48 * 1024;
-// Hard floor for attempting a section *rebuild*. Below this, the parser
-// pipeline will reliably hit bad_alloc deep inside expat callbacks and
-// terminate(). Hardware testing on Wolfe (216-spine, dense prose) shows
-// rebuilds at largest=25588 still overflow on big sections; 28 KB is the
-// observed safe boundary where books known to fit (Lydia Davis 53 pages,
-// Shadow Slave 18 pages) all open and known-too-big books (Wolfe section
-// 26) get the recovery screen instead of a reset. Future work: streaming
-// section build that doesn't hold full per-page elements in heap during
-// parseAndBuildPages -- that fix lifts this floor back down.
-constexpr size_t kMinLargestBlockHardFloor = 28 * 1024;
+// Hard floor for attempting a section *rebuild*. Devices with persistent
+// boot-state fragmentation sit at largest~25 KB indefinitely (PR #96
+// hardware capture). PR #95 set this to 36 KB and PR #100 raised it to
+// 28 KB to give Wolfe-class books (216-spine, dense prose) a recovery
+// screen instead of a bad_alloc->terminate() reset; both values bounced
+// every modest book on this device because the post-defrag largest never
+// climbed above the gate. Reverted to PR #96's 20 KB: the retry-once +
+// auto-revert path in ensureSectionLoaded plus the OOM screen escape
+// hatch added in PR #100 handle a real mid-layout malloc failure cleanly,
+// so the floor optimizes for "try and let the failure path catch it"
+// over "block proactively". Wolfe still cannot complete its layout under
+// any current floor; that needs the streaming-layout work tracked as
+// follow-up to PR #100, not a higher gate.
+constexpr size_t kMinLargestBlockHardFloor = 20 * 1024;
 }  // namespace
 
 void EpubReaderActivity::releaseMaxResources() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -773,6 +773,8 @@ void setup() {
   // default built-in family so the reader doesn't silently render empty
   // text. The header validation runs once at boot via the static
   // validateFile helper — no file is held open afterward.
+  LOG_DIAG("CFONT", "boot fallback check: ff=%u customFont='%s' cfsPt=%u", (unsigned)SETTINGS.fontFamily,
+           SETTINGS.customFontName.c_str(), (unsigned)SETTINGS.customFontSizePt);
   if (SETTINGS.fontFamily == CrossPointSettings::CUSTOM_FAMILY) {
     bool ok = false;
     const char* failReason = "missing";
@@ -805,6 +807,8 @@ void setup() {
       SETTINGS.saveToFile();
     }
   }
+  LOG_DIAG("CFONT", "boot fallback done: ff=%u customFont='%s' cfsPt=%u", (unsigned)SETTINGS.fontFamily,
+           SETTINGS.customFontName.c_str(), (unsigned)SETTINGS.customFontSizePt);
   launchBootDestination();
 
   // Ensure we're not still holding the power button before leaving setup

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -540,6 +540,17 @@ bool ensureCrosspointDataDir() {
   return true;
 }
 
+// Boot heap stage probe: dumps free/largest/free-blocks at named boot
+// checkpoints so we can see which stage strands the heap into small
+// fragments. PR #104 follow-up.
+static void logHeapStage(const char* label) {
+  multi_heap_info_t info;
+  heap_caps_get_info(&info, MALLOC_CAP_8BIT);
+  LOG_DIAG("BOOT", "stage='%s' free=%u largest=%u free_blocks=%u alloc_blocks=%u total=%u", label,
+           (unsigned)info.total_free_bytes, (unsigned)info.largest_free_block, (unsigned)info.free_blocks,
+           (unsigned)info.allocated_blocks, (unsigned)(info.total_free_bytes + info.total_allocated_bytes));
+}
+
 void setup() {
   t1 = millis();
 
@@ -556,6 +567,7 @@ void setup() {
       delay(10);
     }
   }
+  logHeapStage("after_serial");
 
   // SD Card Initialization
   // We need 6 open files concurrently when parsing a new chapter
@@ -576,9 +588,12 @@ void setup() {
     LOG_ERR("MAIN", "Storage layout error: cannot access /.crosspoint");
   }
 
+  logHeapStage("after_sd");
   trash::pruneToCap();
+  logHeapStage("after_trash_prune");
 
   SETTINGS.loadFromFile();
+  logHeapStage("after_settings_load");
   I18N.setLanguage(static_cast<Language>(SETTINGS.uiLanguage));
   // Retry theme load up to 3 times — a transient SD read failure here would
   // leave the theme list empty, and any later save could overwrite the file.
@@ -589,7 +604,9 @@ void setup() {
     LOG_ERR("MAIN", "Theme load attempt %d failed, retrying...", attempt + 1);
     delay(50);
   }
+  logHeapStage("after_themes_load");
   KOREADER_STORE.loadFromFile();
+  logHeapStage("after_koreader_load");
   ButtonNavigator::setMappedInputManager(mappedInputManager);
 
   // Lazy BLE init: only start stack if a device was previously paired
@@ -622,6 +639,7 @@ void setup() {
   LOG_DBG("MAIN", "Starting CrossPoint-Mod-DX34 version " CROSSPOINT_VERSION);
 
   setupDisplayAndFonts();
+  logHeapStage("after_display_fonts");
 
   exitActivity();
   auto* bootActivity = new BootActivity(renderer, mappedInputManager);
@@ -638,6 +656,7 @@ void setup() {
     }
   }
   APP_STATE.loadFromFile();
+  logHeapStage("after_app_state");
 
   // Wire crosspoint::sleep::WallpaperPlaylist deps now that APP_STATE is populated — all
   // subsequent sleep paths (trimSleepFolderIfDirty, SleepActivity) read through
@@ -649,6 +668,7 @@ void setup() {
   // Always load recents early — reader activities call addBook() which saves
   // to disk, so an unloaded list would overwrite the file with just one entry.
   RECENT_BOOKS.loadFromFile();
+  logHeapStage("after_recents");
 
   // Safety: skip straight to reader if Back held or crash-loop detected.
   const bool forcedHome =

--- a/src/util/FavoriteBmp.cpp
+++ b/src/util/FavoriteBmp.cpp
@@ -128,10 +128,10 @@ bool canPlacePathInSleep(const std::string& path) {
   if (!isBmpPathInternal(path) || !isFavoritePath(path) || isInSleepFolder(path)) {
     return true;
   }
-  return countProtectedSleepFavorites() < CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST;
+  return countProtectedSleepFavorites() < CrossPointState::SLEEP_FAVORITES_MAX;
 }
 
-bool isSleepFavoritesFull() { return countProtectedSleepFavorites() >= CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST; }
+bool isSleepFavoritesFull() { return countProtectedSleepFavorites() >= CrossPointState::SLEEP_FAVORITES_MAX; }
 
 size_t countProtectedSleepFavorites() {
   size_t count = 0;
@@ -174,8 +174,8 @@ const char* limitReachedPopupMessage() {
   static char buf[48];
   static bool initialized = false;
   if (!initialized) {
-    snprintf(buf, sizeof(buf), "Sleep favorites full (%zu/%zu)", CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST,
-             CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST);
+    snprintf(buf, sizeof(buf), "Sleep favorites full (%zu/%zu)", CrossPointState::SLEEP_FAVORITES_MAX,
+             CrossPointState::SLEEP_FAVORITES_MAX);
     initialized = true;
   }
   return buf;
@@ -185,8 +185,8 @@ const char* limitReachedHomeMessage() {
   static char buf[48];
   static bool initialized = false;
   if (!initialized) {
-    snprintf(buf, sizeof(buf), "Sleep favorites full: %zu/%zu", CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST,
-             CrossPointState::SLEEP_PLAYLIST_MAX_PERSIST);
+    snprintf(buf, sizeof(buf), "Sleep favorites full: %zu/%zu", CrossPointState::SLEEP_FAVORITES_MAX,
+             CrossPointState::SLEEP_FAVORITES_MAX);
     initialized = true;
   }
   return buf;


### PR DESCRIPTION
## Summary

Root cause for "low memory" / OOM-recovery screen on Bossypants, Selected Poems, Pocket Oracle, etc. on `c20fe2f`: heap is permanently fragmented at boot. After `APP_STATE.loadFromFile()` the largest contiguous free block drops from ~63 KB to ~17 KB and never recovers, so every book open hits the pre-flight gate regardless of what hard-floor we set.

### What was happening

`state.json` carries `sleepImagePlaylist` — a vector of strings used for shuffle randomization on the lock screen. The cap was 500. The deserializer creates one `std::string` heap allocation per entry. With a populated wallpaper folder, ~500 small heap blocks land in a cluster and split the largest contiguous block from ~63 KB to ~17 KB.

Once split, no defrag pass can recover — the small persistent strings stay alive for the lifetime of the app.

Boot-stage probes confirm:

```
after_serial:        largest=86004 alloc_blocks=80
after_sd:            largest=86004 alloc_blocks=80
after_trash_prune:   largest=86004 alloc_blocks=82
after_settings_load: largest=86004 alloc_blocks=82
after_themes_load:   largest=63476 alloc_blocks=83
after_koreader_load: largest=63476 alloc_blocks=85
after_display_fonts: largest=63476 alloc_blocks=117
after_app_state:     largest=17396 alloc_blocks=386   ← +269 blocks
after_recents:       largest=17396 alloc_blocks=411
```

### Fix

- Drop `SLEEP_PLAYLIST_MAX_PERSIST` from 500 → 30. The runtime already has a "large collection" sequential path (`lastShownSleepFilename` only) for any folder above the cap; this just tightens the threshold.
- Introduce `SLEEP_FAVORITES_MAX = 500` for the user-facing favorites cap. Favorites are counted from disk by `countProtectedSleepFavorites()` and do not pressure the heap, so this stays at the historical 500. (Previously the same constant double-counted both, which is why naively dropping it to 30 made the home banner read "Sleep favorites full: 30/30".)
- Update the three favorites-only call sites: `canPlacePathInSleep`, `isSleepFavoritesFull`, `refreshSleepFavoriteWarning`, banner copy.

### Wallpaper rotation behavior

| Sleep folder size | Before (cap 500) | After (cap 30) |
|---|---|---|
| ≤ 30 wallpapers | Full random shuffle | Full random shuffle (unchanged) |
| 31 – 500 | Full random shuffle | Sequential walk; cycles through all wallpapers, just not in shuffled order |
| > 500 | Sequential walk | Sequential walk (unchanged) |

Users with > 30 wallpapers lose shuffled randomness but keep full coverage of the folder. Trade is intentional: random selection requires the playlist in RAM, and the playlist in RAM is what fragments the heap.

### Permanent DIAG instrumentation

Lands the heap probes that found this so the next regression of this class can be isolated from a single log:

- `Activity::onEnter` / `onExit`: `free + largest + min` on every activity transition. Surfaces leaks across screens.
- `main::setup`: per-stage probe (`after_serial`, `after_sd`, `after_trash_prune`, `after_settings_load`, `after_themes_load`, `after_koreader_load`, `after_display_fonts`, `after_app_state`, `after_recents`).
- `JsonSettingsIO`: `safeWriteFile` step1..step4, `safeReadFile` source, `loadSettings` ff_present/ff_raw/ff_clamped/ff_normalized, `saveSettings` enter/exit. Diagnoses settings-revert reports.
- `EpubReader` pre-flight gate: hard-floor lowered 28 KB → 20 KB. With the fragmentation fix the floor is no longer the binding constraint, but a lower floor preserves the retry-once + auto-revert + OOM-recovery escape hatch from #95/#96/#100.

## Test plan

- [x] CI clang-format passes.
- [x] Fresh boot loads `state.json`, `largest` after boot ≥ 60 KB.
- [x] Bossypants opens (was hitting pre-flight gate at largest=17 KB).
- [x] Selected Poems opens.
- [x] Pocket Oracle opens.
- [x] Lydia Davis opens.
- [x] Home screen no longer shows "Sleep favorites full: 30/30".
- [ ] Wolfe-class books still bounce to OOM recovery screen — separate streaming-layout PR (out of scope here).
- [ ] Settings-revert investigation — DIAG lines now in place; needs fresh repro of the lock/wake reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L16qiRDba1jepg3JiWeGfc)_