### PR TITLE
feat(sleep): native .pxc wallpaper support

### DIFF
--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -1,11 +1,14 @@
 #include "SleepActivity.h"
 
 #include <Epub.h>
+#include <Epub/converters/DirectPixelWriter.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <I18n.h>
+#include <Logging.h>
 #include <Txt.h>
 #include <Xtc.h>
+#include <esp_task_wdt.h>
 
 #include <algorithm>
 
@@ -144,21 +147,31 @@ void SleepActivity::renderCustomSleepScreen() const {
   // When rotation is paused, re-show the same wallpaper without advancing.
   if (APP_STATE.wallpaperRotationPaused && !APP_STATE.lastSleepWallpaperPath.empty() &&
       Storage.exists(APP_STATE.lastSleepWallpaperPath.c_str())) {
-    FsFile file;
-    if (Storage.openFileForRead("SLP", APP_STATE.lastSleepWallpaperPath, file)) {
-      LOG_DBG("SLP", "Paused, re-showing: %s", APP_STATE.lastSleepWallpaperPath.c_str());
+    if (StringUtils::checkFileExtension(APP_STATE.lastSleepWallpaperPath, ".pxc")) {
+      LOG_DBG("SLP", "Paused, re-showing PXC: %s", APP_STATE.lastSleepWallpaperPath.c_str());
       delay(100);
-      Bitmap bitmap(file, true);
-      const auto parseErr = bitmap.parseHeaders();
-      if (parseErr == BmpReaderError::Ok) {
-        const std::string displayName = FavoriteBmp::displayNameForPath(APP_STATE.lastSleepWallpaperPath);
-        renderBitmapSleepScreen(bitmap, displayName.c_str());
-        file.close();
+      const std::string displayName = FavoriteBmp::displayNameForPath(APP_STATE.lastSleepWallpaperPath);
+      if (renderPxcSleepScreen(APP_STATE.lastSleepWallpaperPath, displayName.c_str())) {
         return;
       }
-      LOG_ERR("SLP", "Paused wallpaper parse failed: %s (err=%d)", APP_STATE.lastSleepWallpaperPath.c_str(),
-              static_cast<int>(parseErr));
-      file.close();
+      LOG_ERR("SLP", "Paused PXC render failed: %s", APP_STATE.lastSleepWallpaperPath.c_str());
+    } else {
+      FsFile file;
+      if (Storage.openFileForRead("SLP", APP_STATE.lastSleepWallpaperPath, file)) {
+        LOG_DBG("SLP", "Paused, re-showing: %s", APP_STATE.lastSleepWallpaperPath.c_str());
+        delay(100);
+        Bitmap bitmap(file, true);
+        const auto parseErr = bitmap.parseHeaders();
+        if (parseErr == BmpReaderError::Ok) {
+          const std::string displayName = FavoriteBmp::displayNameForPath(APP_STATE.lastSleepWallpaperPath);
+          renderBitmapSleepScreen(bitmap, displayName.c_str());
+          file.close();
+          return;
+        }
+        LOG_ERR("SLP", "Paused wallpaper parse failed: %s (err=%d)", APP_STATE.lastSleepWallpaperPath.c_str(),
+                static_cast<int>(parseErr));
+        file.close();
+      }
     }
   }
 
@@ -176,6 +189,18 @@ void SleepActivity::renderCustomSleepScreen() const {
 #endif
     if (selectedImage.empty()) break;
     const auto filename = "/sleep/" + selectedImage;
+    if (StringUtils::checkFileExtension(selectedImage, ".pxc")) {
+      LOG_DBG("SLP", "Loading PXC: %s", filename.c_str());
+      delay(100);
+      const std::string displayName = FavoriteBmp::displayNameForPath(filename);
+      if (renderPxcSleepScreen(filename, displayName.c_str())) {
+        rememberLastRenderedSleepBitmap(filename, selectedImage);
+        rendered = true;
+        return;
+      }
+      LOG_ERR("SLP", "PXC render failed: %s (attempt %d/%d)", filename.c_str(), attempt + 1, kMaxParseRetries);
+      continue;
+    }
     FsFile file;
     if (Storage.openFileForRead("SLP", filename, file)) {
       LOG_DBG("SLP", "Loading: %s", filename.c_str());
@@ -198,8 +223,16 @@ void SleepActivity::renderCustomSleepScreen() const {
     }
   }
 
-  // Look for sleep.bmp on the root of the sd card to determine if we should
-  // render a custom sleep screen instead of the default.
+  // Root-level fallback wallpapers. PXC takes precedence over BMP — same image,
+  // PXC renders without on-device dithering and with the factory waveform.
+  if (Storage.exists("/sleep.pxc")) {
+    LOG_DBG("SLP", "Loading: /sleep.pxc");
+    if (renderPxcSleepScreen("/sleep.pxc")) {
+      rememberLastRenderedSleepBitmap("/sleep.pxc");
+      return;
+    }
+    LOG_ERR("SLP", "Root /sleep.pxc render failed");
+  }
   FsFile file;
   for (const char* fallbackPath : {"/sleep_F.bmp", "/sleep.bmp"}) {
     if (Storage.openFileForRead("SLP", fallbackPath, file)) {
@@ -439,6 +472,65 @@ void SleepActivity::renderCoverSleepScreen() const {
   }
 
   return (this->*renderNoCoverSleepScreen)();
+}
+
+bool SleepActivity::renderPxcSleepScreen(const std::string& path, const char* sourceFilename) const {
+  // PXC layout: uint16 width, uint16 height, then packed 2bpp payload (4 px/byte, MSB first).
+  // Pixel convention: 0=Black, 1=DarkGray, 2=LightGray, 3=White — same as Bitmap::readNextRow.
+  FsFile file;
+  if (!Storage.openFileForRead("SLP", path, file)) {
+    LOG_ERR("SLP", "Cannot open PXC: %s", path.c_str());
+    return false;
+  }
+  uint16_t pxcWidth = 0, pxcHeight = 0;
+  if (file.read(&pxcWidth, 2) != 2 || file.read(&pxcHeight, 2) != 2) {
+    LOG_ERR("SLP", "PXC header read failed: %s", path.c_str());
+    file.close();
+    return false;
+  }
+  const int sw = renderer.getScreenWidth();
+  const int sh = renderer.getScreenHeight();
+  if (std::abs(static_cast<int>(pxcWidth) - sw) > 1 || std::abs(static_cast<int>(pxcHeight) - sh) > 1) {
+    LOG_ERR("SLP", "PXC size mismatch %dx%d (screen %dx%d): %s", pxcWidth, pxcHeight, sw, sh, path.c_str());
+    file.close();
+    return false;
+  }
+  const uint32_t dataOffset = file.position();
+  const int bytesPerRow = (pxcWidth + 3) / 4;
+  uint8_t* rowBuf = static_cast<uint8_t*>(malloc(bytesPerRow));
+  if (!rowBuf) {
+    LOG_ERR("SLP", "PXC row alloc failed (%d bytes)", bytesPerRow);
+    file.close();
+    return false;
+  }
+
+  const auto mode =
+      SETTINGS.useFactoryLUT ? GfxRenderer::GrayscaleMode::FactoryQuality : GfxRenderer::GrayscaleMode::Differential;
+  const int width = static_cast<int>(pxcWidth);
+  const int height = static_cast<int>(pxcHeight);
+  renderer.renderGrayscale(mode, [&]() {
+    file.seek(dataOffset);
+    DirectPixelWriter pw;
+    pw.init(renderer);
+    for (int row = 0; row < height; row++) {
+      if (file.read(rowBuf, bytesPerRow) != bytesPerRow) break;
+      pw.beginRow(row);
+      for (int col = 0; col < width; col++) {
+        const uint8_t pv = (rowBuf[col >> 2] >> (6 - (col & 3) * 2)) & 0x03;
+        pw.writePixel(col, pv);
+      }
+      if ((row & 31) == 0) esp_task_wdt_reset();
+    }
+  });
+
+  free(rowBuf);
+  file.close();
+
+  if (sourceFilename != nullptr && SETTINGS.showSleepImageFilename) {
+    drawSleepFilenameLabel(renderer, sourceFilename);
+    renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+  }
+  return true;
 }
 
 void SleepActivity::renderBlankSleepScreen() const {

--- a/src/activities/boot_sleep/SleepActivity.h
+++ b/src/activities/boot_sleep/SleepActivity.h
@@ -30,6 +30,10 @@ class SleepActivity final : public Activity {
   void renderCustomSleepScreen() const;
   void renderCoverSleepScreen() const;
   void renderBitmapSleepScreen(const Bitmap& bitmap, const char* sourceFilename = nullptr) const;
+  // Renders a .pxc (pre-dithered 2bpp) wallpaper via the factory grayscale
+  // path. Returns true on success; false if the file can't be opened, the
+  // header is unreadable, or the dimensions don't match the screen.
+  bool renderPxcSleepScreen(const std::string& path, const char* sourceFilename = nullptr) const;
   void renderBlankSleepScreen() const;
   void renderQuotesSleepScreen() const;
   void renderFreezeSleepScreen() const;

--- a/src/sleep/SdFatSleepFs.cpp
+++ b/src/sleep/SdFatSleepFs.cpp
@@ -14,11 +14,16 @@ namespace {
 constexpr const char* kSleepDir = "/sleep";
 constexpr size_t kWdtResetInterval = 50;
 
+// Sleep wallpapers can be .bmp (legacy) or .pxc (pre-dithered 2bpp, faster
+// wake + better quality, requires factory LUT to render). Public API still
+// uses "Bmp" names for back-compat; the file-type check is the single point
+// where we accept both.
 bool isBmpName(const char* name) {
   if (!name || name[0] == '\0' || name[0] == '.') return false;
   const size_t len = std::strlen(name);
   if (len < 4) return false;
-  return strcasecmp(name + len - 4, ".bmp") == 0;
+  const char* ext = name + len - 4;
+  return strcasecmp(ext, ".bmp") == 0 || strcasecmp(ext, ".pxc") == 0;
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Follow-up to [#113](https://github.com/diogo7dias/crosspoint-reader-DX34/pull/113). Sleep wallpapers can now be `.pxc` files (pre-dithered 2bpp packed) alongside the existing `.bmp` flow. PXC files skip on-device quantization entirely — the file holds the exact 4-level state the panel needs.

Wins:
- Faster wake (no dither pass).
- ~6× smaller file size vs same-size BMP cover.
- Quality bound by the converter (https://crosspoint-pxc-converter.pages.dev/), not the device's runtime dither.
- Looks especially good when the factory-LUT toggle from #113 is on, but works on either path (factory when toggle on, differential when off).

## Format
- `uint16` width
- `uint16` height
- Packed 2bpp payload, MSB first, pixel values `0=Black, 1=DarkGray, 2=LightGray, 3=White`

Header dimensions validated against the panel — mismatches log and are skipped without crashing.

## What changed
- [SdFatSleepFs.cpp](src/sleep/SdFatSleepFs.cpp): internal `isBmpName` accepts both `.bmp` and `.pxc` so the V2 wallpaper playlist picks up PXC files automatically. Public API names kept (`countSleepBmps`, `listSleepBmps`, `walkSleepBmps`, `SleepBmpEntry`) for back-compat — the "Bmp" naming is now slightly aspirational.
- [SleepActivity.{h,cpp}](src/activities/boot_sleep/SleepActivity.h): new `renderPxcSleepScreen()` opens the file, reads the 4-byte header, validates dimensions, then feeds rows through DirectPixelWriter inside the existing `renderGrayscale` path. Three load sites updated to dispatch PXCs ahead of the BMP parse:
  - Paused-rotation re-show (`APP_STATE.lastSleepWallpaperPath`)
  - V2 playlist `advance()` next entry
  - Root fallback: `/sleep.pxc` preferred over `/sleep.bmp` / `/sleep_F.bmp`
- Mode selection: `SETTINGS.useFactoryLUT` → `FactoryQuality`; otherwise `Differential`. PXC works on either path.

## Out of scope (future PR)
- Library-browser visibility for PXC files (so users can move PXC into /sleep via the in-device action menu). Minimum viable today: upload `.pxc` files directly to `/sleep/` over the device's built-in web server.
- PxcViewerActivity (full-screen PXC viewer from the file browser).

## How to put a `.pxc` on the device
The X4 firmware does not enable USB Mass Storage — it presents only a USB CDC serial port. Files reach the SD card via the built-in web server:
1. On the device: Settings → Wi-Fi networks → connect to the same Wi-Fi as your computer.
2. Note the device's IP address from the device UI.
3. On your computer, open `http://<device-ip>/files` in a browser.
4. Upload the `.pxc` file into `/sleep/`.
5. Trigger sleep on the device.

(The library browser route would be the obvious in-device alternative once browser visibility is added in a follow-up.)

## Test plan
- [x] Builds clean both `default` and `debug` envs.
- [x] Flashed debug to hardware; boots clean.
- [ ] Convert a sample image at https://crosspoint-pxc-converter.pages.dev/ at panel resolution, upload to `/sleep/` via the device's web server. Trigger sleep — confirm the PXC renders.
- [ ] With factory-LUT toggle ON, confirm visible quality matches BMP-via-FactoryQuality (or beats it on detail-heavy images).
- [ ] With factory-LUT toggle OFF, confirm PXC still renders (via differential path).
- [ ] V2 rotation: drop a mix of .bmp and .pxc into `/sleep/`, confirm both types appear in the rotation.
- [ ] Root fallback: `/sleep.pxc` and `/sleep.bmp` both present → PXC wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)