### PR TITLE
chore: auto-spawn serial monitor after debug flash

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,22 @@
       "Bash(~/.platformio/packages/toolchain-riscv32-esp/bin/riscv32-esp-elf-addr2line:*)",
       "Bash(~/.platformio/packages/toolchain-riscv32-esp/bin/riscv32-esp-elf-nm:*)",
       "Bash(shasum:*)",
-      "Bash(xxd:*)"
+      "Bash(xxd:*)",
+      "Bash(bash scripts/serial_monitor_bg.sh)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command'); case \"$cmd\" in *\"pio run -e debug -t upload\"*) bash scripts/serial_monitor_bg.sh ;; esac",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }

--- a/scripts/serial_monitor_bg.sh
+++ b/scripts/serial_monitor_bg.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Spawns a resilient background serial reader for the DX34 device after a
+# debug flash. Auto-reconnects on USB drops. Appends to /tmp/dx34_serial.log
+# so the hook can fire across multiple flashes without losing prior context.
+#
+# Idempotent: kills any prior instance reading /dev/cu.usbmodem* before
+# starting a new one so the new debug session sees the freshly booted device.
+
+set -u
+
+LOG=/tmp/dx34_serial.log
+
+# Kill any prior reader holding a /dev/cu.usbmodem* port. Match on the python
+# invocation so we do not nuke unrelated `cu` usage.
+pkill -f "serial_monitor_bg_inner|cu.usbmodem.*serial.Serial" 2>/dev/null || true
+
+# Detach with nohup + & + disown so the reader survives Claude's tool
+# boundary and continues running after this hook exits. macOS lacks setsid.
+nohup python3 -c '
+import serial, sys, time, glob, os
+# tag for pkill matching above
+os.environ["_DX34_TAG"] = "serial_monitor_bg_inner"
+LOG = "/tmp/dx34_serial.log"
+with open(LOG, "ab", buffering=0) as fh:
+    fh.write(b"\n--- monitor started " + str(int(time.time())).encode() + b" ---\n")
+    while True:
+        ports = glob.glob("/dev/cu.usbmodem*")
+        if not ports:
+            time.sleep(0.5); continue
+        try:
+            s = serial.Serial(ports[0], 115200, timeout=1)
+            fh.write(f"\n--- connected {ports[0]} ---\n".encode())
+            while True:
+                data = s.read(4096)
+                if data:
+                    fh.write(data)
+        except Exception as e:
+            fh.write(f"\n--- disconnect: {e} ---\n".encode())
+            time.sleep(1)
+' >>"$LOG" 2>&1 &
+disown
+
+echo "[serial-monitor] background reader spawned, tail -f $LOG"


### PR DESCRIPTION
## Summary

PostToolUse hook on Bash. When the command contains \`pio run -e debug -t upload\`, runs \`scripts/serial_monitor_bg.sh\` which kills any prior reader holding /dev/cu.usbmodem* then spawns a detached python reader. The reader auto-reconnects on USB drops and appends to /tmp/dx34_serial.log.

Removes the manual \"start serial monitor after flash\" step. Production flashes (\`pio run -e default -t upload\`) do not match and skip the hook.

## Test plan

- [x] Pipe-test: synthesized PostToolUse stdin produced spawn + log line.
- [x] Reader survives USB drop, reconnects.
- [x] Schema valid (\`jq -e\` confirms hook command extracts cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)