### PR TITLE
perf(reader): half-refresh fast path on same-book re-entry

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -125,17 +125,26 @@ void EpubReaderActivity::onEnter() {
             (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
   }
 
-  // Full refresh on book enter. The v1.2.0 experiment downgraded this to
-  // requestHalfRefresh() to shave ~1 s off open time, but hardware capture
-  // 2026-04-24 caught the failure mode the original author warned about:
-  // the first page on open, and the first page after a mid-book font switch,
-  // both showed ghost pixels of the previous screen overlaid on the new
-  // render. Half refresh doesn't fully invert the segment drivers, so
-  // incompletely-reset pixels bleed through the first buffer write. Pay the
-  // extra second at enter-time to get a clean first page — especially
-  // important after a font switch, where old-font glyph positions would
-  // otherwise double-expose under the new layout.
-  renderer.requestFullRefresh();
+  // Refresh on book enter. The v1.2.0 experiment unconditionally downgraded
+  // this to requestHalfRefresh() to shave ~1 s off open time, but hardware
+  // capture 2026-04-24 caught the failure mode the original author warned
+  // about: the first page on open, and the first page after a mid-book font
+  // switch, both showed ghost pixels of the previous screen overlaid on the
+  // new render. Half refresh doesn't fully invert the segment drivers, so
+  // incompletely-reset pixels bleed through the first buffer write.
+  //
+  // Compromise: full refresh only when the book path or a layout-/pixel-
+  // affecting setting (font family/size, custom font name+pt, orientation,
+  // reader style mode, image dither) has changed since the previous enter.
+  // Same-book / same-settings re-entry (resume at boot, return from a
+  // subactivity that didn't touch fonts) takes the half-refresh fast path,
+  // since the previous frame already laid down the same glyph positions
+  // and there's nothing to ghost.
+  if (ReaderCommon::shouldFullRefreshOnEnter(epub->getPath())) {
+    renderer.requestFullRefresh();
+  } else {
+    renderer.requestHalfRefresh();
+  }
 
   // Configure screen orientation based on settings
   // NOTE: This affects layout math and must be applied before any render calls.

--- a/src/activities/reader/ReaderCommon.cpp
+++ b/src/activities/reader/ReaderCommon.cpp
@@ -8,6 +8,44 @@
 
 namespace ReaderCommon {
 
+namespace {
+struct LastEnterSig {
+  std::string bookPath;
+  uint8_t fontFamily = 0xFF;
+  uint8_t fontSize = 0xFF;
+  std::string customFontName;
+  uint8_t customFontSizePt = 0xFF;
+  uint8_t orientation = 0xFF;
+  uint8_t readerStyleMode = 0xFF;
+  uint8_t imageDither = 0xFF;
+  bool valid = false;
+};
+LastEnterSig g_lastEnter;
+}  // namespace
+
+bool shouldFullRefreshOnEnter(const std::string& bookPath) {
+  const auto& s = SETTINGS;
+  const bool needsFull = !g_lastEnter.valid || g_lastEnter.bookPath != bookPath ||
+                         g_lastEnter.fontFamily != s.fontFamily || g_lastEnter.fontSize != s.fontSize ||
+                         g_lastEnter.customFontName != s.customFontName ||
+                         g_lastEnter.customFontSizePt != s.customFontSizePt ||
+                         g_lastEnter.orientation != s.orientation ||
+                         g_lastEnter.readerStyleMode != s.readerStyleMode ||
+                         g_lastEnter.imageDither != s.imageDither;
+
+  g_lastEnter.bookPath = bookPath;
+  g_lastEnter.fontFamily = s.fontFamily;
+  g_lastEnter.fontSize = s.fontSize;
+  g_lastEnter.customFontName = s.customFontName;
+  g_lastEnter.customFontSizePt = s.customFontSizePt;
+  g_lastEnter.orientation = s.orientation;
+  g_lastEnter.readerStyleMode = s.readerStyleMode;
+  g_lastEnter.imageDither = s.imageDither;
+  g_lastEnter.valid = true;
+
+  return needsFull;
+}
+
 std::string formatPageCounterText(const uint8_t mode, const int currentPage, const int totalPages) {
   const int safeTotalPages = std::max(totalPages, 0);
   const int safeCurrentPage = std::max(currentPage, 0);

--- a/src/activities/reader/ReaderCommon.h
+++ b/src/activities/reader/ReaderCommon.h
@@ -20,6 +20,17 @@ void applyReaderOrientation(GfxRenderer& renderer, uint8_t orientation);
 // Txt passes its total page count.
 std::string formatPageCounterText(uint8_t mode, int currentPage, int totalPages);
 
+// Decide whether the renderer needs a full refresh on reader onEnter, or a
+// half refresh suffices. Returns true when the book path or any layout-/
+// pixel-affecting setting has changed since the previous reader entry —
+// the cases that produced ghost artifacts when v1.2.0 unconditionally
+// downgraded to half refresh. Returns false on same-book / same-settings
+// re-entry (e.g. resuming the last-opened book at boot, or returning from
+// a subactivity that didn't touch fonts), letting the caller skip the
+// ~1 s full refresh penalty. Updates internal state — call exactly once
+// per onEnter.
+bool shouldFullRefreshOnEnter(const std::string& bookPath);
+
 // Persist the currently opened book as the last-opened entry and add it to
 // the recent books list. Shared by all three reader activities (Epub, Txt,
 // Xtc). Callers remain responsible for any subsequent moveBookToRecents()

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -64,10 +64,15 @@ void TxtReaderActivity::onEnter() {
     return;
   }
 
-  // Full refresh on book enter — see EpubReaderActivity::onEnter for the
-  // regression the v1.2.0 half-refresh downgrade caused (ghost artifacts
-  // under the first page, especially post-font-switch).
-  renderer.requestFullRefresh();
+  // Refresh on book enter — see EpubReaderActivity::onEnter for full
+  // rationale. Full refresh only when path/layout/pixel-affecting settings
+  // changed since last enter; otherwise half refresh (same-book resume,
+  // return from subactivity without font change).
+  if (ReaderCommon::shouldFullRefreshOnEnter(txt->getPath())) {
+    renderer.requestFullRefresh();
+  } else {
+    renderer.requestHalfRefresh();
+  }
 
   // Configure screen orientation based on settings
   ReaderCommon::applyReaderOrientation(renderer, SETTINGS.orientation);

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -43,10 +43,15 @@ void XtcReaderActivity::onEnter() {
     return;
   }
 
-  // Full refresh on book enter — see EpubReaderActivity::onEnter for the
-  // regression the v1.2.0 half-refresh downgrade caused (ghost artifacts
-  // under the first page, especially post-font-switch).
-  renderer.requestFullRefresh();
+  // Refresh on book enter — see EpubReaderActivity::onEnter for full
+  // rationale. Full refresh only when path/layout/pixel-affecting settings
+  // changed since last enter; otherwise half refresh (same-book resume,
+  // return from subactivity without font change).
+  if (ReaderCommon::shouldFullRefreshOnEnter(xtc->getPath())) {
+    renderer.requestFullRefresh();
+  } else {
+    renderer.requestHalfRefresh();
+  }
 
   EpdFontFamily::setReaderBoldSwapEnabled(RECENT_BOOKS.getBoldSwap(xtc->getPath()));
   xtc->setupCacheDir();


### PR DESCRIPTION
## Summary
- Reader `onEnter` previously always issued a full e-ink refresh (~1s) after the v1.2.0 half-refresh experiment was reverted in 7448729 to fix ghost artifacts.
- Track a signature of the last-entered reader state (book path + fontFamily/Size + customFontName/SizePt + orientation + readerStyleMode + imageDither) in `ReaderCommon::shouldFullRefreshOnEnter()`.
- Full-refresh only when the signature differs (cold open, different book, font switch, orientation/theme change). Otherwise half-refresh — same-book resume and subactivity round-trips skip the ~1s penalty.
- Wired into `EpubReaderActivity`, `XtcReaderActivity`, `TxtReaderActivity`.

## Test plan
- [x] Build: `pio run -e default` green
- [x] Cold boot → open book → full refresh, clean first page
- [x] Open book A → home → open book B → full refresh on B
- [x] Mid-book font switch → return → full refresh, no glyph double-expose
- [x] Orientation change → reopen → full refresh
- [x] Resume same book → home → reopen → half refresh, faster, no ghosts
- [x] Subactivity round-trip (bookmarks / quotes / TOC) → faster return, no ghosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)