### PR TITLE
fix(web): trim AP baseline + heap watchdog (#108 cont'd)

### DIFF
--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -206,15 +206,11 @@ void CrossPointWebServerActivity::startAccessPoint() {
   LOG_DBG("WEBACT", "IP: %s", connectedIP.c_str());
   LOG_DIAG("WEBACT", "[HEAP] a0_after_softAP free=%u min=%u", ESP.getFreeHeap(), ESP.getMinFreeHeap());
 
-  // Start mDNS for hostname resolution
-  if (MDNS.begin(AP_HOSTNAME)) {
-    MDNS.addService("http", "tcp", 80);
-    MDNS.addService("ws", "tcp", 81);
-    LOG_DBG("WEBACT", "mDNS started: http://%s.local/", AP_HOSTNAME);
-  } else {
-    LOG_DBG("WEBACT", "WARNING: mDNS failed to start");
-  }
-  LOG_DIAG("WEBACT", "[HEAP] a1_after_mdns_begin free=%u min=%u", ESP.getFreeHeap(), ESP.getMinFreeHeap());
+  // Skip mDNS in AP mode: the DNS captive portal below already redirects every
+  // hostname to apIP, so the MDNS responder is dead weight (~6.5 KB heap) on a
+  // chip whose AP-mode baseline is already tight. Phones type the IP or land
+  // via captive-portal probe regardless.
+  LOG_DIAG("WEBACT", "[HEAP] a1_skipped_mdns_ap free=%u min=%u", ESP.getFreeHeap(), ESP.getMinFreeHeap());
 
   // Start DNS server for captive portal behavior
   // This redirects all DNS queries to our IP, making any domain typed resolve to us

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -293,15 +293,30 @@ void CrossPointWebServer::begin() {
   server->begin();
   LOG_DIAG("WEB", "[HEAP] s4_after_server_begin free=%u min=%u", ESP.getFreeHeap(), ESP.getMinFreeHeap());
 
-  // Start WebSocket server for fast binary uploads
-  LOG_DBG("WEB", "Starting WebSocket server on port %d...", wsPort);
-  wsServer.reset(new WebSocketsServer(wsPort));
-  wsInstance = const_cast<CrossPointWebServer*>(this);
-  wsServer->begin();
-  wsServer->onEvent(wsEventCallback);
-  LOG_DIAG("WEB", "[HEAP] s5_after_wsServer_begin free=%u min=%u", ESP.getFreeHeap(), ESP.getMinFreeHeap());
+  // Start WebSocket server for fast binary uploads — STA only.
+  // In AP mode the heap pool can't sustain WS server (~1.8 KB resident +
+  // per-client buffers) plus parallel HTTP fetches from a phone loading
+  // asset-heavy pages like /fonts. AP clients fall back to HTTP POST upload
+  // (handleUploadPost), which is the same code path used before WS support.
+  if (!apMode) {
+    LOG_DBG("WEB", "Starting WebSocket server on port %d...", wsPort);
+    wsServer.reset(new WebSocketsServer(wsPort));
+    wsInstance = const_cast<CrossPointWebServer*>(this);
+    wsServer->begin();
+    wsServer->onEvent(wsEventCallback);
+  } else {
+    LOG_DBG("WEB", "Skipping WebSocket server (AP mode — HTTP POST fallback only)");
+  }
+  LOG_DIAG("WEB", "[HEAP] s5_after_wsServer_begin free=%u min=%u apMode=%d", ESP.getFreeHeap(), ESP.getMinFreeHeap(),
+           apMode ? 1 : 0);
 
-  udpActive = udp.begin(LOCAL_UDP_PORT);
+  // UDP discovery beacon — STA only. In AP mode the device IS the gateway,
+  // so clients see it without broadcast discovery.
+  if (!apMode) {
+    udpActive = udp.begin(LOCAL_UDP_PORT);
+  } else {
+    udpActive = false;
+  }
   LOG_DIAG("WEB", "[HEAP] s6_after_udp_begin free=%u min=%u udpActive=%d", ESP.getFreeHeap(), ESP.getMinFreeHeap(),
            udpActive ? 1 : 0);
 
@@ -579,6 +594,37 @@ void CrossPointWebServer::handleClient() {
   if (millis() - lastDebugPrint > 10000) {
     LOG_DBG("WEB", "handleClient active, server running on port %d", port);
     lastDebugPrint = millis();
+  }
+
+  // Heap watchdog (B6): when free heap stays below the danger floor for >3 s,
+  // kill any in-flight WS download/upload to release their buffers and break
+  // the lwIP retransmit deadlock that otherwise pins ~8 KB of un-ACK'd pbufs
+  // until reboot. STA-side last-line defense; AP path already trimmed.
+  static unsigned long lowHeapSinceMs = 0;
+  static unsigned long lastHeapDiagMs = 0;
+  constexpr uint32_t kLowHeapDangerBytes = 8000;
+  constexpr uint32_t kLowHeapDurationMs = 3000;
+  const uint32_t freeNow = ESP.getFreeHeap();
+  const unsigned long nowMs = millis();
+  if (freeNow < kLowHeapDangerBytes) {
+    if (lowHeapSinceMs == 0) lowHeapSinceMs = nowMs;
+    if ((nowMs - lastHeapDiagMs) > 1000) {
+      LOG_DIAG("WEB", "[HEAP] low free=%u dur=%lu", freeNow, nowMs - lowHeapSinceMs);
+      lastHeapDiagMs = nowMs;
+    }
+    if ((nowMs - lowHeapSinceMs) > kLowHeapDurationMs) {
+      LOG_DIAG("WEB", "[HEAP] danger sustained free=%u — aborting in-flight WS", freeNow);
+      if (wsDownloadInProgress) {
+        if (wsServer) wsServer->disconnect(wsDownloadClientNum);
+        if (wsDownloadFile) wsDownloadFile.close();
+        wsDownloadInProgress = false;
+      }
+      if (g_wsUploadSession) g_wsUploadSession->abort("low_heap");
+      lowHeapSinceMs = nowMs;  // reset so we don't spam aborts every tick
+    }
+  } else if (lowHeapSinceMs != 0) {
+    LOG_DIAG("WEB", "[HEAP] recovered free=%u after %lu ms low", freeNow, nowMs - lowHeapSinceMs);
+    lowHeapSinceMs = 0;
   }
 
   server->handleClient();


### PR DESCRIPTION
Stacked on top of #109. Targets the AP+phone+/fonts repro from #108 that PR #109 (lazy upload buffers) alone is not expected to fix.

## Changes

- **A2** Skip MDNS responder in AP mode (~6.5 KB heap). DNS captive portal already redirects every hostname to apIP.
- **A3** Skip WebSocketsServer in AP mode (~1.8 KB resident + per-client buffers). HTTP POST fallback covers uploads. Existing `if (wsServer)` guards in `handleClient`/event handlers mean no other call sites need touching.
- **A4** Skip UDP discovery beacon in AP mode (~1.9 KB). Device IS the gateway; clients see it without broadcast.
- **B6** Heap watchdog in `handleClient`: when `ESP.getFreeHeap() < 8000` for >3 s, abort any in-flight WS download/upload to free their buffers and break the lwIP retransmit deadlock that otherwise pins ~8 KB of un-ACK'd pbufs until reboot. STA-side last-line defense.

Total expected baseline gain in AP mode: **~10 KB**, on top of #109's ~8 KB. New `[HEAP] s5/s6/a1` markers also give us forensic data on the next round.

## Why these are safe

- A2/A3/A4 are mode-gated on `apMode`. STA path is unchanged — STA clients still get full WS + UDP discovery.
- All `wsServer` and `udp` consumers were already null/active-flag-guarded before this PR (verified via grep). No new conditional branches needed in callers.
- B6 only fires when free heap is already in the danger zone (<8 KB). At that point the connection is in retransmit deadlock anyway — abort releases the ~8 KB of pinned pbufs and gives the user a recoverable state instead of a wedge until reboot.

## Build / boot

- `pio run -e default` — clean, RAM 55.8%, flash 87.8%
- `pio run -e debug -t upload` — clean
- Boot heap on debug build: free=88 KB, min=49 KB (no regression vs. #109 baseline)

## Test plan

- [ ] AP mode: pair phone, navigate to `http://192.168.4.1/fonts`. Should load the same JS bundle as before without wedging.
- [ ] AP mode: upload a small file via the web UI. Should fall through HTTP POST path (no WS in AP).
- [ ] STA mode: regression check — full WS upload/download still works on desktop.
- [ ] Stress: load `/fonts` with multiple parallel tabs. Watch serial for `[HEAP] low/danger/recovered` markers; if `danger` fires, B6 should abort WS and recover.
- [ ] Captive portal: AP mode, type any hostname — DNS server still resolves to apIP without MDNS.

## Scope note

If the AP+phone repro still wedges after this PR, the next layer is:
- B5: explicit `server->client().stop()` after every response
- A5: trim parallel HTTP connection limit at the WebServer level

But this is the natural next stop in the trim-the-fat sequence, and the watchdog gives us recovery telemetry to validate further work against.