### PR TITLE
docs: document .pxc wallpaper support + converter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See [docs/development.md](./docs/development.md) for build, flash, serial monito
 
 - **[EPUB reader](./docs/reader.md)** — in-book menu, Reading Themes (16 per book), highlights and quotes, bookmarks (20 per book), footnote navigation, live text settings, configurable status bar
 - **[Fonts](./docs/fonts.md)** — three reader families (ChareInk, Bookerly, Vollkorn) at six sizes (12–17 pt) with regular/bold/italic styles; Unifont fallback
-- **[Sleep wallpapers](./docs/wallpapers.md)** — nine sleep modes, managed `/sleep` folder, favorites with auto-trim protection, in-book triage actions
+- **[Sleep wallpapers](./docs/wallpapers.md)** — nine sleep modes, managed `/sleep` folder, favorites with auto-trim protection, in-book triage actions, native `.pxc` pre-dithered wallpapers (convert at <https://crosspoint-pxc-converter.pages.dev/> for sharper, faster, smaller wallpapers than `.bmp`)
 - **[Device controls](./docs/controls.md)** — side and front button remapping, power button action, auto-sleep, refresh frequency, custom boot image, orientation
 - **[Wi-Fi features](./docs/webserver.md)** — web file transfer with resume, OPDS browser, Calibre wireless, KOReader progress sync, OTA updates from GitHub
 - **[Home screen and library](#home-screen-and-library)** — recents (up to 100), file browser with search, QR file sharing

--- a/docs/wallpapers.md
+++ b/docs/wallpapers.md
@@ -25,13 +25,55 @@ When using Cover or Cover + Custom:
 
 ## Custom wallpaper lookup
 
-The firmware looks for a custom BMP in this order:
+The firmware looks for a custom wallpaper in this order:
 
-1. Files inside `/sleep/`
-2. `/sleep_F.bmp`
-3. `/sleep.bmp`
+1. Files inside `/sleep/` (`.bmp` or `.pxc`)
+2. `/sleep.pxc` at the SD root (preferred)
+3. `/sleep_F.bmp` at the SD root
+4. `/sleep.bmp` at the SD root
 
 If none is found, the default DX34 sleep screen is used.
+
+## Wallpaper formats: `.bmp` vs `.pxc`
+
+DX34 reads two wallpaper file types. They share the rotation, the favorites system, and the playlist — pick whichever fits the source image.
+
+### `.bmp` (legacy, on-device dithered)
+
+A standard BMP image. The firmware reads pixels from the file at sleep time and runs a dithering pass on the device to quantise them down to the panel's four grey levels. Works with anything you can save as a BMP. The dithering is decent but bound by what fits in the device's tight CPU/heap budget.
+
+### `.pxc` (recommended, pre-dithered)
+
+PXC is a small native format storing a pre-dithered 2-bit (4-level grey) image with embedded dimensions, packed at 4 pixels per byte. The dithering is done **once, in the browser**, with full precision. The device then reads the file straight into the panel — no decode, no dithering, no quantisation noise.
+
+**Why PXC is superior:**
+
+- **Better image quality.** Dithering happens in the converter with full floating-point precision and access to algorithms (Floyd-Steinberg, etc.) that don't fit on the device's runtime budget. The result is bound by the converter, not by what the firmware can squeeze in.
+- **Faster sleep wake.** The on-device dither pass is skipped entirely — the file is already in the format the panel wants.
+- **Smaller files.** Roughly 6× smaller than the equivalent BMP at the same resolution. More wallpapers fit on your SD card and the V2 playlist scans them faster.
+- **Cleaner gradients.** No quantisation artefacts from runtime dithering — the converter picks the best 4-level approximation per pixel and writes it directly.
+- **Ideal pair with Factory Grayscale.** When **Display → Factory Grayscale** is enabled, PXC files render through the panel's manufacturer waveform (`lut_factory_quality`) for the broadest tonal range. With the toggle off they still render correctly via the differential path — just less sharp.
+
+If you already use a converter to resize an image to panel dimensions before dropping it in `/sleep/`, going straight to PXC is the logical next step: skip the lossy on-device dither stage and hand the panel exactly what it expects.
+
+### How to convert images to `.pxc`
+
+Use the official converter: **<https://crosspoint-pxc-converter.pages.dev/>**
+
+1. Open the converter in a browser.
+2. Upload an image at panel resolution (480 × 800 portrait).
+3. Pick a dither algorithm.
+4. Download the resulting `.pxc`.
+
+### How to put files on the device
+
+The X4 firmware does **not** present as a USB drive — only a USB serial port. File transfer goes through the device's built-in web server:
+
+1. **Settings → Wi-Fi networks** on the device. Connect to the same Wi-Fi as your computer.
+2. Note the device's IP address shown on the Wi-Fi screen.
+3. On your computer, open `http://<device-ip>/files` in a browser.
+4. Upload the `.pxc` (or `.bmp`) file. Place inside `/sleep/` for the rotation, or as `/sleep.pxc` at the root for the static fallback.
+5. Trigger sleep — the new wallpaper appears.
 
 ## Playlist behavior
 


### PR DESCRIPTION
## Summary

Documentation follow-up for [#114](https://github.com/diogo7dias/crosspoint-reader-DX34/pull/114). Adds a \"Wallpaper formats: .bmp vs .pxc\" section to [docs/wallpapers.md](docs/wallpapers.md) and a pointer in the README so users find the new format without digging.

Covers:
- Why PXC beats BMP (quality, speed, size, factory-LUT pairing).
- Link to the converter at <https://crosspoint-pxc-converter.pages.dev/>.
- Web-server upload steps (firmware does not present USB MSC).
- Updated lookup order: `.pxc` files in `/sleep/`, `/sleep.pxc` preferred over `/sleep.bmp` at root.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)