### PR TITLE
docs: track v2.0.2 inclusions in TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,14 @@
 
 Open follow-ups for this firmware. Prioritised top-down. Workflow per item: build → flash → user tests on device → ship in next release. No soak windows, no waiting periods — this is a hobby project, not a paid product.
 
+## Next release inclusions
+
+Items already merged to `main` that should be called out in the release notes for the next version. Move into the release body when cutting the tag, then clear this section.
+
+### v2.0.2
+
+- **Reader open: half-refresh fast path on same-book / same-settings re-entry** ([#117](https://github.com/diogo7dias/crosspoint-reader-DX34/pull/117), `6376368`). EPUB / XTC / TXT readers no longer pay the ~1 s full-refresh cost when re-entering the same book at the same font, size, orientation, theme, and dither. Cold open, different book, font/orientation/theme change still full-refresh — ghost-prone cases stay covered. Returning from menus / bookmarks / TOC and resuming the last book at boot are visibly faster.
+
 ## Active
 
 - [ ] **Flip `useFactoryLUT` default to ON.** Today the toggle ships off in [src/CrossPointSettings.h](src/CrossPointSettings.h). Default-on means new users get the sharper sleep-cover rendering immediately. Existing on-SD cover BMPs were generated with the prior dither + double-bright, so they'll render slightly darker until the user runs Library Refresh — call that out in the release notes for the version that flips it.


### PR DESCRIPTION
## Summary
- Adds **Next release inclusions** section at top of TODO.md.
- Seeded with [#117](https://github.com/diogo7dias/crosspoint-reader-DX34/pull/117) (reader half-refresh fast path) under `### v2.0.2`.
- Workflow: items move into the GitHub release body when the tag is cut, then the section is cleared as part of the release commit.

A matching release checklist was added to local `CLAUDE.md` (gitignored) so the version-bump / firmware.bin copy / OTA-artefact steps are documented for the next session.

## Test plan
- [x] TODO.md still readable, formatting intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)