### PR TITLE
feat: PXC image parity with BMP across firmware

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,16 +12,20 @@ Items already merged to `main` that should be called out in the release notes fo
 
 - **Fix: per-book theme no longer leaks into global settings.** In-book toggles (orientation long-press, text render mode, custom-font safety reverts) used to call `SETTINGS.saveToFile()` directly, which wrote the per-book theme overlay (font, size, margins, etc.) back to `/.crosspoint/settings.json` as the new global default. Routed all 8 reader-side save sites through a new `ReadingThemeStore::persistContextual()` that picks per-book or global by context. The "random book on boot" toggle inside the reader menu now snapshots the per-book theme, reloads the on-disk globals, flips the flag, saves clean, and restores the overlay. XTC reader also now loads its per-book `reader_settings.json` on open, for parity with EPUB / TXT. Net effect: global defaults are only ever changed via the global Settings UI, exactly as documented.
 
+- **Sleep wallpapers and library images now support `.pxc` (pre-dithered, faster sleep entry).** `.pxc` files appear in the file browser alongside `.bmp`, can be moved to `/sleep`, favorited (`_F.pxc`), renamed, deleted, and viewed full-screen. The home-screen SD card stats popup counts `.pxc` wallpapers and favorites correctly. Sleep entry using a `.pxc` file is noticeably faster than the equivalent `.bmp` because no dithering is done at wake time.
+
 ## Active
 
 - [ ] **Flip `useFactoryLUT` default to ON.** Today the toggle ships off in [src/CrossPointSettings.h](src/CrossPointSettings.h). Default-on means new users get the sharper sleep-cover rendering immediately. Existing on-SD cover BMPs were generated with the prior dither + double-bright, so they'll render slightly darker until the user runs Library Refresh — call that out in the release notes for the version that flips it.
 
-- [ ] **PXC visibility in MyLibrary file browser.** Today `.pxc` files are only picked up when dropped directly into `/sleep/`. Wiring needed:
-  - [MyLibraryActivity.cpp](src/activities/home/MyLibraryActivity.cpp): add `isPxcFile()`, expand `isManagedFile()` to OR it. PXC files should appear in the browser list.
-  - Action menu for PXC files: Move-to-Sleep + Delete + Rename. Skip the BMP-only "Open Image" item (no PXC viewer yet).
-  - [UITheme.cpp](src/components/UITheme.cpp): map `.pxc` to the existing image icon.
+- [x] ~~**PXC visibility in MyLibrary file browser.** Today `.pxc` files are only picked up when dropped directly into `/sleep/`. Wiring needed:~~
+  ~~- [MyLibraryActivity.cpp](src/activities/home/MyLibraryActivity.cpp): add `isPxcFile()`, expand `isManagedFile()` to OR it. PXC files should appear in the browser list.~~
+  ~~- Action menu for PXC files: Move-to-Sleep + Delete + Rename. Skip the BMP-only "Open Image" item (no PXC viewer yet).~~
+  ~~- [UITheme.cpp](src/components/UITheme.cpp): map `.pxc` to the existing image icon.~~
+  *(Shipped on `feat/pxc-image-parity` — full browser + action menu + viewer + home-stats parity)*
 
-- [ ] **`PxcViewerActivity`** for full-screen PXC viewing from the file browser. Model on the `renderPxcSleepScreen` flow in [SleepActivity.cpp](src/activities/boot_sleep/SleepActivity.cpp). Pairs with the browser-visibility item above.
+- [x] ~~**`PxcViewerActivity`** for full-screen PXC viewing from the file browser. Model on the `renderPxcSleepScreen` flow in [SleepActivity.cpp](src/activities/boot_sleep/SleepActivity.cpp). Pairs with the browser-visibility item above.~~
+  *(Shipped on `feat/pxc-image-parity` as inline `renderPxcImageView` in MyLibraryActivity)*
 
 - [ ] **EPUB factory LUT for image pages.** Today image pages stay on the differential overlay because the upstream full-page approach needs a 48 KB transient `secondaryFrameBuffer` we can't afford on a ~26 KB-free-heap device. Possible paths:
   - Wait for SDK-side support of windowed factory absolute drive (would let us factory-LUT only the image rect, keep BW text untouched).

--- a/docs/superpowers/plans/2026-04-27-pxc-image-parity.md
+++ b/docs/superpowers/plans/2026-04-27-pxc-image-parity.md
@@ -1,0 +1,1023 @@
+# PXC Image Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Treat `.pxc` (pre-dithered 2 bpp screen-sized image) as a first-class viewable image format anywhere `.bmp` is treated as one today: library browser, image viewer, favorites, rename/move/delete, sleep flows, web `/files`.
+
+**Architecture:** Extract the existing `SleepActivity::renderPxcSleepScreen` body into a shared `PxcRenderer` free function so both sleep and the library viewer share one implementation. Rename the C++ `FavoriteBmp` module to `FavoriteImage` and broaden its predicates to cover `.pxc`. Branch the library viewer on extension. Filter EPUB-render-cache `.pxc` files from the library browser and the web `/files` page.
+
+**Tech Stack:** C++ on PlatformIO/Arduino/ESP32-C3, Unity for host-side tests via `pio test -e test_host`, vanilla HTML/JS for the web UI in `src/network/html/FilesPage.html`.
+
+**Spec:** [docs/superpowers/specs/2026-04-27-pxc-image-parity-design.md](../specs/2026-04-27-pxc-image-parity-design.md)
+
+---
+
+## File map
+
+**Created:**
+- `src/util/PxcRenderer.h` — public header for the shared PXC renderer
+- `src/util/PxcRenderer.cpp` — implementation extracted from `SleepActivity`
+- `src/util/FavoriteImage.h` — renamed module header
+- `src/util/FavoriteImage.cpp` — renamed module impl, extended for `.pxc`
+- `test/test_favorite_image/test_main.cpp` — host-side Unity tests for the suffix helpers and the cache-filter helper
+
+**Modified:**
+- `src/activities/boot_sleep/SleepActivity.cpp` — `renderPxcSleepScreen` becomes a thin wrapper around `PxcRenderer::renderPxc`
+- `src/activities/home/MyLibraryActivity.h` — mode rename, viewer state rename, new helpers, cache-filter helper
+- `src/activities/home/MyLibraryActivity.cpp` — branch viewer on extension, use `FavoriteImage`, apply cache filter, rename method
+- `src/main.cpp`, `src/sleep/WallpaperPlaylist.h`, `src/network/CrossPointWebServer.{h,cpp}`, `src/components/themes/BaseTheme.cpp`, `src/activities/reader/EpubReaderMenuActivity.cpp`, `src/activities/reader/EpubReaderActivity.cpp`, `src/activities/home/HomeActivity.cpp` — include path + namespace updates
+- `src/network/CrossPointWebServer.cpp` — add `info.isPxc`, apply cache filter to listings, accept `.pxc` in download/upload allowlists where applicable
+- `src/network/html/FilesPage.html` — add `pxc-file` row class, `PXC` badge
+
+**Deleted:**
+- `src/util/FavoriteBmp.h`, `src/util/FavoriteBmp.cpp` (replaced by `FavoriteImage.{h,cpp}`)
+
+---
+
+## Task 1: Add `isPxcFile` and `isImageFile` predicates to `MyLibraryActivity`
+
+**Files:**
+- Modify: `src/activities/home/MyLibraryActivity.h`
+- Modify: `src/activities/home/MyLibraryActivity.cpp`
+
+Tiny, additive step — leaves all existing `isBmpFile` callers compiling. Used by later tasks.
+
+- [ ] **Step 1: Add the new declarations to the header.**
+
+In `src/activities/home/MyLibraryActivity.h`, locate the existing `static bool isBmpFile(const std::string& filename);` declaration and add two siblings immediately below it:
+
+```cpp
+  static bool isBmpFile(const std::string& filename);
+  static bool isPxcFile(const std::string& filename);
+  static bool isImageFile(const std::string& filename);
+```
+
+- [ ] **Step 2: Implement them in the .cpp.**
+
+In `src/activities/home/MyLibraryActivity.cpp`, find the existing `isBmpFile` definition (~line 414) and add the two new helpers immediately below:
+
+```cpp
+bool MyLibraryActivity::isBmpFile(const std::string& filename) {
+  return StringUtils::checkFileExtension(filename, ".bmp");
+}
+
+bool MyLibraryActivity::isPxcFile(const std::string& filename) {
+  return StringUtils::checkFileExtension(filename, ".pxc");
+}
+
+bool MyLibraryActivity::isImageFile(const std::string& filename) {
+  return isBmpFile(filename) || isPxcFile(filename);
+}
+```
+
+- [ ] **Step 3: Build to confirm no regressions.**
+
+Run: `pio run -e default`
+Expected: build succeeds, no new warnings.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add src/activities/home/MyLibraryActivity.h src/activities/home/MyLibraryActivity.cpp
+git commit -m "feat(library): add isPxcFile/isImageFile predicates"
+```
+
+---
+
+## Task 2: Extract `PxcRenderer` from `SleepActivity`
+
+**Files:**
+- Create: `src/util/PxcRenderer.h`
+- Create: `src/util/PxcRenderer.cpp`
+- Modify: `src/activities/boot_sleep/SleepActivity.cpp`
+
+The current implementation lives at `src/activities/boot_sleep/SleepActivity.cpp:477-534`. Move the body into a free function; keep the existing wrapper method calling into it so the sleep filename label and the optional final HALF_REFRESH stay where they are.
+
+- [ ] **Step 1: Create the header.**
+
+Write `src/util/PxcRenderer.h`:
+
+```cpp
+#pragma once
+
+#include <string>
+
+class GfxRenderer;
+
+namespace PxcRenderer {
+
+// Streams a screen-sized .pxc into the framebuffer using the configured
+// grayscale mode (FactoryQuality if SETTINGS.useFactoryLUT, else
+// Differential). Returns false if the file cannot be opened, the header
+// cannot be read, the declared dimensions diverge from the current screen
+// by more than 1 px, or the per-row buffer cannot be allocated.
+//
+// Does NOT call displayBuffer — caller picks the refresh mode after this
+// returns.
+//
+// PXC layout: uint16_t width, uint16_t height, then packed 2 bpp payload
+// (4 px/byte, MSB first). Pixel convention: 0=Black, 1=DarkGray,
+// 2=LightGray, 3=White (matches Bitmap::readNextRow).
+bool renderPxc(GfxRenderer& renderer, const std::string& path);
+
+}  // namespace PxcRenderer
+```
+
+- [ ] **Step 2: Create the implementation.**
+
+Write `src/util/PxcRenderer.cpp` by lifting lines 477-527 of `SleepActivity.cpp` (everything from the file open through `free(rowBuf)` / `file.close()`), wrapped in the new namespace:
+
+```cpp
+#include "PxcRenderer.h"
+
+#include <GfxRenderer.h>
+#include <HalStorage.h>
+#include <Logging.h>
+#include <esp_task_wdt.h>
+
+#include <cstdint>
+#include <cstdlib>
+
+#include "../CrossPointSettings.h"
+#include "../components/converters/DirectPixelWriter.h"
+
+namespace PxcRenderer {
+
+bool renderPxc(GfxRenderer& renderer, const std::string& path) {
+  FsFile file;
+  if (!Storage.openFileForRead("PXC", path, file)) {
+    LOG_ERR("PXC", "Cannot open: %s", path.c_str());
+    return false;
+  }
+  uint16_t pxcWidth = 0, pxcHeight = 0;
+  if (file.read(&pxcWidth, 2) != 2 || file.read(&pxcHeight, 2) != 2) {
+    LOG_ERR("PXC", "Header read failed: %s", path.c_str());
+    file.close();
+    return false;
+  }
+  const int sw = renderer.getScreenWidth();
+  const int sh = renderer.getScreenHeight();
+  if (std::abs(static_cast<int>(pxcWidth) - sw) > 1 ||
+      std::abs(static_cast<int>(pxcHeight) - sh) > 1) {
+    LOG_ERR("PXC", "Size mismatch %dx%d (screen %dx%d): %s",
+            pxcWidth, pxcHeight, sw, sh, path.c_str());
+    file.close();
+    return false;
+  }
+  const uint32_t dataOffset = file.position();
+  const int bytesPerRow = (pxcWidth + 3) / 4;
+  uint8_t* rowBuf = static_cast<uint8_t*>(malloc(bytesPerRow));
+  if (!rowBuf) {
+    LOG_ERR("PXC", "Row alloc failed (%d bytes)", bytesPerRow);
+    file.close();
+    return false;
+  }
+
+  const auto mode = SETTINGS.useFactoryLUT
+                        ? GfxRenderer::GrayscaleMode::FactoryQuality
+                        : GfxRenderer::GrayscaleMode::Differential;
+  const int width = static_cast<int>(pxcWidth);
+  const int height = static_cast<int>(pxcHeight);
+  renderer.renderGrayscale(mode, [&]() {
+    file.seek(dataOffset);
+    DirectPixelWriter pw;
+    pw.init(renderer);
+    for (int row = 0; row < height; row++) {
+      if (file.read(rowBuf, bytesPerRow) != bytesPerRow) break;
+      pw.beginRow(row);
+      for (int col = 0; col < width; col++) {
+        const uint8_t pv = (rowBuf[col >> 2] >> (6 - (col & 3) * 2)) & 0x03;
+        pw.writePixel(col, pv);
+      }
+      if ((row & 31) == 0) esp_task_wdt_reset();
+    }
+  });
+
+  free(rowBuf);
+  file.close();
+  return true;
+}
+
+}  // namespace PxcRenderer
+```
+
+Verify the include path for `DirectPixelWriter` matches what `SleepActivity.cpp` currently uses (open the existing file and copy its include line if the relative path above is wrong).
+
+- [ ] **Step 3: Replace the body of `SleepActivity::renderPxcSleepScreen`.**
+
+In `src/activities/boot_sleep/SleepActivity.cpp`, replace the body of `renderPxcSleepScreen` (the entire function at lines 477-534) with this thin wrapper that retains the optional filename label and final HALF_REFRESH:
+
+```cpp
+bool SleepActivity::renderPxcSleepScreen(const std::string& path, const char* sourceFilename) const {
+  if (!PxcRenderer::renderPxc(renderer, path)) {
+    return false;
+  }
+
+  if (sourceFilename != nullptr && SETTINGS.showSleepImageFilename) {
+    drawSleepFilenameLabel(renderer, sourceFilename);
+    renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+  }
+  return true;
+}
+```
+
+Add `#include "../../util/PxcRenderer.h"` at the top of `SleepActivity.cpp` next to the existing util/ includes. Remove now-unused includes (e.g. `DirectPixelWriter.h`) only if they are not referenced by the rest of the file — search before deleting.
+
+- [ ] **Step 4: Build.**
+
+Run: `pio run -e default`
+Expected: build succeeds. `firmware.bin` size should change negligibly.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/util/PxcRenderer.h src/util/PxcRenderer.cpp src/activities/boot_sleep/SleepActivity.cpp
+git commit -m "refactor(pxc): extract renderPxc into shared PxcRenderer util"
+```
+
+---
+
+## Task 3: Rename `FavoriteBmp` → `FavoriteImage` (mechanical), keep BMP-only behavior
+
+**Files:**
+- Create: `src/util/FavoriteImage.h`
+- Create: `src/util/FavoriteImage.cpp`
+- Delete: `src/util/FavoriteBmp.h`, `src/util/FavoriteBmp.cpp`
+- Modify: every caller listed under "File map → Modified"
+
+This task is a pure rename — no semantic changes. The next task adds `.pxc` support inside `FavoriteImage`. Splitting the rename from the behavior change keeps the diff reviewable.
+
+- [ ] **Step 1: `git mv` the files.**
+
+```bash
+git mv src/util/FavoriteBmp.h src/util/FavoriteImage.h
+git mv src/util/FavoriteBmp.cpp src/util/FavoriteImage.cpp
+```
+
+- [ ] **Step 2: Rename the namespace and the `NotBmp` enum value inside the new files.**
+
+In both `src/util/FavoriteImage.h` and `src/util/FavoriteImage.cpp`:
+
+- Replace `namespace FavoriteBmp` with `namespace FavoriteImage`.
+- Replace `}  // namespace FavoriteBmp` with `}  // namespace FavoriteImage`.
+- Replace `SetFavoriteResult::NotBmp` with `SetFavoriteResult::NotImage` (declaration in the header, every reference in the .cpp).
+- Update the `#include "FavoriteBmp.h"` line at the top of `FavoriteImage.cpp` to `#include "FavoriteImage.h"`.
+
+Internal helpers like `isBmpPathInternal` keep their names and behavior in this task.
+
+- [ ] **Step 3: Update every caller.**
+
+For each file listed below, update the include and the namespace references via search-and-replace:
+
+```bash
+git grep -l 'FavoriteBmp' -- 'src/' 'lib/'
+```
+
+In each result:
+- `#include "util/FavoriteBmp.h"` or `#include "FavoriteBmp.h"` → corresponding `FavoriteImage.h` path.
+- `FavoriteBmp::` → `FavoriteImage::`.
+- Any `SetFavoriteResult::NotBmp` → `SetFavoriteResult::NotImage`.
+
+Expected file list (from `git grep`): `src/main.cpp`, `src/sleep/WallpaperPlaylist.h`, `src/network/CrossPointWebServer.{h,cpp}`, `src/components/themes/BaseTheme.cpp`, `src/activities/reader/EpubReaderMenuActivity.cpp`, `src/activities/reader/EpubReaderActivity.cpp`, `src/activities/home/MyLibraryActivity.{h,cpp}`, `src/activities/home/HomeActivity.cpp`, `src/activities/boot_sleep/SleepActivity.cpp`.
+
+- [ ] **Step 4: Confirm no stragglers.**
+
+Run: `git grep -n 'FavoriteBmp\|NotBmp'`
+Expected: zero results.
+
+- [ ] **Step 5: Build.**
+
+Run: `pio run -e default`
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add -A
+git commit -m "refactor(favorites): rename FavoriteBmp module to FavoriteImage"
+```
+
+---
+
+## Task 4: Extend `FavoriteImage` to handle `.pxc`
+
+**Files:**
+- Modify: `src/util/FavoriteImage.cpp`
+
+Internal predicate `isBmpPathInternal` currently checks only `.bmp`. Generalize it to accept `.pxc` as well, and rename it for clarity. The `_F` suffix logic already operates on the last 4 characters, which is correct for both extensions.
+
+- [ ] **Step 1: Replace `isBmpPathInternal` with `isImagePath`.**
+
+In `src/util/FavoriteImage.cpp`, locate (around line 17):
+
+```cpp
+bool isBmpPathInternal(const std::string& path) { return StringUtils::checkFileExtension(path, ".bmp"); }
+```
+
+Replace with:
+
+```cpp
+bool isImagePath(const std::string& path) {
+  return StringUtils::checkFileExtension(path, ".bmp") ||
+         StringUtils::checkFileExtension(path, ".pxc");
+}
+```
+
+- [ ] **Step 2: Rename every internal call site.**
+
+In the same file, replace all `isBmpPathInternal(` with `isImagePath(`. Verify with:
+
+```bash
+grep -n 'isBmpPathInternal\|isImagePath' src/util/FavoriteImage.cpp
+```
+
+Expected: no `isBmpPathInternal` remains; one definition + multiple call sites of `isImagePath`.
+
+- [ ] **Step 3: Build to confirm no callers were missed.**
+
+Run: `pio run -e default`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add src/util/FavoriteImage.cpp
+git commit -m "feat(favorites): accept .pxc in FavoriteImage predicates"
+```
+
+---
+
+## Task 5: Host-side tests for `FavoriteImage` suffix helpers
+
+**Files:**
+- Create: `test/test_favorite_image/test_main.cpp`
+
+The pure helpers `hasFavoriteSuffix`, `addFavoriteSuffix`, `stripFavoriteSuffix` are exposed in the public header and don't depend on `Storage` or `APP_STATE`, so they're testable on the host. We test BMP behavior preservation and the new PXC behavior.
+
+- [ ] **Step 1: Write the failing test file.**
+
+Write `test/test_favorite_image/test_main.cpp`:
+
+```cpp
+// Host-side tests for FavoriteImage suffix helpers.
+// Run via: pio test -e test_host -f test_favorite_image
+
+#include <unity.h>
+
+#include <string>
+
+#include "util/FavoriteImage.h"
+
+void setUp() {}
+void tearDown() {}
+
+namespace {
+
+void test_has_favorite_suffix_bmp() {
+  TEST_ASSERT_TRUE(FavoriteImage::hasFavoriteSuffix("foo_F.bmp"));
+  TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("foo.bmp"));
+  TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("F.bmp"));
+}
+
+void test_has_favorite_suffix_pxc() {
+  TEST_ASSERT_TRUE(FavoriteImage::hasFavoriteSuffix("foo_F.pxc"));
+  TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("foo.pxc"));
+  TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("F.pxc"));
+}
+
+void test_has_favorite_suffix_rejects_non_image() {
+  TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("foo_F.txt"));
+  TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("foo_F.epub"));
+}
+
+void test_add_favorite_suffix_bmp() {
+  TEST_ASSERT_EQUAL_STRING("foo_F.bmp", FavoriteImage::addFavoriteSuffix("foo.bmp").c_str());
+  TEST_ASSERT_EQUAL_STRING("foo_F.bmp", FavoriteImage::addFavoriteSuffix("foo_F.bmp").c_str());
+}
+
+void test_add_favorite_suffix_pxc() {
+  TEST_ASSERT_EQUAL_STRING("foo_F.pxc", FavoriteImage::addFavoriteSuffix("foo.pxc").c_str());
+  TEST_ASSERT_EQUAL_STRING("foo_F.pxc", FavoriteImage::addFavoriteSuffix("foo_F.pxc").c_str());
+}
+
+void test_add_favorite_suffix_passthrough_for_non_image() {
+  TEST_ASSERT_EQUAL_STRING("foo.txt", FavoriteImage::addFavoriteSuffix("foo.txt").c_str());
+}
+
+void test_strip_favorite_suffix_bmp() {
+  TEST_ASSERT_EQUAL_STRING("foo.bmp", FavoriteImage::stripFavoriteSuffix("foo_F.bmp").c_str());
+  TEST_ASSERT_EQUAL_STRING("foo.bmp", FavoriteImage::stripFavoriteSuffix("foo.bmp").c_str());
+}
+
+void test_strip_favorite_suffix_pxc() {
+  TEST_ASSERT_EQUAL_STRING("foo.pxc", FavoriteImage::stripFavoriteSuffix("foo_F.pxc").c_str());
+  TEST_ASSERT_EQUAL_STRING("foo.pxc", FavoriteImage::stripFavoriteSuffix("foo.pxc").c_str());
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+  RUN_TEST(test_has_favorite_suffix_bmp);
+  RUN_TEST(test_has_favorite_suffix_pxc);
+  RUN_TEST(test_has_favorite_suffix_rejects_non_image);
+  RUN_TEST(test_add_favorite_suffix_bmp);
+  RUN_TEST(test_add_favorite_suffix_pxc);
+  RUN_TEST(test_add_favorite_suffix_passthrough_for_non_image);
+  RUN_TEST(test_strip_favorite_suffix_bmp);
+  RUN_TEST(test_strip_favorite_suffix_pxc);
+  return UNITY_END();
+}
+```
+
+- [ ] **Step 2: Run the tests.**
+
+Run: `pio test -e test_host -f test_favorite_image`
+Expected: all 8 tests pass. If `FavoriteImage::isFavoritePath` or other helpers transitively pull in `APP_STATE` via the linker even when unused, restrict the test to call only the three pure helpers above; they're declared `extern` and don't reach `APP_STATE`.
+
+If a link error names `APP_STATE` or `Storage`, the most likely cause is that `FavoriteImage.cpp` is being compiled into the test binary. Check `platformio.ini`'s `[env:test_host]` and the `test_filter` / `lib_compat_mode` settings; you may need to mark the test source with `test_build_src = false` for this single env, or add `build_src_filter` to exclude SDK-dependent units. Refer to the existing `test_wallpaper_playlist_v2` test for a working pattern.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add test/test_favorite_image/
+git commit -m "test(favorites): host-side coverage for .bmp and .pxc suffix helpers"
+```
+
+---
+
+## Task 6: Rename `Mode::BMP_VIEW` and viewer state symbols in `MyLibraryActivity`
+
+**Files:**
+- Modify: `src/activities/home/MyLibraryActivity.h`
+- Modify: `src/activities/home/MyLibraryActivity.cpp`
+
+Mechanical rename. Behavior unchanged.
+
+- [ ] **Step 1: Rename the enum value and the state field in the header.**
+
+In `src/activities/home/MyLibraryActivity.h`:
+
+- `Mode::BMP_VIEW` → `Mode::IMAGE_VIEW`.
+- `bool bmpViewFullyLoaded` → `bool imageViewFullyLoaded`.
+- `void enterBmpView(const std::string& bmpPath)` → `void enterImageView(const std::string& imagePath)`.
+- `void renderBmpView()` → `void renderImageView()`.
+- `void openKeyboardForRenameBmp()` → `void openKeyboardForRenameImage()`.
+- `void renameSelectedBmp(const std::string& newBase)` → `void renameSelectedImage(const std::string& newBase)`.
+
+- [ ] **Step 2: Rename every reference in the .cpp.**
+
+In `src/activities/home/MyLibraryActivity.cpp`, search-and-replace each old symbol to its new name. After the edits, verify:
+
+```bash
+git grep -n 'BMP_VIEW\|bmpViewFullyLoaded\|enterBmpView\|renderBmpView\|openKeyboardForRenameBmp\|renameSelectedBmp'
+```
+
+Expected: zero results.
+
+- [ ] **Step 3: Build.**
+
+Run: `pio run -e default`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add src/activities/home/MyLibraryActivity.h src/activities/home/MyLibraryActivity.cpp
+git commit -m "refactor(library): rename BMP_VIEW symbols to IMAGE_VIEW"
+```
+
+---
+
+## Task 7: Switch library callers from `isBmpFile` to `isImageFile`
+
+**Files:**
+- Modify: `src/activities/home/MyLibraryActivity.cpp`
+
+Every existing site that gates on "is this a viewable image" should accept `.pxc` too. The only sites to keep as `isBmpFile` are explicit BMP-format-only branches, of which there should be none in this file.
+
+- [ ] **Step 1: Audit current usages.**
+
+Run:
+
+```bash
+grep -n 'isBmpFile' src/activities/home/MyLibraryActivity.cpp
+```
+
+For each hit, decide:
+- If it's "should this row be treated as a viewable image?" → switch to `isImageFile`.
+- If it's "is this exactly a BMP, where the BMP-specific code path matters?" → keep as `isBmpFile` and document why with a one-line comment.
+
+Concrete sites you should switch (based on the current source):
+- `isManagedFile` (around line 419): `return isBookFile(filename) || isImageFile(filename);`
+- `getDisplayNameForRawFile` (around line 432): branch on `isImageFile`, not `isBmpFile`, so PXC favorites get the `[F]` prefix.
+
+- [ ] **Step 2: Build.**
+
+Run: `pio run -e default`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/activities/home/MyLibraryActivity.cpp
+git commit -m "feat(library): treat .pxc rows as images for display + actions"
+```
+
+---
+
+## Task 8: Branch `renderImageView` on extension; add the PXC fast path
+
+**Files:**
+- Modify: `src/activities/home/MyLibraryActivity.cpp`
+
+The existing `renderImageView` (formerly `renderBmpView`) is the BMP renderer. Wrap it in an extension branch.
+
+- [ ] **Step 1: Add `#include "../../util/PxcRenderer.h"` near the existing util/ includes** (top of the file).
+
+- [ ] **Step 2: Replace `renderImageView` with a branching version.**
+
+Find the existing `void MyLibraryActivity::renderImageView()` (formerly at ~line 1450) and replace its body with:
+
+```cpp
+void MyLibraryActivity::renderImageView() {
+  if (isPxcFile(selectedFilePath)) {
+    renderPxcImageView();
+    return;
+  }
+  renderBmpImageView();
+}
+```
+
+Then rename the existing render-the-BMP body to `renderBmpImageView` (declare it `private` in the header beside `renderImageView`) — leave its implementation untouched apart from the rename.
+
+- [ ] **Step 3: Add `renderPxcImageView`.**
+
+Below `renderBmpImageView`, add:
+
+```cpp
+void MyLibraryActivity::renderPxcImageView() {
+  renderer.clearScreen();
+
+  if (!PxcRenderer::renderPxc(renderer, selectedFilePath)) {
+    renderer.drawCenteredText(UI_12_FONT_ID, 80, tr(STR_INVALID_BMP));
+    const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
+    GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+    displayFrame();
+    imageViewFullyLoaded = true;
+    return;
+  }
+
+  const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_ACTIONS_BUTTON), "", "");
+  GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+  if (messagePopupOpen) {
+    GUI.drawPopup(renderer, messagePopupText.c_str());
+  }
+  renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+  nextRefreshMode = HalDisplay::FAST_REFRESH;
+  imageViewFullyLoaded = true;
+}
+```
+
+- [ ] **Step 4: Declare the two new privates in the header.**
+
+In `src/activities/home/MyLibraryActivity.h`, beside the existing `renderImageView` declaration:
+
+```cpp
+  void renderImageView();
+  void renderBmpImageView();
+  void renderPxcImageView();
+```
+
+- [ ] **Step 5: Build.**
+
+Run: `pio run -e default`
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/activities/home/MyLibraryActivity.h src/activities/home/MyLibraryActivity.cpp
+git commit -m "feat(library): PXC fast-path render in image viewer"
+```
+
+---
+
+## Task 9: Make `renameSelectedImage` extension-aware
+
+**Files:**
+- Modify: `src/activities/home/MyLibraryActivity.cpp`
+
+The current implementation hard-codes `.bmp` for both stripping and rebuilding. Switch to using whatever extension the selected file actually has.
+
+- [ ] **Step 1: Replace the extension handling block.**
+
+In `renameSelectedImage` (formerly `renameSelectedBmp`, ~line 524), find the lines:
+
+```cpp
+  // Strip user-typed trailing .bmp (any case) and _F — we control both.
+  if (base.size() >= 4) {
+    std::string tail = base.substr(base.size() - 4);
+    std::transform(tail.begin(), tail.end(), tail.begin(), ::tolower);
+    if (tail == ".bmp") base = base.substr(0, base.size() - 4);
+  }
+```
+
+Replace with:
+
+```cpp
+  // Capture the original extension up-front so the rebuilt path keeps it.
+  std::string originalExt = ".bmp";
+  if (selectedFilePath.size() >= 4) {
+    std::string tail = selectedFilePath.substr(selectedFilePath.size() - 4);
+    std::transform(tail.begin(), tail.end(), tail.begin(), ::tolower);
+    if (tail == ".pxc") originalExt = ".pxc";
+  }
+
+  // Strip a user-typed trailing .bmp/.pxc (any case) and _F — we control both.
+  if (base.size() >= 4) {
+    std::string tail = base.substr(base.size() - 4);
+    std::transform(tail.begin(), tail.end(), tail.begin(), ::tolower);
+    if (tail == ".bmp" || tail == ".pxc") base = base.substr(0, base.size() - 4);
+  }
+```
+
+Then, in the same function, find:
+
+```cpp
+  const std::string suffix = std::string(wasFav ? "_F" : "") + ".bmp";
+```
+
+Replace with:
+
+```cpp
+  const std::string suffix = std::string(wasFav ? "_F" : "") + originalExt;
+```
+
+- [ ] **Step 2: Verify no other `.bmp` literals slipped through in this function.**
+
+```bash
+grep -n '\.bmp' src/activities/home/MyLibraryActivity.cpp
+```
+
+For any hit inside `renameSelectedImage`, check whether it should be `originalExt`. Other functions may legitimately keep `.bmp` literals (e.g. defaults in unrelated paths) — only the rename function is in scope here.
+
+- [ ] **Step 3: Build.**
+
+Run: `pio run -e default`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add src/activities/home/MyLibraryActivity.cpp
+git commit -m "feat(library): preserve original extension on image rename"
+```
+
+---
+
+## Task 10: Add EPUB-cache filter to library browser scan
+
+**Files:**
+- Modify: `src/activities/home/MyLibraryActivity.h`
+- Modify: `src/activities/home/MyLibraryActivity.cpp`
+
+Filter the populated `files` vector after scan to drop:
+- Any `*_q.pxc`.
+- Any `*.pxc` whose basename has a sibling `.{jpg,jpeg,png,gif,webp}` in the same listing (case-insensitive). `.bmp` is **excluded** from the sibling-source set per the spec.
+
+- [ ] **Step 1: Add the filter helper to the header.**
+
+In `src/activities/home/MyLibraryActivity.h` (private section):
+
+```cpp
+  static void filterEpubCachePxc(std::vector<std::string>& files);
+```
+
+- [ ] **Step 2: Implement the helper.**
+
+Place near the other static helpers in `MyLibraryActivity.cpp`:
+
+```cpp
+void MyLibraryActivity::filterEpubCachePxc(std::vector<std::string>& files) {
+  // Build set of source-image basenames (sans extension, lowercased) present
+  // in the listing. .bmp is intentionally excluded — a .bmp + .pxc with the
+  // same basename in /sleep are two independent user wallpapers.
+  static const char* const kSourceExts[] = {".jpg", ".jpeg", ".png", ".gif", ".webp"};
+
+  auto lowerExt = [](const std::string& name, size_t extLen) {
+    if (name.size() < extLen) return std::string{};
+    std::string ext = name.substr(name.size() - extLen);
+    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+    return ext;
+  };
+
+  auto stemOf = [](const std::string& name) {
+    const auto dot = name.find_last_of('.');
+    return (dot == std::string::npos) ? name : name.substr(0, dot);
+  };
+
+  auto toLower = [](std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    return s;
+  };
+
+  std::unordered_set<std::string> sourceStems;
+  for (const auto& name : files) {
+    if (name.empty() || name.back() == '/') continue;
+    for (const char* ext : kSourceExts) {
+      const std::string e = ext;
+      if (name.size() >= e.size() && lowerExt(name, e.size()) == e) {
+        sourceStems.insert(toLower(stemOf(name)));
+        break;
+      }
+    }
+  }
+
+  files.erase(
+      std::remove_if(files.begin(), files.end(),
+                     [&](const std::string& name) {
+                       if (name.empty() || name.back() == '/') return false;
+                       if (lowerExt(name, 4) != ".pxc") return false;
+                       const std::string lower = toLower(name);
+                       // Drop any *_q.pxc.
+                       if (lower.size() >= 6 &&
+                           lower.compare(lower.size() - 6, 6, "_q.pxc") == 0) {
+                         return true;
+                       }
+                       // Drop *.pxc shadowed by a source-format sibling.
+                       return sourceStems.count(toLower(stemOf(name))) > 0;
+                     }),
+      files.end());
+}
+```
+
+Add `#include <unordered_set>` and `#include <algorithm>` at the top of the .cpp if not already present.
+
+- [ ] **Step 3: Call the filter at the end of the scan.**
+
+Locate `MyLibraryActivity::loadFiles` (this is where the `files` vector is populated and `orderSleepFolderByPlaylist` is called per the existing memory note). Immediately before the existing `orderSleepFolderByPlaylist`-related logic, call:
+
+```cpp
+  filterEpubCachePxc(files);
+```
+
+The exact line will be obvious from the scan: it's after the directory iteration completes and before any sorting/ordering.
+
+- [ ] **Step 4: Build.**
+
+Run: `pio run -e default`
+Expected: build succeeds.
+
+- [ ] **Step 5: Add a host-side test for the filter.**
+
+Append to `test/test_favorite_image/test_main.cpp` (or create a sibling file `test/test_library_filter/test_main.cpp` if you prefer to keep tests focused — sibling file is recommended):
+
+Create `test/test_library_filter/test_main.cpp`:
+
+```cpp
+// Host-side tests for the EPUB-cache PXC filter on library listings.
+// Run via: pio test -e test_host -f test_library_filter
+
+#include <unity.h>
+
+#include <string>
+#include <vector>
+
+#include "activities/home/MyLibraryActivity.h"
+
+void setUp() {}
+void tearDown() {}
+
+namespace {
+
+std::vector<std::string> sampleListing() {
+  return {
+      // User PXC + BMP wallpapers in /sleep — both must survive.
+      "wallpaper1.pxc",
+      "wallpaper1.bmp",
+      // Standalone PXC with no sibling source — must survive.
+      "lonely.pxc",
+      // EPUB cache: image1.pxc shadowed by image1.jpg.
+      "image1.jpg",
+      "image1.pxc",
+      // EPUB cache quality variant — always dropped.
+      "anything_q.pxc",
+      // Non-image files unaffected.
+      "book.epub",
+      "notes.txt",
+      "subdir/",
+  };
+}
+
+void test_filter_drops_q_pxc() {
+  std::vector<std::string> files = sampleListing();
+  MyLibraryActivity::filterEpubCachePxc(files);
+  for (const auto& name : files) {
+    TEST_ASSERT_FALSE_MESSAGE(name.size() >= 6 && name.compare(name.size() - 6, 6, "_q.pxc") == 0,
+                              name.c_str());
+  }
+}
+
+void test_filter_drops_shadowed_pxc() {
+  std::vector<std::string> files = sampleListing();
+  MyLibraryActivity::filterEpubCachePxc(files);
+  for (const auto& name : files) {
+    TEST_ASSERT_NOT_EQUAL_MESSAGE(0, name.compare("image1.pxc"), "image1.pxc should be filtered");
+  }
+}
+
+void test_filter_keeps_user_pxc_alongside_bmp() {
+  std::vector<std::string> files = sampleListing();
+  MyLibraryActivity::filterEpubCachePxc(files);
+  bool keptPxc = false, keptBmp = false;
+  for (const auto& name : files) {
+    if (name == "wallpaper1.pxc") keptPxc = true;
+    if (name == "wallpaper1.bmp") keptBmp = true;
+  }
+  TEST_ASSERT_TRUE(keptPxc);
+  TEST_ASSERT_TRUE(keptBmp);
+}
+
+void test_filter_keeps_lonely_pxc() {
+  std::vector<std::string> files = sampleListing();
+  MyLibraryActivity::filterEpubCachePxc(files);
+  bool kept = false;
+  for (const auto& name : files) {
+    if (name == "lonely.pxc") kept = true;
+  }
+  TEST_ASSERT_TRUE(kept);
+}
+
+void test_filter_leaves_non_image_files_alone() {
+  std::vector<std::string> files = sampleListing();
+  MyLibraryActivity::filterEpubCachePxc(files);
+  bool keptEpub = false, keptTxt = false, keptDir = false;
+  for (const auto& name : files) {
+    if (name == "book.epub") keptEpub = true;
+    if (name == "notes.txt") keptTxt = true;
+    if (name == "subdir/") keptDir = true;
+  }
+  TEST_ASSERT_TRUE(keptEpub);
+  TEST_ASSERT_TRUE(keptTxt);
+  TEST_ASSERT_TRUE(keptDir);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+  RUN_TEST(test_filter_drops_q_pxc);
+  RUN_TEST(test_filter_drops_shadowed_pxc);
+  RUN_TEST(test_filter_keeps_user_pxc_alongside_bmp);
+  RUN_TEST(test_filter_keeps_lonely_pxc);
+  RUN_TEST(test_filter_leaves_non_image_files_alone);
+  return UNITY_END();
+}
+```
+
+If the test fails to link because `MyLibraryActivity` pulls in display dependencies, extract `filterEpubCachePxc` into a free function in a small dedicated unit (`src/activities/home/LibraryListingFilter.{h,cpp}`) and have `MyLibraryActivity` call it. Update the test to include that header. Refactor only if the simpler arrangement fails to link.
+
+- [ ] **Step 6: Run the tests.**
+
+Run: `pio test -e test_host -f test_library_filter`
+Expected: 5 pass.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add src/activities/home/MyLibraryActivity.h src/activities/home/MyLibraryActivity.cpp test/test_library_filter/
+git commit -m "feat(library): hide EPUB-cache .pxc files from browser"
+```
+
+---
+
+## Task 11: Web `/files` listing — add `isPxc`, apply cache filter, render badge
+
+**Files:**
+- Modify: `src/network/CrossPointWebServer.cpp`
+- Modify: `src/network/html/FilesPage.html`
+
+- [ ] **Step 1: Add `isPxc` to the listing struct.**
+
+In `src/network/CrossPointWebServer.cpp`, find the struct that holds `info.isBmp` (around the line with `info.isBmp = hasExtCI(name, nameLen, ".bmp", 4);` near line 777). Add an adjacent field and population line:
+
+```cpp
+        info.isBmp = hasExtCI(name, nameLen, ".bmp", 4);
+        info.isPxc = hasExtCI(name, nameLen, ".pxc", 4);
+```
+
+Also add the `isPxc` field to the struct definition (search up from line 777 for the matching struct; mirror `isBmp` exactly).
+
+- [ ] **Step 2: Emit `isPxc` in the JSON listing payload.**
+
+Where the listing serializer writes `"isBmp"`, add a parallel `"isPxc"` boolean. Match the existing JSON style.
+
+- [ ] **Step 3: Apply the EPUB-cache filter to web listings.**
+
+Right before the JSON serialization loop, run the same logic as `MyLibraryActivity::filterEpubCachePxc` against the listing entries: drop any `*_q.pxc`, drop any `*.pxc` whose stem matches a sibling `.jpg/.jpeg/.png/.gif/.webp` in the same listing.
+
+If the listing struct is local to that function, inline the filter. If you'd rather share with the native browser, factor `filterEpubCachePxc` into a free helper in a new `src/util/ImageListingFilter.{h,cpp}` and call it from both sites — recommended, but only if it's a 5-minute change. If it's not, inline here and leave the duplication for a follow-up.
+
+- [ ] **Step 4: Render the PXC badge in the HTML.**
+
+In `src/network/html/FilesPage.html`:
+
+- Find the `.bmp-file` CSS rules (around lines 245-251) and add parallel `.pxc-file` rules. Use the same colors and hover treatment to keep visual parity.
+- Find the `.bmp-badge` CSS rule (line 251) and add a parallel `.pxc-badge` rule.
+- In the desktop responsive override block (around line 1205) add `.pxc-badge` next to `.bmp-badge`.
+- In the folder-contents override block (around lines 1571 / 1580) add `.pxc-file` next to `.bmp-file`.
+- In the row rendering JS (around line 2600), update the row class selection:
+
+```js
+const rowClass = file.isEpub
+    ? 'epub-file'
+    : (file.isBmp ? 'bmp-file' : (file.isPxc ? 'pxc-file' : ''));
+```
+
+- And the badge emit (around line 2606):
+
+```js
+if (file.isBmp) fileTableContent += '<span class="bmp-badge">BMP</span>';
+if (file.isPxc) fileTableContent += '<span class="pxc-badge">PXC</span>';
+```
+
+- [ ] **Step 5: Build.**
+
+Run: `pio run -e default`
+Expected: build succeeds. The hashed CSS/HTML index regenerates as part of the build.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/network/CrossPointWebServer.cpp src/network/html/FilesPage.html
+git commit -m "feat(web): list .pxc files with cache filter and PXC badge"
+```
+
+---
+
+## Task 12: Manual on-device verification
+
+**Files:**
+- None (verification only)
+
+The renderer, the viewer, the sleep flow, and the web UI all need real-device confirmation. This task is a checklist; nothing is committed.
+
+- [ ] **Step 1: Build production firmware.**
+
+```bash
+pio run -e default
+```
+
+Expected: build succeeds. Compare Flash% / RAM% to the previous tag and note the delta.
+
+- [ ] **Step 2: Flash to device.**
+
+```bash
+pio run -e default -t upload --upload-port /dev/cu.usbmodem101
+```
+
+(Adjust the port if `ls /dev/cu.usb*` shows a different one.)
+
+- [ ] **Step 3: Drop test images on the SD card.**
+
+Place these on the SD card (substitute the actual screen dimensions for the device):
+
+- `/sleep/test1.pxc` (screen-sized, valid PXC)
+- `/sleep/test1.bmp` (different image, screen-sized BMP)
+- `/test2.pxc` at the SD root
+- `/Books/coversample.pxc` (an arbitrary screen-sized PXC outside `/sleep`)
+- `/Books/some-cached-book/page1.jpg` and `/Books/some-cached-book/page1.pxc` (forces the EPUB-cache filter)
+- `/Books/some-cached-book/anything_q.pxc` (forces the `_q.pxc` filter)
+- `/Wallpapers/badsize.pxc` (a PXC whose declared dimensions are wrong — e.g. 100×100 — to test the size-mismatch error path)
+
+- [ ] **Step 4: Walk the verification checklist.**
+
+For each, capture the result inline:
+
+- [ ] `/sleep/test1.pxc` and `/sleep/test1.bmp` both visible in library browser.
+- [ ] Open `/sleep/test1.pxc` in the viewer — renders fast (single HALF_REFRESH), no garbage.
+- [ ] Favorite `/sleep/test1.pxc` — file renames to `test1_F.pxc`, `[F]` prefix appears in browser.
+- [ ] Unfavorite — renames back to `test1.pxc`.
+- [ ] Rename `test1.pxc` to `renamed` via keyboard — file becomes `renamed.pxc` (extension preserved).
+- [ ] Delete `/sleep/test1.pxc` — disappears from listing and from `state.json` favorites.
+- [ ] Open `/Books/some-cached-book/`. Verify `page1.pxc` and `anything_q.pxc` are NOT visible. Verify `page1.jpg` IS visible.
+- [ ] Open `/Books/coversample.pxc` (no sibling jpg) — visible, opens, behaves as a normal image.
+- [ ] Open `/Wallpapers/badsize.pxc` — viewer shows the invalid-image error, back works.
+- [ ] Enter sleep with a `.pxc` selected from the playlist; pause sleep (button); resume. Same `.pxc` re-renders.
+- [ ] Connect to the web UI. `/files` lists the test PXC files with the `PXC` badge. `_q.pxc` and `page1.pxc` (shadowed) are absent. PXC files are downloadable.
+- [ ] Reboot the device. Verify previously-favorited PXC files still show `[F]` (state.json round-trip).
+
+- [ ] **Step 5: If anything fails, re-open the relevant earlier task and fix.**
+
+Don't move on with a known broken step.
+
+---
+
+## Self-review notes
+
+After this plan was drafted I checked it against the spec:
+
+- **Spec coverage:** All sections of the spec map to a task. Section 2's "no state migration" is delivered by Task 3 (rename without touching the JSON key) plus the explicit Task 12 boot-with-existing-state check. Section 3's renamed C++ symbols are covered by Tasks 3 + 6. The PXC renderer extraction is Task 2. The viewer fast path is Task 8. The rename-extension fix is Task 9. The cache filter is Task 10 (native) + Task 11 (web). The web UI is Task 11.
+- **Type consistency:** `renderImageView` (defined Task 8), `renderBmpImageView` and `renderPxcImageView` (defined Task 8), `imageViewFullyLoaded` (renamed Task 6), `Mode::IMAGE_VIEW` (renamed Task 6), `enterImageView` (renamed Task 6), `renameSelectedImage` (renamed Task 6, extended Task 9), `FavoriteImage::isImagePath` (renamed Task 4), `SetFavoriteResult::NotImage` (renamed Task 3), `filterEpubCachePxc` (added Task 10), `info.isPxc` (added Task 11). All consistent across tasks.
+- **Scope:** This is one feature plan, not multiple. No decomposition needed.

--- a/docs/superpowers/specs/2026-04-27-pxc-image-parity-design.md
+++ b/docs/superpowers/specs/2026-04-27-pxc-image-parity-design.md
@@ -1,0 +1,249 @@
+# PXC parity with BMP across firmware
+
+Status: design approved 2026-04-27.
+Author: CLU1 / Diogo.
+
+## Goal
+
+Treat `.pxc` (pre-dithered 2 bpp screen-sized image) as a first-class viewable
+image format anywhere `.bmp` is currently treated as one: `/sleep` browser,
+sleep-pause flow, library browser everywhere, image viewer activity,
+favorites, rename / move / delete, and the web `/files` listing.
+
+The `.pxc` wallpaper paths shipped in commit 0facea4 (sleep wallpaper render
+and root fallback) are not changed by this work — they continue to operate as
+they do today.
+
+## Non-goals
+
+- No support for arbitrary-sized `.pxc`. PXC stays strictly screen-sized; an
+  off-size file is a render error, exactly as it is today in the sleep
+  renderer.
+- No browser-side decode of `.pxc` for the web `/files` page. PXC files are
+  listed and downloadable but not previewed.
+- No `state.json` migration. The on-disk JSON key `favoriteBmpPaths` stays as
+  it is; only C++ symbols are renamed.
+- No new translation strings. Existing `STR_FAILED_OPEN_BMP` /
+  `STR_INVALID_BMP` are reused for PXC error cases. The string keys keep their
+  BMP names; the user-visible text is already generic enough ("Failed to open
+  image" / "Invalid image").
+
+## Constraints
+
+1. **Screen-size-only.** PXC layout is `uint16 width` + `uint16 height` +
+   packed 2 bpp payload. The renderer rejects any file whose width or height
+   differs from the screen by more than 1 px.
+2. **EPUB cache files must remain invisible.** The EPUB image renderer writes
+   cache files named `<basename>.pxc` and `<basename>_q.pxc` next to the
+   source image (see `lib/Epub/Epub/blocks/ImageBlock.cpp`). These are
+   internal cache and must not appear in the library browser, the web
+   `/files` page, or any favorites flow.
+3. **Single source of truth for the PXC renderer.** Sleep, library viewer,
+   and any future caller share one renderer.
+
+## Filtering rule for EPUB cache PXC files
+
+Apply identically in the native library browser scan and the web `/files`
+listing:
+
+- Always hide `*_q.pxc`.
+- Hide `<base>.pxc` if a sibling file in the same directory matches
+  `<base>.{jpg,jpeg,png,gif,webp}` (case-insensitive). The presence of a
+  book-format source image with the same basename is the signal that the
+  `.pxc` is a render cache, not a user image. `.bmp` is intentionally
+  **excluded** from the sibling-source list: a `.bmp` and `.pxc` with the
+  same basename in `/sleep` are two independent user wallpapers (per the
+  Q3 design decision), not a source/cache pair.
+- Otherwise show the `.pxc` as a user image.
+
+This preserves the "treat .bmp and .pxc independently" decision for `/sleep`
+(where users place their own files and there are no source siblings), while
+keeping book folders clean.
+
+## Components
+
+### New: `src/util/PxcRenderer.{h,cpp}`
+
+Free function extracted from `SleepActivity::renderPxcSleepScreen`:
+
+```cpp
+namespace PxcRenderer {
+// Streams a screen-sized .pxc into the framebuffer using the configured
+// grayscale mode (FactoryQuality if SETTINGS.useFactoryLUT, else
+// Differential). Returns false if open fails, header read fails, the
+// declared dimensions diverge from the screen by more than 1 px, or the row
+// buffer cannot be allocated. Does NOT call displayBuffer — caller picks
+// the refresh mode.
+bool renderPxc(GfxRenderer& renderer, const std::string& path);
+}  // namespace PxcRenderer
+```
+
+`SleepActivity::renderPxcSleepScreen` becomes a thin wrapper that calls
+`PxcRenderer::renderPxc` and then handles its existing optional filename
+label + HALF_REFRESH.
+
+### Renamed (C++ symbols only — JSON state untouched)
+
+| Old | New |
+|---|---|
+| `FavoriteBmp` namespace, `FavoriteBmp.{h,cpp}` | `FavoriteImage` namespace, `FavoriteImage.{h,cpp}` |
+| `Mode::BMP_VIEW` | `Mode::IMAGE_VIEW` |
+| `MyLibraryActivity::isBmpFile` | `MyLibraryActivity::isImageFile` (= bmp \|\| pxc) |
+| `enterBmpView` | `enterImageView` |
+| `renderBmpView` | `renderImageView` |
+| `bmpViewFullyLoaded` | `imageViewFullyLoaded` |
+| `openKeyboardForRenameBmp` | `openKeyboardForRenameImage` |
+| `renameSelectedBmp` | `renameSelectedImage` |
+
+`APP_STATE.favoriteBmpPaths` keeps its name — both as the C++ field and the
+JSON key — so existing user `state.json` files keep their favorites.
+Internally, `FavoriteImage` is documented to operate on both `.bmp` and
+`.pxc` despite the legacy field name.
+
+A new helper:
+
+```cpp
+bool MyLibraryActivity::isPxcFile(const std::string& filename);  // ".pxc"
+bool MyLibraryActivity::isBmpFile(const std::string& filename);  // ".bmp" (kept private — used by isImageFile)
+bool MyLibraryActivity::isImageFile(const std::string& filename); // bmp || pxc
+```
+
+`isManagedFile` becomes `isBookFile(name) || isImageFile(name)`.
+
+### Extended
+
+#### `FavoriteImage::setFavorite`
+
+Accepts paths whose extension is `.bmp` or `.pxc`. The `_F` favorite suffix
+is inserted before the actual extension — i.e. `foo.pxc` becomes
+`foo_F.pxc`, `bar.bmp` becomes `bar_F.bmp`. The internal helpers
+`hasFavoriteSuffix`, `addFavoriteSuffix`, `stripFavoriteSuffix` operate on
+the last 4 characters (which is the same length for both extensions).
+
+The internal `isBmpPathInternal` predicate is renamed to `isImagePath` and
+checks for either extension.
+
+`countProtectedSleepFavorites` counts both `.bmp` and `.pxc` favorites in
+`/sleep` against the same `SLEEP_FAVORITES_MAX = 500` cap. There is no
+per-format cap.
+
+`SetFavoriteResult::NotBmp` is renamed to `SetFavoriteResult::NotImage`.
+
+#### `MyLibraryActivity::renderImageView`
+
+Branches on the actual extension of `selectedFilePath`:
+
+- `.bmp` → existing path unchanged: `Bitmap` parse, optional centering,
+  `HALF_REFRESH` BW pass, optional grayscale double pass when present, mark
+  `imageViewFullyLoaded`.
+- `.pxc` → `PxcRenderer::renderPxc`, then a single `HALF_REFRESH`. No
+  centering math (PXC is screen-sized by contract). No grayscale double pass
+  (PXC is already pre-dithered with the factory waveform). Mark
+  `imageViewFullyLoaded` immediately on success. On failure, render the
+  same `STR_INVALID_BMP` / `STR_FAILED_OPEN_BMP` error path as BMP.
+
+#### `MyLibraryActivity::renameSelectedImage`
+
+The previous implementation hard-coded `.bmp` for both extension stripping
+and the rebuilt target path. The new implementation:
+
+- Detects the original extension from `selectedFilePath`.
+- Strips a user-typed trailing `.bmp` or `.pxc` (case-insensitive) and a
+  trailing `_F` from the entered base name.
+- Rebuilds the target path with the same original extension.
+
+The auto-suffix collision loop and the reload-and-snap-cursor logic are
+unchanged.
+
+#### Library browser folder scan
+
+After populating `files` for the current folder, apply the EPUB cache
+filter described above. Implementation: build a `std::unordered_set<string>`
+of source-image basenames in the listing once per folder load, then drop
+any `_q.pxc` and any `.pxc` whose basename appears in the source-image
+set. O(n) over the listing, no extra SD I/O.
+
+#### Sleep playlist / sleep-pause
+
+`SdFatSleepFs::isSleepImageExt` already accepts both `.bmp` and `.pxc`, and
+`SleepActivity::onResume` already re-renders the saved
+`lastSleepWallpaperPath` via PXC when the path ends in `.pxc`
+(SleepActivity.cpp:150). No code changes needed; verification only.
+
+`syncSleepPlaylistWithFiles` and `randomizeSleepImagePlaylist` already
+operate on whatever `getValidSleepBitmaps` returns, which uses the
+extension predicate. No changes needed.
+
+#### Web `/files`
+
+In `CrossPointWebServer.cpp`:
+
+- Add `info.isPxc` populated the same way as `info.isBmp`.
+- Apply the EPUB cache filter to listings: same `_q.pxc` / sibling-source
+  rule.
+- Existing BMP download endpoint pattern reused for PXC; MIME type
+  `application/octet-stream` (browser cannot render PXC anyway).
+
+In `FilesPage.html`:
+
+- Add a `pxc-file` row class mirroring `bmp-file`.
+- Add a `PXC` badge mirroring `BMP`.
+- No browser preview path. The PXC entry is downloadable like any other
+  file.
+
+The hashed CSS index is regenerated as part of the build.
+
+## Data flow — library viewer for .pxc
+
+1. User selects `foo.pxc` in the library browser.
+2. `enterImageView(path)` sets `selectedFilePath`, `Mode::IMAGE_VIEW`,
+   `imageViewFullyLoaded = false`, queues a clean refresh.
+3. `renderImageView()` detects `.pxc` and calls
+   `PxcRenderer::renderPxc(renderer, selectedFilePath)`.
+4. On success: button hints drawn, `HalDisplay::HALF_REFRESH`,
+   `imageViewFullyLoaded = true`.
+5. On open fail / header fail / size mismatch: error text via
+   `STR_FAILED_OPEN_BMP` or `STR_INVALID_BMP`, back-button hint, frame
+   displayed.
+6. Action menu (rename / favorite / move / delete) operates on
+   `selectedFilePath` regardless of extension.
+
+## Heap impact
+
+- `PxcRenderer::renderPxc` allocates one row buffer of `(screenWidth + 3) /
+  4` bytes (≈75 B on a 296-px screen) for the duration of the render and
+  frees it before returning. No persistent heap commitment.
+- The folder-scan EPUB-cache filter builds a transient
+  `unordered_set<string>` of source-image basenames per folder load. Bounded
+  by the existing browser cap (300 normally, 1000 for `/sleep`).
+
+## Testing
+
+Manual on device:
+
+- Drop a screen-sized `.pxc` into `/sleep`, `/`, `/Books`, `/Wallpapers`.
+  Verify each appears in the library browser, opens via the image viewer,
+  favorites correctly (renames to `*_F.pxc`), renames via keyboard,
+  deletes.
+- Drop an EPUB book whose images get cached as `.pxc` and `_q.pxc`
+  siblings. Open the book to populate the cache, return to the library
+  browser, verify the cache files are invisible.
+- Drop a standalone `_q.pxc` anywhere outside `/sleep`. Verify it is
+  hidden.
+- Enter sleep mode with a `.pxc` selected from the playlist; pause sleep
+  (button press); resume; verify the same `.pxc` re-renders.
+- Open the web `/files` page; verify each `.pxc` shows with a `PXC` badge,
+  is not previewed, and is downloadable. Verify no `_q.pxc` or
+  source-shadowed `.pxc` appears.
+- Boot with an existing `state.json` containing `favoriteBmpPaths`; verify
+  favorites are preserved and continue to render the `[F]` prefix.
+- Rename / move / delete on `.pxc` favorites; verify
+  `APP_STATE.favoriteBmpPaths` updates and `state.json` round-trips.
+- Drop a `.pxc` whose declared dimensions do not match the screen; verify
+  the viewer shows the invalid-image error rather than rendering garbage.
+
+Build:
+
+- `pio run -e default` — confirm Flash% / RAM% deltas.
+- `pio run -e debug -t upload` for serial verification of the cache filter
+  log lines and PXC render log lines.

--- a/platformio.ini
+++ b/platformio.ini
@@ -165,6 +165,7 @@ build_src_filter =
   +<persist/CrossPointStateJson.cpp>
   +<activities/reader/ReaderProgressTracker.cpp>
   +<activities/reader/HighlightController.cpp>
+  +<util/FavoriteImageNames.cpp>
 build_flags =
   -std=gnu++2a
   -DUNIT_TEST_HOST=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -166,6 +166,7 @@ build_src_filter =
   +<activities/reader/ReaderProgressTracker.cpp>
   +<activities/reader/HighlightController.cpp>
   +<util/FavoriteImageNames.cpp>
+  +<activities/home/LibraryListingFilter.cpp>
 build_flags =
   -std=gnu++2a
   -DUNIT_TEST_HOST=1

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -475,7 +475,12 @@ void SleepActivity::renderCoverSleepScreen() const {
 }
 
 bool SleepActivity::renderPxcSleepScreen(const std::string& path, const char* sourceFilename) const {
-  if (!PxcRenderer::renderPxc(renderer, path)) {
+  // Sleep wallpapers cover the full screen with no overlay underneath, so
+  // Factory mode (with its pre-flash) gives the best image quality.
+  // Differential is the fallback when the user has the factory LUT off.
+  const auto mode = SETTINGS.useFactoryLUT ? GfxRenderer::GrayscaleMode::FactoryQuality
+                                           : GfxRenderer::GrayscaleMode::Differential;
+  if (!PxcRenderer::renderPxc(renderer, path, mode)) {
     return false;
   }
 

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -1,7 +1,6 @@
 #include "SleepActivity.h"
 
 #include <Epub.h>
-#include <Epub/converters/DirectPixelWriter.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <I18n.h>
@@ -25,6 +24,7 @@
 #include "sleep/WallpaperPlaylistV2.h"
 #endif
 #include "util/FavoriteBmp.h"
+#include "util/PxcRenderer.h"
 #include "util/StringUtils.h"
 
 namespace {
@@ -475,56 +475,9 @@ void SleepActivity::renderCoverSleepScreen() const {
 }
 
 bool SleepActivity::renderPxcSleepScreen(const std::string& path, const char* sourceFilename) const {
-  // PXC layout: uint16 width, uint16 height, then packed 2bpp payload (4 px/byte, MSB first).
-  // Pixel convention: 0=Black, 1=DarkGray, 2=LightGray, 3=White — same as Bitmap::readNextRow.
-  FsFile file;
-  if (!Storage.openFileForRead("SLP", path, file)) {
-    LOG_ERR("SLP", "Cannot open PXC: %s", path.c_str());
+  if (!PxcRenderer::renderPxc(renderer, path)) {
     return false;
   }
-  uint16_t pxcWidth = 0, pxcHeight = 0;
-  if (file.read(&pxcWidth, 2) != 2 || file.read(&pxcHeight, 2) != 2) {
-    LOG_ERR("SLP", "PXC header read failed: %s", path.c_str());
-    file.close();
-    return false;
-  }
-  const int sw = renderer.getScreenWidth();
-  const int sh = renderer.getScreenHeight();
-  if (std::abs(static_cast<int>(pxcWidth) - sw) > 1 || std::abs(static_cast<int>(pxcHeight) - sh) > 1) {
-    LOG_ERR("SLP", "PXC size mismatch %dx%d (screen %dx%d): %s", pxcWidth, pxcHeight, sw, sh, path.c_str());
-    file.close();
-    return false;
-  }
-  const uint32_t dataOffset = file.position();
-  const int bytesPerRow = (pxcWidth + 3) / 4;
-  uint8_t* rowBuf = static_cast<uint8_t*>(malloc(bytesPerRow));
-  if (!rowBuf) {
-    LOG_ERR("SLP", "PXC row alloc failed (%d bytes)", bytesPerRow);
-    file.close();
-    return false;
-  }
-
-  const auto mode =
-      SETTINGS.useFactoryLUT ? GfxRenderer::GrayscaleMode::FactoryQuality : GfxRenderer::GrayscaleMode::Differential;
-  const int width = static_cast<int>(pxcWidth);
-  const int height = static_cast<int>(pxcHeight);
-  renderer.renderGrayscale(mode, [&]() {
-    file.seek(dataOffset);
-    DirectPixelWriter pw;
-    pw.init(renderer);
-    for (int row = 0; row < height; row++) {
-      if (file.read(rowBuf, bytesPerRow) != bytesPerRow) break;
-      pw.beginRow(row);
-      for (int col = 0; col < width; col++) {
-        const uint8_t pv = (rowBuf[col >> 2] >> (6 - (col & 3) * 2)) & 0x03;
-        pw.writePixel(col, pv);
-      }
-      if ((row & 31) == 0) esp_task_wdt_reset();
-    }
-  });
-
-  free(rowBuf);
-  file.close();
 
   if (sourceFilename != nullptr && SETTINGS.showSleepImageFilename) {
     drawSleepFilenameLabel(renderer, sourceFilename);

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -23,7 +23,7 @@
 #if FEATURE_WALLPAPER_V2
 #include "sleep/WallpaperPlaylistV2.h"
 #endif
-#include "util/FavoriteBmp.h"
+#include "util/FavoriteImage.h"
 #include "util/PxcRenderer.h"
 #include "util/StringUtils.h"
 
@@ -150,7 +150,7 @@ void SleepActivity::renderCustomSleepScreen() const {
     if (StringUtils::checkFileExtension(APP_STATE.lastSleepWallpaperPath, ".pxc")) {
       LOG_DBG("SLP", "Paused, re-showing PXC: %s", APP_STATE.lastSleepWallpaperPath.c_str());
       delay(100);
-      const std::string displayName = FavoriteBmp::displayNameForPath(APP_STATE.lastSleepWallpaperPath);
+      const std::string displayName = FavoriteImage::displayNameForPath(APP_STATE.lastSleepWallpaperPath);
       if (renderPxcSleepScreen(APP_STATE.lastSleepWallpaperPath, displayName.c_str())) {
         return;
       }
@@ -163,7 +163,7 @@ void SleepActivity::renderCustomSleepScreen() const {
         Bitmap bitmap(file, true);
         const auto parseErr = bitmap.parseHeaders();
         if (parseErr == BmpReaderError::Ok) {
-          const std::string displayName = FavoriteBmp::displayNameForPath(APP_STATE.lastSleepWallpaperPath);
+          const std::string displayName = FavoriteImage::displayNameForPath(APP_STATE.lastSleepWallpaperPath);
           renderBitmapSleepScreen(bitmap, displayName.c_str());
           file.close();
           return;
@@ -192,7 +192,7 @@ void SleepActivity::renderCustomSleepScreen() const {
     if (StringUtils::checkFileExtension(selectedImage, ".pxc")) {
       LOG_DBG("SLP", "Loading PXC: %s", filename.c_str());
       delay(100);
-      const std::string displayName = FavoriteBmp::displayNameForPath(filename);
+      const std::string displayName = FavoriteImage::displayNameForPath(filename);
       if (renderPxcSleepScreen(filename, displayName.c_str())) {
         rememberLastRenderedSleepBitmap(filename, selectedImage);
         rendered = true;
@@ -208,7 +208,7 @@ void SleepActivity::renderCustomSleepScreen() const {
       Bitmap bitmap(file, true);
       const auto parseErr = bitmap.parseHeaders();
       if (parseErr == BmpReaderError::Ok) {
-        const std::string displayName = FavoriteBmp::displayNameForPath(filename);
+        const std::string displayName = FavoriteImage::displayNameForPath(filename);
         rememberLastRenderedSleepBitmap(filename, selectedImage);
         renderBitmapSleepScreen(bitmap, displayName.c_str());
         file.close();
@@ -239,7 +239,7 @@ void SleepActivity::renderCustomSleepScreen() const {
       Bitmap bitmap(file, true);
       const auto parseErr = bitmap.parseHeaders();
       if (parseErr == BmpReaderError::Ok) {
-        const std::string displayName = FavoriteBmp::displayNameForPath(fallbackPath);
+        const std::string displayName = FavoriteImage::displayNameForPath(fallbackPath);
         LOG_DBG("SLP", "Loading: %s", fallbackPath);
         rememberLastRenderedSleepBitmap(fallbackPath);
         renderBitmapSleepScreen(bitmap, displayName.c_str());

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -25,7 +25,7 @@
 #include "fontIds.h"
 #include "util/BookProgress.h"
 #include "util/DrawUtils.h"
-#include "util/FavoriteBmp.h"
+#include "util/FavoriteImage.h"
 #include "util/StringUtils.h"
 
 namespace {
@@ -328,7 +328,7 @@ void HomeActivity::render(Activity::RenderLock&&) {
     const int warningY = warningBottomY;
     const int warningWidth = pageWidth - metrics.contentSidePadding * 2;
     const std::string warningText =
-        renderer.truncatedText(SMALL_FONT_ID, FavoriteBmp::limitReachedHomeMessage(), warningWidth);
+        renderer.truncatedText(SMALL_FONT_ID, FavoriteImage::limitReachedHomeMessage(), warningWidth);
     renderer.drawText(SMALL_FONT_ID, metrics.contentSidePadding, warningY, warningText.c_str());
     warningBottomY = warningY + renderer.getLineHeight(SMALL_FONT_ID) + 8;
   }

--- a/src/activities/home/LibraryListingFilter.cpp
+++ b/src/activities/home/LibraryListingFilter.cpp
@@ -1,0 +1,63 @@
+#include "LibraryListingFilter.h"
+
+#include <algorithm>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace LibraryListingFilter {
+
+void filterEpubCachePxc(std::vector<std::string>& files) {
+  // Source extensions whose presence protects a same-stem .pxc from display.
+  // .bmp is intentionally excluded — a .bmp + .pxc pair in /sleep are two
+  // independent user wallpapers, not a source/cache pair.
+  static const char* const kSourceExts[] = {".jpg", ".jpeg", ".png", ".gif", ".webp"};
+
+  auto lowerExt = [](const std::string& name, size_t extLen) {
+    if (name.size() < extLen) return std::string{};
+    std::string ext = name.substr(name.size() - extLen);
+    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+    return ext;
+  };
+
+  auto stemOf = [](const std::string& name) {
+    const auto dot = name.find_last_of('.');
+    return (dot == std::string::npos) ? name : name.substr(0, dot);
+  };
+
+  auto toLower = [](std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    return s;
+  };
+
+  // Build set of lowercased stems for which a source-format sibling exists.
+  std::unordered_set<std::string> sourceStems;
+  for (const auto& name : files) {
+    if (name.empty() || name.back() == '/') continue;
+    for (const char* ext : kSourceExts) {
+      const std::string e = ext;
+      if (name.size() >= e.size() && lowerExt(name, e.size()) == e) {
+        sourceStems.insert(toLower(stemOf(name)));
+        break;
+      }
+    }
+  }
+
+  files.erase(
+      std::remove_if(files.begin(), files.end(),
+                     [&](const std::string& name) {
+                       if (name.empty() || name.back() == '/') return false;
+                       if (lowerExt(name, 4) != ".pxc") return false;
+                       const std::string lower = toLower(name);
+                       // Drop any *_q.pxc.
+                       if (lower.size() >= 6 &&
+                           lower.compare(lower.size() - 6, 6, "_q.pxc") == 0) {
+                         return true;
+                       }
+                       // Drop *.pxc whose stem has a source-format sibling.
+                       return sourceStems.count(toLower(stemOf(name))) > 0;
+                     }),
+      files.end());
+}
+
+}  // namespace LibraryListingFilter

--- a/src/activities/home/LibraryListingFilter.h
+++ b/src/activities/home/LibraryListingFilter.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace LibraryListingFilter {
+
+// Removes EPUB-render cache files from a flat directory listing.
+//
+// Rules:
+//  - Always drop *_q.pxc.
+//  - Drop <base>.pxc when a sibling file with the same stem and a source
+//    image extension (.jpg/.jpeg/.png/.gif/.webp) is present in the listing.
+//  - .bmp is intentionally NOT in the source-extension list: a .bmp and a
+//    .pxc with the same basename in /sleep are two independent user
+//    wallpapers and must both survive.
+//
+// The function operates on bare filenames (no directory prefix). Directory
+// entries (names ending with '/') are ignored and left untouched.
+void filterEpubCachePxc(std::vector<std::string>& files);
+
+}  // namespace LibraryListingFilter

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -1,4 +1,5 @@
 #include "MyLibraryActivity.h"
+#include "LibraryListingFilter.h"
 
 #include <Bitmap.h>
 #include <Epub.h>
@@ -258,6 +259,9 @@ void MyLibraryActivity::loadFilesWithLimit() {
 
   sortFileList(files);
 
+  // Remove EPUB-render cache files before any ordering/capping logic.
+  filterEpubCachePxc(files);
+
   // Randomize display order for media-browsing folders
   bool shouldShuffle = (basepath == "/sleep pause" || basepath == "/sleep library");
   if (basepath == "/books" && SETTINGS.booksFolderOrder == 1) shouldShuffle = true;
@@ -426,6 +430,10 @@ bool MyLibraryActivity::isImageFile(const std::string& filename) {
 
 bool MyLibraryActivity::isManagedFile(const std::string& filename) {
   return isBookFile(filename) || isImageFile(filename);
+}
+
+void MyLibraryActivity::filterEpubCachePxc(std::vector<std::string>& files) {
+  LibraryListingFilter::filterEpubCachePxc(files);
 }
 
 std::string MyLibraryActivity::getDisplayNameForRawFile(const size_t rawIndex) {

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -1584,6 +1584,20 @@ void MyLibraryActivity::renderBmpImageView() {
 }
 
 void MyLibraryActivity::renderPxcImageView() {
+  // Post-load render (returning from menu, popup toggle, etc.): draw
+  // buttons and refresh fast. Image was already streamed once, so skip the
+  // slow HALF_REFRESH + full PXC decode pipeline.
+  if (imageViewFullyLoaded) {
+    const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_ACTIONS_BUTTON), "", "");
+    GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+    if (messagePopupOpen) {
+      GUI.drawPopup(renderer, messagePopupText.c_str());
+    }
+    renderer.displayBuffer(HalDisplay::FAST_REFRESH);
+    nextRefreshMode = HalDisplay::FAST_REFRESH;
+    return;
+  }
+
   renderer.clearScreen();
 
   if (!PxcRenderer::renderPxc(renderer, selectedFilePath)) {

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -493,16 +493,15 @@ std::string MyLibraryActivity::getRowTextForListIndex(const size_t listIndex) {
 }
 
 void MyLibraryActivity::enterImageView(const std::string& imagePath) {
-  // Stacking toasts for image-open stages. Natural FAST_REFRESH pacing
-  // (~400 ms each) keeps each toast visible briefly; no artificial stall.
-  // Full refresh on enter scrubs the list ghost.
+  // Single "Opening image" toast — PXC renders fast enough that a stacked
+  // load toast would just race the image onto the screen. Full refresh on
+  // enter scrubs the list ghost.
   if (!TransitionFeedback::isActive()) {
     TransitionFeedback::show(renderer, tr(STR_OPENING_IMAGE));
   }
   selectedFilePath = imagePath;
   mode = Mode::IMAGE_VIEW;
   imageViewFullyLoaded = false;
-  TransitionFeedback::show(renderer, tr(STR_LOADING_BITMAP));
   renderer.requestFullRefresh();
   requestCleanRefresh();
   requestUpdate();
@@ -1609,16 +1608,16 @@ void MyLibraryActivity::renderPxcImageView() {
     return;
   }
 
-  // PXC is pre-dithered: renderGrayscale() inside PxcRenderer::renderPxc
-  // already pushed the image to the panel via displayGrayBuffer. Here we
-  // only overlay button hints / popup, so FAST_REFRESH (~300 ms) is
-  // sufficient — no need for the legacy BMP HALF_REFRESH (~1.7 s).
+  // HALF_REFRESH required to overlay BW button hints cleanly on top of the
+  // grayscale image just pushed by renderGrayscale. FAST_REFRESH inverts
+  // the panel because the BW buffer state diverges from the grayscale
+  // composite the panel currently shows.
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_ACTIONS_BUTTON), "", "");
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
   if (messagePopupOpen) {
     GUI.drawPopup(renderer, messagePopupText.c_str());
   }
-  renderer.displayBuffer(HalDisplay::FAST_REFRESH);
+  renderer.displayBuffer(HalDisplay::HALF_REFRESH);
   nextRefreshMode = HalDisplay::FAST_REFRESH;
   imageViewFullyLoaded = true;
 }

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -30,6 +30,7 @@
 #include "persist/Trash.h"
 #include "util/BookProgress.h"
 #include "util/FavoriteImage.h"
+#include "util/PxcRenderer.h"
 #include "util/StatusPopup.h"
 #include "util/StringUtils.h"
 #include "util/TransitionFeedback.h"
@@ -1435,14 +1436,14 @@ void MyLibraryActivity::render(Activity::RenderLock&&) {
   // Help text
   const auto selectedRawIndex = rawFileIndexForListIndex(selectorIndex);
   const bool hasSelectedFile = selectedRawIndex.has_value() && isManagedFile(files[*selectedRawIndex]);
-  const bool hasSelectedBmp = selectedRawIndex.has_value() && isImageFile(files[*selectedRawIndex]);
+  const bool hasSelectedImage = selectedRawIndex.has_value() && isImageFile(files[*selectedRawIndex]);
   const char* confirmLabel = tr(STR_OPEN);
   if (isSearchActionRow(selectorIndex)) {
     confirmLabel = tr(STR_SEARCH_BUTTON);
   } else if (isClearSearchRow(selectorIndex)) {
     confirmLabel = tr(STR_CLEAR_BUTTON);
   } else if (hasSelectedFile) {
-    confirmLabel = hasSelectedBmp ? tr(STR_VIEW_HOLD) : tr(STR_OPEN_HOLD);
+    confirmLabel = hasSelectedImage ? tr(STR_VIEW_HOLD) : tr(STR_OPEN_HOLD);
   }
   const char* backLabel = basepath == "/" ? tr(STR_HOME) : tr(STR_BACK_HOLD);
   const auto labels = mappedInput.mapLabels(backLabel, confirmLabel, tr(STR_DIR_UP), tr(STR_DIR_DOWN));
@@ -1456,6 +1457,14 @@ void MyLibraryActivity::render(Activity::RenderLock&&) {
 }
 
 void MyLibraryActivity::renderImageView() {
+  if (isPxcFile(selectedFilePath)) {
+    renderPxcImageView();
+    return;
+  }
+  renderBmpImageView();
+}
+
+void MyLibraryActivity::renderBmpImageView() {
   renderer.clearScreen();
 
   FsFile file;
@@ -1556,6 +1565,28 @@ void MyLibraryActivity::renderImageView() {
   // fast post-load path above.
   imageViewFullyLoaded = true;
   requestUpdate();
+}
+
+void MyLibraryActivity::renderPxcImageView() {
+  renderer.clearScreen();
+
+  if (!PxcRenderer::renderPxc(renderer, selectedFilePath)) {
+    renderer.drawCenteredText(UI_12_FONT_ID, 80, tr(STR_INVALID_BMP));
+    const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
+    GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+    displayFrame();
+    imageViewFullyLoaded = true;
+    return;
+  }
+
+  const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_ACTIONS_BUTTON), "", "");
+  GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+  if (messagePopupOpen) {
+    GUI.drawPopup(renderer, messagePopupText.c_str());
+  }
+  renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+  nextRefreshMode = HalDisplay::FAST_REFRESH;
+  imageViewFullyLoaded = true;
 }
 
 void MyLibraryActivity::renderFileActions() {

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -424,7 +424,7 @@ bool MyLibraryActivity::isImageFile(const std::string& filename) {
 }
 
 bool MyLibraryActivity::isManagedFile(const std::string& filename) {
-  return isBookFile(filename) || isBmpFile(filename);
+  return isBookFile(filename) || isImageFile(filename);
 }
 
 std::string MyLibraryActivity::getDisplayNameForRawFile(const size_t rawIndex) {
@@ -437,7 +437,7 @@ std::string MyLibraryActivity::getDisplayNameForRawFile(const size_t rawIndex) {
     return "[" + name.substr(0, name.size() - 1) + "]";
   }
 
-  if (isBmpFile(name)) {
+  if (isImageFile(name)) {
     return FavoriteImage::displayNameForPath(makeAbsolutePath(name));
   }
 
@@ -515,7 +515,7 @@ void MyLibraryActivity::enterFileMoveBrowser() {
 }
 
 void MyLibraryActivity::openKeyboardForRenameImage() {
-  if (!isBmpFile(selectedFilePath)) return;
+  if (!isImageFile(selectedFilePath)) return;
 
   pendingRenameBase.clear();
   pendingRenameSubmit = false;
@@ -615,12 +615,12 @@ void MyLibraryActivity::renameSelectedImage(const std::string& newBase) {
 }
 
 int MyLibraryActivity::getFileActionCount() const {
-  if (!isBmpFile(selectedFilePath)) return 5;
+  if (!isImageFile(selectedFilePath)) return 5;
   return actionsOpenedFromViewer ? 7 : 8;
 }
 
 std::string MyLibraryActivity::getFileActionLabel(const int index) const {
-  if (isBmpFile(selectedFilePath)) {
+  if (isImageFile(selectedFilePath)) {
     int i = index;
     if (!actionsOpenedFromViewer) {
       if (i == 0) return tr(STR_OPEN_IMAGE);
@@ -762,7 +762,7 @@ bool MyLibraryActivity::moveSelectedFileTo(const std::string& targetDir, std::st
       }
     }
     RECENT_BOOKS.removeBook(selectedFilePath);
-  } else if (isBmpFile(selectedFilePath)) {
+  } else if (isImageFile(selectedFilePath)) {
     FavoriteImage::replacePathReferences(selectedFilePath, destination);
     APP_STATE.saveToFile();
   }
@@ -790,7 +790,7 @@ bool MyLibraryActivity::deleteFile(const std::string& path) {
     return false;
   }
 
-  if (isBmpFile(path)) {
+  if (isImageFile(path)) {
     FavoriteImage::removePathReferences(path);
     APP_STATE.saveToFile();
   }
@@ -938,7 +938,7 @@ void MyLibraryActivity::loopFileActions() {
   });
 
   if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    if (isBmpFile(selectedFilePath)) {
+    if (isImageFile(selectedFilePath)) {
       // When menu opened from library browser, index 0 is "Open Image" and
       // the remaining actions start at 1. When opened from the viewer,
       // "Open Image" is hidden and actions start at 0. Shift to a unified
@@ -1270,7 +1270,7 @@ void MyLibraryActivity::loopBrowse() {
       requestCleanRefresh();
       requestUpdate();
     } else if (isManagedFile(selectedEntry)) {
-      if (isBmpFile(selectedEntry)) {
+      if (isImageFile(selectedEntry)) {
         enterImageView(selectedPath);
       } else {
         onSelectBook(selectedPath);
@@ -1435,7 +1435,7 @@ void MyLibraryActivity::render(Activity::RenderLock&&) {
   // Help text
   const auto selectedRawIndex = rawFileIndexForListIndex(selectorIndex);
   const bool hasSelectedFile = selectedRawIndex.has_value() && isManagedFile(files[*selectedRawIndex]);
-  const bool hasSelectedBmp = selectedRawIndex.has_value() && isBmpFile(files[*selectedRawIndex]);
+  const bool hasSelectedBmp = selectedRawIndex.has_value() && isImageFile(files[*selectedRawIndex]);
   const char* confirmLabel = tr(STR_OPEN);
   if (isSearchActionRow(selectorIndex)) {
     confirmLabel = tr(STR_SEARCH_BUTTON);

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -415,6 +415,14 @@ bool MyLibraryActivity::isBmpFile(const std::string& filename) {
   return StringUtils::checkFileExtension(filename, ".bmp");
 }
 
+bool MyLibraryActivity::isPxcFile(const std::string& filename) {
+  return StringUtils::checkFileExtension(filename, ".pxc");
+}
+
+bool MyLibraryActivity::isImageFile(const std::string& filename) {
+  return isBmpFile(filename) || isPxcFile(filename);
+}
+
 bool MyLibraryActivity::isManagedFile(const std::string& filename) {
   return isBookFile(filename) || isBmpFile(filename);
 }

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -1583,14 +1583,12 @@ void MyLibraryActivity::renderBmpImageView() {
 }
 
 void MyLibraryActivity::renderPxcImageView() {
-  // Post-load render (returning from menu, popup toggle, etc.): rewrite
-  // BW frameBuffer to (white + button hints) and FAST_REFRESH. RED RAM
-  // already holds white from the initial-load cleanup below, so this
-  // FAST pass only drives the hint-region pixels — the grayscale image
-  // is left untouched.
+  // Post-load render (returning from menu, popup toggle, etc.): redraw
+  // hints + popup with FAST_REFRESH. The grayscale image was already
+  // composited by the differential pass below; FAST refresh only drives
+  // pixels that differ from the BW base captured during initial load.
   if (imageViewFullyLoaded) {
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_ACTIONS_BUTTON), "", "");
-    renderer.clearScreen();
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
     if (messagePopupOpen) {
       GUI.drawPopup(renderer, messagePopupText.c_str());
@@ -1600,22 +1598,22 @@ void MyLibraryActivity::renderPxcImageView() {
     return;
   }
 
-  // Initial PXC viewer load.
-  //
-  // Render strategy:
-  //   1. Factory grayscale push of the PXC. Pre-flashes white and absolutely
-  //      drives a clean 4-level image. Differential mode can't render pure
-  //      black (Black and White both encode as LSB=0,MSB=0 and rely on the
-  //      panel's prior state), so PXC viewer needs Factory.
-  //   2. Reset BW frameBuffer to white and copy that into RED RAM via
-  //      cleanupGrayscaleWithFrameBuffer. After this: BW RAM = factory LSB,
-  //      RED RAM = white, panel = grayscale image.
-  //   3. Draw button hints (and any popup) into BW frameBuffer, FAST_REFRESH.
-  //      Standard fast waveform compares BW (=white+hints) to RED (=white)
-  //      and only drives the hint-region pixels — image area stays as-is.
+  // Initial PXC viewer load — same strategy as the BMP viewer:
+  //   1. BW pass: stream PXC as 1-bit (pv < 3 → black, pv == 3 → white) into
+  //      the BW frameBuffer; overlay button hints; HALF_REFRESH. Panel now
+  //      shows a stark BW silhouette of the image plus the hints.
+  //   2. storeBwBuffer to preserve the BW base.
+  //   3. Differential grayscale overlay: re-streams the PXC twice (LSB plane
+  //      + MSB plane) and pushes the composite. Differential's encoding
+  //      identifies pure-black and pure-white as (0,0) and lets the prior
+  //      panel state — set by step 1 — disambiguate them, so stark images
+  //      come out correctly without Factory mode's pre-flash wiping the
+  //      button hints.
+  //   4. restoreBwBuffer (also calls cleanupGrayscaleBuffers, syncing RED
+  //      RAM back to the BW base for future FAST_REFRESH transitions).
   renderer.clearScreen();
 
-  if (!PxcRenderer::renderPxc(renderer, selectedFilePath, GfxRenderer::GrayscaleMode::FactoryQuality)) {
+  if (!PxcRenderer::streamPxcAsBw(renderer, selectedFilePath)) {
     renderer.clearScreen();
     renderer.drawCenteredText(UI_12_FONT_ID, 80, tr(STR_INVALID_BMP));
     const auto errLabels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
@@ -1625,19 +1623,19 @@ void MyLibraryActivity::renderPxcImageView() {
     return;
   }
 
-  // Sync BW frameBuffer + RED RAM to white so the upcoming FAST_REFRESH
-  // computes hint-region transitions against a clean baseline and treats
-  // the grayscale image area as "no change".
-  renderer.clearScreen();
-  renderer.cleanupGrayscaleWithFrameBuffer();
-
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_ACTIONS_BUTTON), "", "");
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
   if (messagePopupOpen) {
     GUI.drawPopup(renderer, messagePopupText.c_str());
   }
-  renderer.displayBuffer(HalDisplay::FAST_REFRESH);
+  renderer.displayBuffer(HalDisplay::HALF_REFRESH);
   nextRefreshMode = HalDisplay::FAST_REFRESH;
+
+  if (renderer.storeBwBuffer()) {
+    PxcRenderer::renderPxc(renderer, selectedFilePath, GfxRenderer::GrayscaleMode::Differential);
+    renderer.restoreBwBuffer();
+  }
+
   imageViewFullyLoaded = true;
 }
 

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -536,11 +536,19 @@ void MyLibraryActivity::renameSelectedImage(const std::string& newBase) {
   while (!base.empty() && (base.front() == ' ' || base.front() == '\t')) base.erase(base.begin());
   while (!base.empty() && (base.back() == ' ' || base.back() == '\t')) base.pop_back();
 
-  // Strip user-typed trailing .bmp (any case) and _F — we control both.
+  // Capture the original extension up-front so the rebuilt path keeps it.
+  std::string originalExt = ".bmp";
+  if (selectedFilePath.size() >= 4) {
+    std::string tail = selectedFilePath.substr(selectedFilePath.size() - 4);
+    std::transform(tail.begin(), tail.end(), tail.begin(), ::tolower);
+    if (tail == ".pxc") originalExt = ".pxc";
+  }
+
+  // Strip a user-typed trailing .bmp/.pxc (any case) and _F — we control both.
   if (base.size() >= 4) {
     std::string tail = base.substr(base.size() - 4);
     std::transform(tail.begin(), tail.end(), tail.begin(), ::tolower);
-    if (tail == ".bmp") base = base.substr(0, base.size() - 4);
+    if (tail == ".bmp" || tail == ".pxc") base = base.substr(0, base.size() - 4);
   }
   if (base.size() >= 2 && base.substr(base.size() - 2) == "_F") {
     base = base.substr(0, base.size() - 2);
@@ -561,7 +569,7 @@ void MyLibraryActivity::renameSelectedImage(const std::string& newBase) {
   const bool wasFav = FavoriteImage::isFavoritePath(selectedFilePath);
   const std::string parent = basepath.empty() ? "/" : basepath;
   const std::string parentSlash = (parent.back() == '/') ? parent : parent + "/";
-  const std::string suffix = std::string(wasFav ? "_F" : "") + ".bmp";
+  const std::string suffix = std::string(wasFav ? "_F" : "") + originalExt;
 
   auto buildPath = [&](const std::string& b) { return parentSlash + b + suffix; };
 

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -483,16 +483,16 @@ std::string MyLibraryActivity::getRowTextForListIndex(const size_t listIndex) {
   return rowText;
 }
 
-void MyLibraryActivity::enterBmpView(const std::string& bmpPath) {
+void MyLibraryActivity::enterImageView(const std::string& imagePath) {
   // Stacking toasts for image-open stages. Natural FAST_REFRESH pacing
   // (~400 ms each) keeps each toast visible briefly; no artificial stall.
   // Full refresh on enter scrubs the list ghost.
   if (!TransitionFeedback::isActive()) {
     TransitionFeedback::show(renderer, tr(STR_OPENING_IMAGE));
   }
-  selectedFilePath = bmpPath;
-  mode = Mode::BMP_VIEW;
-  bmpViewFullyLoaded = false;
+  selectedFilePath = imagePath;
+  mode = Mode::IMAGE_VIEW;
+  imageViewFullyLoaded = false;
   TransitionFeedback::show(renderer, tr(STR_LOADING_BITMAP));
   renderer.requestFullRefresh();
   requestCleanRefresh();
@@ -514,7 +514,7 @@ void MyLibraryActivity::enterFileMoveBrowser() {
   mode = Mode::FILE_MOVE_BROWSER;
 }
 
-void MyLibraryActivity::openKeyboardForRenameBmp() {
+void MyLibraryActivity::openKeyboardForRenameImage() {
   if (!isBmpFile(selectedFilePath)) return;
 
   pendingRenameBase.clear();
@@ -529,7 +529,7 @@ void MyLibraryActivity::openKeyboardForRenameBmp() {
       [this]() { pendingRenameCancel = true; }));
 }
 
-void MyLibraryActivity::renameSelectedBmp(const std::string& newBase) {
+void MyLibraryActivity::renameSelectedImage(const std::string& newBase) {
   std::string base = newBase;
   // Trim whitespace.
   while (!base.empty() && (base.front() == ' ' || base.front() == '\t')) base.erase(base.begin());
@@ -566,7 +566,7 @@ void MyLibraryActivity::renameSelectedBmp(const std::string& newBase) {
 
   std::string targetPath = buildPath(base);
   if (targetPath == selectedFilePath) {
-    mode = actionsOpenedFromViewer ? Mode::BMP_VIEW : Mode::FILE_ACTIONS;
+    mode = actionsOpenedFromViewer ? Mode::IMAGE_VIEW : Mode::FILE_ACTIONS;
     requestUpdate();
     return;
   }
@@ -839,8 +839,8 @@ void MyLibraryActivity::loop() {
     loopMessagePopup();
     return;
   }
-  if (mode == Mode::BMP_VIEW) {
-    loopBmpView();
+  if (mode == Mode::IMAGE_VIEW) {
+    loopImageView();
     return;
   }
   if (mode == Mode::FILE_ACTIONS) {
@@ -876,7 +876,7 @@ void MyLibraryActivity::loopSubActivity() {
     pendingRenameBase.clear();
     exitActivity();
     if (shouldApplyRename) {
-      renameSelectedBmp(typed);
+      renameSelectedImage(typed);
     } else {
       requestUpdate();
     }
@@ -898,7 +898,7 @@ void MyLibraryActivity::loopMessagePopup() {
   }
 }
 
-void MyLibraryActivity::loopBmpView() {
+void MyLibraryActivity::loopImageView() {
   if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
     mode = Mode::BROWSE;
     requestCleanRefresh();
@@ -919,7 +919,7 @@ void MyLibraryActivity::loopFileActions() {
   if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
     if (actionsOpenedFromViewer) {
       actionsOpenedFromViewer = false;
-      mode = Mode::BMP_VIEW;
+      mode = Mode::IMAGE_VIEW;
     } else {
       mode = Mode::BROWSE;
     }
@@ -944,7 +944,7 @@ void MyLibraryActivity::loopFileActions() {
       // "Open Image" is hidden and actions start at 0. Shift to a unified
       // action index so the switch below stays simple.
       if (!actionsOpenedFromViewer && fileActionIndex == 0) {
-        mode = Mode::BMP_VIEW;
+        mode = Mode::IMAGE_VIEW;
         requestUpdateAndWait();
         return;
       }
@@ -1003,7 +1003,7 @@ void MyLibraryActivity::loopFileActions() {
           break;
         }
         case 2:
-          openKeyboardForRenameBmp();
+          openKeyboardForRenameImage();
           return;
         case 3:
           actionsOpenedFromViewer = false;
@@ -1075,7 +1075,7 @@ void MyLibraryActivity::loopFileActions() {
           // where the menu came from, otherwise to the file list.
           if (actionsOpenedFromViewer) {
             actionsOpenedFromViewer = false;
-            mode = Mode::BMP_VIEW;
+            mode = Mode::IMAGE_VIEW;
           } else {
             mode = Mode::BROWSE;
           }
@@ -1271,7 +1271,7 @@ void MyLibraryActivity::loopBrowse() {
       requestUpdate();
     } else if (isManagedFile(selectedEntry)) {
       if (isBmpFile(selectedEntry)) {
-        enterBmpView(selectedPath);
+        enterImageView(selectedPath);
       } else {
         onSelectBook(selectedPath);
         return;
@@ -1331,8 +1331,8 @@ void MyLibraryActivity::render(Activity::RenderLock&&) {
   // Reset stacking so render-loop popups start at the top.
   TransitionFeedback::resetStacking();
 
-  if (mode == Mode::BMP_VIEW) {
-    renderBmpView();
+  if (mode == Mode::IMAGE_VIEW) {
+    renderImageView();
     return;
   }
 
@@ -1455,7 +1455,7 @@ void MyLibraryActivity::render(Activity::RenderLock&&) {
   displayFrame();
 }
 
-void MyLibraryActivity::renderBmpView() {
+void MyLibraryActivity::renderImageView() {
   renderer.clearScreen();
 
   FsFile file;
@@ -1501,7 +1501,7 @@ void MyLibraryActivity::renderBmpView() {
   // Post-load render (returning from menu, popup toggle, etc.): draw
   // buttons and refresh fast. Image was already loaded once, so skip the
   // slow HALF_REFRESH + grayscale pipeline.
-  if (bmpViewFullyLoaded) {
+  if (imageViewFullyLoaded) {
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_ACTIONS_BUTTON), "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
     if (messagePopupOpen) {
@@ -1531,7 +1531,7 @@ void MyLibraryActivity::renderBmpView() {
     // the button hints via the fast post-load path.
     gpio.update();
     if (gpio.wasAnyPressed()) {
-      bmpViewFullyLoaded = true;
+      imageViewFullyLoaded = true;
       requestUpdate();
       return;
     }
@@ -1554,7 +1554,7 @@ void MyLibraryActivity::renderBmpView() {
 
   // Image fully loaded — mark so next frame renders button hints via the
   // fast post-load path above.
-  bmpViewFullyLoaded = true;
+  imageViewFullyLoaded = true;
   requestUpdate();
 }
 

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -1583,11 +1583,11 @@ void MyLibraryActivity::renderBmpImageView() {
 }
 
 void MyLibraryActivity::renderPxcImageView() {
-  // Post-load render (returning from menu, popup toggle, etc.): redraw
-  // hints + popup against the saved BW base. The grayscale image is
-  // already on the panel from the initial render and will be left alone
-  // because FAST_REFRESH only drives pixels that differ from the BW
-  // base just stored on first entry.
+  // Post-load render (returning from menu, popup toggle, etc.): rewrite
+  // BW frameBuffer to (white + button hints) and FAST_REFRESH. RED RAM
+  // already holds white from the initial-load cleanup below, so this
+  // FAST pass only drives the hint-region pixels — the grayscale image
+  // is left untouched.
   if (imageViewFullyLoaded) {
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_ACTIONS_BUTTON), "", "");
     renderer.clearScreen();
@@ -1600,27 +1600,22 @@ void MyLibraryActivity::renderPxcImageView() {
     return;
   }
 
-  // Initial PXC viewer load. Mirrors EpubReaderActivity's image-page
-  // pattern: lay down a BW base (white + button hints), HALF_REFRESH it,
-  // then layer the PXC image as a Differential grayscale overlay so the
-  // button hints survive underneath.
+  // Initial PXC viewer load.
+  //
+  // Render strategy:
+  //   1. Factory grayscale push of the PXC. Pre-flashes white and absolutely
+  //      drives a clean 4-level image. Differential mode can't render pure
+  //      black (Black and White both encode as LSB=0,MSB=0 and rely on the
+  //      panel's prior state), so PXC viewer needs Factory.
+  //   2. Reset BW frameBuffer to white and copy that into RED RAM via
+  //      cleanupGrayscaleWithFrameBuffer. After this: BW RAM = factory LSB,
+  //      RED RAM = white, panel = grayscale image.
+  //   3. Draw button hints (and any popup) into BW frameBuffer, FAST_REFRESH.
+  //      Standard fast waveform compares BW (=white+hints) to RED (=white)
+  //      and only drives the hint-region pixels — image area stays as-is.
   renderer.clearScreen();
-  const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_ACTIONS_BUTTON), "", "");
-  GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-  if (messagePopupOpen) {
-    GUI.drawPopup(renderer, messagePopupText.c_str());
-  }
-  renderer.displayBuffer(HalDisplay::HALF_REFRESH);
-  nextRefreshMode = HalDisplay::FAST_REFRESH;
 
-  if (!renderer.storeBwBuffer()) {
-    LOG_ERR("LIB", "PXC viewer: storeBwBuffer failed; skipping grayscale overlay");
-    imageViewFullyLoaded = true;
-    return;
-  }
-
-  if (!PxcRenderer::renderPxc(renderer, selectedFilePath, GfxRenderer::GrayscaleMode::Differential)) {
-    renderer.restoreBwBuffer();
+  if (!PxcRenderer::renderPxc(renderer, selectedFilePath, GfxRenderer::GrayscaleMode::FactoryQuality)) {
     renderer.clearScreen();
     renderer.drawCenteredText(UI_12_FONT_ID, 80, tr(STR_INVALID_BMP));
     const auto errLabels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
@@ -1630,7 +1625,19 @@ void MyLibraryActivity::renderPxcImageView() {
     return;
   }
 
-  renderer.restoreBwBuffer();
+  // Sync BW frameBuffer + RED RAM to white so the upcoming FAST_REFRESH
+  // computes hint-region transitions against a clean baseline and treats
+  // the grayscale image area as "no change".
+  renderer.clearScreen();
+  renderer.cleanupGrayscaleWithFrameBuffer();
+
+  const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_ACTIONS_BUTTON), "", "");
+  GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+  if (messagePopupOpen) {
+    GUI.drawPopup(renderer, messagePopupText.c_str());
+  }
+  renderer.displayBuffer(HalDisplay::FAST_REFRESH);
+  nextRefreshMode = HalDisplay::FAST_REFRESH;
   imageViewFullyLoaded = true;
 }
 

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -1609,12 +1609,16 @@ void MyLibraryActivity::renderPxcImageView() {
     return;
   }
 
+  // PXC is pre-dithered: renderGrayscale() inside PxcRenderer::renderPxc
+  // already pushed the image to the panel via displayGrayBuffer. Here we
+  // only overlay button hints / popup, so FAST_REFRESH (~300 ms) is
+  // sufficient — no need for the legacy BMP HALF_REFRESH (~1.7 s).
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_ACTIONS_BUTTON), "", "");
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
   if (messagePopupOpen) {
     GUI.drawPopup(renderer, messagePopupText.c_str());
   }
-  renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+  renderer.displayBuffer(HalDisplay::FAST_REFRESH);
   nextRefreshMode = HalDisplay::FAST_REFRESH;
   imageViewFullyLoaded = true;
 }

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -29,7 +29,7 @@
 #include "fontIds.h"
 #include "persist/Trash.h"
 #include "util/BookProgress.h"
-#include "util/FavoriteBmp.h"
+#include "util/FavoriteImage.h"
 #include "util/StatusPopup.h"
 #include "util/StringUtils.h"
 #include "util/TransitionFeedback.h"
@@ -438,7 +438,7 @@ std::string MyLibraryActivity::getDisplayNameForRawFile(const size_t rawIndex) {
   }
 
   if (isBmpFile(name)) {
-    return FavoriteBmp::displayNameForPath(makeAbsolutePath(name));
+    return FavoriteImage::displayNameForPath(makeAbsolutePath(name));
   }
 
   if (!isBookFile(name)) {
@@ -557,7 +557,7 @@ void MyLibraryActivity::renameSelectedBmp(const std::string& newBase) {
     }
   }
 
-  const bool wasFav = FavoriteBmp::isFavoritePath(selectedFilePath);
+  const bool wasFav = FavoriteImage::isFavoritePath(selectedFilePath);
   const std::string parent = basepath.empty() ? "/" : basepath;
   const std::string parentSlash = (parent.back() == '/') ? parent : parent + "/";
   const std::string suffix = std::string(wasFav ? "_F" : "") + ".bmp";
@@ -594,7 +594,7 @@ void MyLibraryActivity::renameSelectedBmp(const std::string& newBase) {
     return;
   }
 
-  FavoriteBmp::replacePathReferences(selectedFilePath, targetPath);
+  FavoriteImage::replacePathReferences(selectedFilePath, targetPath);
   APP_STATE.saveToFile();
 
   const std::string newName = getBasename(targetPath);
@@ -630,7 +630,7 @@ std::string MyLibraryActivity::getFileActionLabel(const int index) const {
       case 0:
         return tr(STR_MOVE_TO_SLEEP_ACTION);
       case 1:
-        return FavoriteBmp::isFavoritePath(selectedFilePath) ? tr(STR_UNFAVORITE) : tr(STR_FAVORITE);
+        return FavoriteImage::isFavoritePath(selectedFilePath) ? tr(STR_UNFAVORITE) : tr(STR_FAVORITE);
       case 2:
         return tr(STR_RENAME_ACTION);
       case 3:
@@ -716,7 +716,7 @@ bool MyLibraryActivity::moveSelectedFileTo(const std::string& targetDir, std::st
   std::string normalizedTarget = targetDir;
   if (normalizedTarget.empty()) normalizedTarget = "/";
   if (normalizedTarget.back() != '/') normalizedTarget += "/";
-  if (normalizedTarget == "/sleep/" && !FavoriteBmp::canPlacePathInSleep(selectedFilePath)) {
+  if (normalizedTarget == "/sleep/" && !FavoriteImage::canPlacePathInSleep(selectedFilePath)) {
     return false;
   }
 
@@ -763,7 +763,7 @@ bool MyLibraryActivity::moveSelectedFileTo(const std::string& targetDir, std::st
     }
     RECENT_BOOKS.removeBook(selectedFilePath);
   } else if (isBmpFile(selectedFilePath)) {
-    FavoriteBmp::replacePathReferences(selectedFilePath, destination);
+    FavoriteImage::replacePathReferences(selectedFilePath, destination);
     APP_STATE.saveToFile();
   }
   if (destinationPath != nullptr) {
@@ -791,7 +791,7 @@ bool MyLibraryActivity::deleteFile(const std::string& path) {
   }
 
   if (isBmpFile(path)) {
-    FavoriteBmp::removePathReferences(path);
+    FavoriteImage::removePathReferences(path);
     APP_STATE.saveToFile();
   }
   if (selectedFilePath == path) selectedFilePath.clear();
@@ -951,8 +951,8 @@ void MyLibraryActivity::loopFileActions() {
       const int actionIndex = fileActionIndex - (actionsOpenedFromViewer ? 0 : 1);
       switch (actionIndex) {
         case 0: {
-          if (!FavoriteBmp::canPlacePathInSleep(selectedFilePath)) {
-            showMessagePopup(FavoriteBmp::limitReachedPopupMessage());
+          if (!FavoriteImage::canPlacePathInSleep(selectedFilePath)) {
+            showMessagePopup(FavoriteImage::limitReachedPopupMessage());
             return;
           }
           StatusPopup::showBlocking(renderer, tr(STR_MOVING_TO_SLEEP));
@@ -972,11 +972,11 @@ void MyLibraryActivity::loopFileActions() {
           break;
         }
         case 1: {
-          const bool makeFavorite = !FavoriteBmp::isFavoritePath(selectedFilePath);
+          const bool makeFavorite = !FavoriteImage::isFavoritePath(selectedFilePath);
           StatusPopup::showBlocking(renderer, makeFavorite ? tr(STR_FAVORITING) : tr(STR_UNFAVORITING));
           std::string updatedPath;
-          const auto result = FavoriteBmp::setFavorite(selectedFilePath, makeFavorite, &updatedPath);
-          if (result == FavoriteBmp::SetFavoriteResult::Success) {
+          const auto result = FavoriteImage::setFavorite(selectedFilePath, makeFavorite, &updatedPath);
+          if (result == FavoriteImage::SetFavoriteResult::Success) {
             const std::string newName = getBasename(updatedPath);
             if (const auto rawIndex = rawFileIndexForPath(selectedFilePath); rawIndex.has_value()) {
               files[*rawIndex] = newName;
@@ -986,13 +986,13 @@ void MyLibraryActivity::loopFileActions() {
             }
             selectedFilePath = updatedPath;
             StatusPopup::showConfirmation(renderer, makeFavorite ? tr(STR_FAVORITED) : tr(STR_UNFAVORITED));
-          } else if (result == FavoriteBmp::SetFavoriteResult::LimitReached) {
-            showMessagePopup(FavoriteBmp::limitReachedPopupMessage());
+          } else if (result == FavoriteImage::SetFavoriteResult::LimitReached) {
+            showMessagePopup(FavoriteImage::limitReachedPopupMessage());
             return;
-          } else if (result == FavoriteBmp::SetFavoriteResult::RenameConflict) {
+          } else if (result == FavoriteImage::SetFavoriteResult::RenameConflict) {
             showMessagePopup(tr(STR_FAVORITE_NAME_EXISTS));
             return;
-          } else if (result == FavoriteBmp::SetFavoriteResult::RenameFailed) {
+          } else if (result == FavoriteImage::SetFavoriteResult::RenameFailed) {
             showMessagePopup(tr(STR_FAILED_RENAME_IMAGE));
             return;
           } else {
@@ -1179,8 +1179,8 @@ void MyLibraryActivity::loopFileMoveBrowser() {
 
   if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     const auto& entry = moveBrowseEntries[fileMoveIndex];
-    if (entry.path == "/sleep" && !FavoriteBmp::canPlacePathInSleep(selectedFilePath)) {
-      showMessagePopup(FavoriteBmp::limitReachedPopupMessage());
+    if (entry.path == "/sleep" && !FavoriteImage::canPlacePathInSleep(selectedFilePath)) {
+      showMessagePopup(FavoriteImage::limitReachedPopupMessage());
       return;
     }
     StatusPopup::showBlocking(renderer, tr(STR_MOVING_FILE));

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -1583,11 +1583,14 @@ void MyLibraryActivity::renderBmpImageView() {
 }
 
 void MyLibraryActivity::renderPxcImageView() {
-  // Post-load render (returning from menu, popup toggle, etc.): draw
-  // buttons and refresh fast. Image was already streamed once, so skip the
-  // slow HALF_REFRESH + full PXC decode pipeline.
+  // Post-load render (returning from menu, popup toggle, etc.): redraw
+  // hints + popup against the saved BW base. The grayscale image is
+  // already on the panel from the initial render and will be left alone
+  // because FAST_REFRESH only drives pixels that differ from the BW
+  // base just stored on first entry.
   if (imageViewFullyLoaded) {
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_ACTIONS_BUTTON), "", "");
+    renderer.clearScreen();
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
     if (messagePopupOpen) {
       GUI.drawPopup(renderer, messagePopupText.c_str());
@@ -1597,21 +1600,11 @@ void MyLibraryActivity::renderPxcImageView() {
     return;
   }
 
+  // Initial PXC viewer load. Mirrors EpubReaderActivity's image-page
+  // pattern: lay down a BW base (white + button hints), HALF_REFRESH it,
+  // then layer the PXC image as a Differential grayscale overlay so the
+  // button hints survive underneath.
   renderer.clearScreen();
-
-  if (!PxcRenderer::renderPxc(renderer, selectedFilePath)) {
-    renderer.drawCenteredText(UI_12_FONT_ID, 80, tr(STR_INVALID_BMP));
-    const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
-    GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-    displayFrame();
-    imageViewFullyLoaded = true;
-    return;
-  }
-
-  // HALF_REFRESH required to overlay BW button hints cleanly on top of the
-  // grayscale image just pushed by renderGrayscale. FAST_REFRESH inverts
-  // the panel because the BW buffer state diverges from the grayscale
-  // composite the panel currently shows.
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_ACTIONS_BUTTON), "", "");
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
   if (messagePopupOpen) {
@@ -1619,6 +1612,25 @@ void MyLibraryActivity::renderPxcImageView() {
   }
   renderer.displayBuffer(HalDisplay::HALF_REFRESH);
   nextRefreshMode = HalDisplay::FAST_REFRESH;
+
+  if (!renderer.storeBwBuffer()) {
+    LOG_ERR("LIB", "PXC viewer: storeBwBuffer failed; skipping grayscale overlay");
+    imageViewFullyLoaded = true;
+    return;
+  }
+
+  if (!PxcRenderer::renderPxc(renderer, selectedFilePath, GfxRenderer::GrayscaleMode::Differential)) {
+    renderer.restoreBwBuffer();
+    renderer.clearScreen();
+    renderer.drawCenteredText(UI_12_FONT_ID, 80, tr(STR_INVALID_BMP));
+    const auto errLabels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
+    GUI.drawButtonHints(renderer, errLabels.btn1, errLabels.btn2, errLabels.btn3, errLabels.btn4);
+    displayFrame();
+    imageViewFullyLoaded = true;
+    return;
+  }
+
+  renderer.restoreBwBuffer();
   imageViewFullyLoaded = true;
 }
 

--- a/src/activities/home/MyLibraryActivity.h
+++ b/src/activities/home/MyLibraryActivity.h
@@ -29,7 +29,7 @@ class MyLibraryActivity final : public ActivityWithSubactivity {
     bool isMoveHere = false;
   };
 
-  enum class Mode { BROWSE, BMP_VIEW, FILE_ACTIONS, FILE_MOVE_BROWSER };
+  enum class Mode { BROWSE, IMAGE_VIEW, FILE_ACTIONS, FILE_MOVE_BROWSER };
 
   ButtonNavigator buttonNavigator;
 
@@ -43,13 +43,13 @@ class MyLibraryActivity final : public ActivityWithSubactivity {
   std::string messagePopupText;
   std::vector<MoveBrowseEntry> moveBrowseEntries;
   HalDisplay::RefreshMode nextRefreshMode = HalDisplay::FAST_REFRESH;
-  // True when FILE_ACTIONS was entered from BMP_VIEW (tap Actions in viewer).
+  // True when FILE_ACTIONS was entered from IMAGE_VIEW (tap Actions in viewer).
   // Controls menu layout (no "Open Image") and back-destination (returns to viewer).
   bool actionsOpenedFromViewer = false;
   // False until the initial BW + grayscale render of the current image has
-  // completed. While false, renderBmpView hides the bottom button hints so
+  // completed. While false, renderImageView hides the bottom button hints so
   // the user doesn't try to press buttons that aren't yet responsive.
-  bool bmpViewFullyLoaded = false;
+  bool imageViewFullyLoaded = false;
 
   // Files state
   std::string basepath = "/";
@@ -99,11 +99,11 @@ class MyLibraryActivity final : public ActivityWithSubactivity {
   static bool isPxcFile(const std::string& filename);
   static bool isImageFile(const std::string& filename);
   static bool isManagedFile(const std::string& filename);
-  void enterBmpView(const std::string& bmpPath);
+  void enterImageView(const std::string& imagePath);
   void enterFileActions(const std::string& filePath);
   void enterFileMoveBrowser();
-  void openKeyboardForRenameBmp();
-  void renameSelectedBmp(const std::string& newBase);
+  void openKeyboardForRenameImage();
+  void renameSelectedImage(const std::string& newBase);
   void loadMoveBrowseEntries();
   int getFileActionCount() const;
   std::string getFileActionLabel(int index) const;
@@ -115,12 +115,12 @@ class MyLibraryActivity final : public ActivityWithSubactivity {
   void requestCleanRefresh();
   void loopSubActivity();
   void loopMessagePopup();
-  void loopBmpView();
+  void loopImageView();
   void loopFileActions();
   void loopFileMoveBrowser();
   void loopBrowse();
   void displayFrame();
-  void renderBmpView();
+  void renderImageView();
   void renderFileActions();
   void renderFileMoveBrowser();
   size_t findEntry(const std::string& name) const;

--- a/src/activities/home/MyLibraryActivity.h
+++ b/src/activities/home/MyLibraryActivity.h
@@ -99,6 +99,7 @@ class MyLibraryActivity final : public ActivityWithSubactivity {
   static bool isPxcFile(const std::string& filename);
   static bool isImageFile(const std::string& filename);
   static bool isManagedFile(const std::string& filename);
+  static void filterEpubCachePxc(std::vector<std::string>& files);
   void enterImageView(const std::string& imagePath);
   void enterFileActions(const std::string& filePath);
   void enterFileMoveBrowser();

--- a/src/activities/home/MyLibraryActivity.h
+++ b/src/activities/home/MyLibraryActivity.h
@@ -96,6 +96,8 @@ class MyLibraryActivity final : public ActivityWithSubactivity {
   static std::string getBasename(const std::string& path);
   static bool isBookFile(const std::string& filename);
   static bool isBmpFile(const std::string& filename);
+  static bool isPxcFile(const std::string& filename);
+  static bool isImageFile(const std::string& filename);
   static bool isManagedFile(const std::string& filename);
   void enterBmpView(const std::string& bmpPath);
   void enterFileActions(const std::string& filePath);

--- a/src/activities/home/MyLibraryActivity.h
+++ b/src/activities/home/MyLibraryActivity.h
@@ -121,6 +121,8 @@ class MyLibraryActivity final : public ActivityWithSubactivity {
   void loopBrowse();
   void displayFrame();
   void renderImageView();
+  void renderBmpImageView();
+  void renderPxcImageView();
   void renderFileActions();
   void renderFileMoveBrowser();
   size_t findEntry(const std::string& name) const;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -38,7 +38,7 @@
 #include "fonts/CustomBinFontManager.h"
 #include "persist/BackupMirror.h"
 #include "util/DrawUtils.h"
-#include "util/FavoriteBmp.h"
+#include "util/FavoriteImage.h"
 #include "util/StatusPopup.h"
 #include "util/TransitionFeedback.h"
 
@@ -1134,13 +1134,13 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       const std::string lastPath = APP_STATE.lastSleepWallpaperPath;
       if (lastPath.empty()) break;
       std::string updatedPath;
-      const bool makeFavorite = !FavoriteBmp::isFavoritePath(lastPath);
-      const auto result = FavoriteBmp::setFavorite(lastPath, makeFavorite, &updatedPath);
-      if (result == FavoriteBmp::SetFavoriteResult::LimitReached) {
-        StatusPopup::showConfirmation(renderer, FavoriteBmp::limitReachedPopupMessage());
-      } else if (result == FavoriteBmp::SetFavoriteResult::RenameConflict) {
+      const bool makeFavorite = !FavoriteImage::isFavoritePath(lastPath);
+      const auto result = FavoriteImage::setFavorite(lastPath, makeFavorite, &updatedPath);
+      if (result == FavoriteImage::SetFavoriteResult::LimitReached) {
+        StatusPopup::showConfirmation(renderer, FavoriteImage::limitReachedPopupMessage());
+      } else if (result == FavoriteImage::SetFavoriteResult::RenameConflict) {
         StatusPopup::showConfirmation(renderer, tr(STR_FAVORITE_NAME_EXISTS));
-      } else if (result != FavoriteBmp::SetFavoriteResult::Success) {
+      } else if (result != FavoriteImage::SetFavoriteResult::Success) {
         StatusPopup::showConfirmation(renderer, tr(STR_FAVORITE_FAILED));
       } else {
         StatusPopup::showConfirmation(renderer, makeFavorite ? tr(STR_FAVORITED) : tr(STR_UNFAVORITED));
@@ -1194,7 +1194,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
         dst.close();
         if (ok) {
           Storage.remove(lastPath.c_str());
-          FavoriteBmp::replacePathReferences(lastPath, dstPath);
+          FavoriteImage::replacePathReferences(lastPath, dstPath);
           APP_STATE.wallpaperRotationPaused = false;
           APP_STATE.saveToFile();
         } else {
@@ -1216,7 +1216,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       if (lastPath.empty()) break;
       const bool removed = Storage.remove(lastPath.c_str());
       if (removed) {
-        FavoriteBmp::removePathReferences(lastPath);
+        FavoriteImage::removePathReferences(lastPath);
         APP_STATE.wallpaperRotationPaused = false;
         APP_STATE.saveToFile();
       }

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -12,7 +12,7 @@
 #include "RecentBooksStore.h"
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"
-#include "util/FavoriteBmp.h"
+#include "util/FavoriteImage.h"
 
 EpubReaderMenuActivity::EpubReaderMenuActivity(
     GfxRenderer& renderer, MappedInputManager& mappedInput, const std::string& title, const std::string& bookPath,
@@ -62,7 +62,7 @@ std::vector<EpubReaderMenuActivity::MenuItem> EpubReaderMenuActivity::buildMenuI
   const std::string& wallpaperPath = APP_STATE.lastSleepWallpaperPath;
   if (!wallpaperPath.empty() && Storage.exists(wallpaperPath.c_str())) {
     items.push_back({MenuAction::NONE, StrId::STR_WALLPAPER_TRIAGE, nullptr, true});
-    const bool isFav = FavoriteBmp::isFavoritePath(wallpaperPath);
+    const bool isFav = FavoriteImage::isFavoritePath(wallpaperPath);
     items.push_back({MenuAction::TRIAGE_FAVORITE, isFav ? StrId::STR_UNFAVORITE : StrId::STR_FAVORITE});
     items.push_back({MenuAction::TRIAGE_PAUSE_ROTATION,
                      APP_STATE.wallpaperRotationPaused ? StrId::STR_TRIAGE_UNPAUSE : StrId::STR_TRIAGE_PAUSE});

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -95,7 +95,13 @@ bool isBookFile(const char* name) {
          endsWithIgnoreCase(name, ".txt") || endsWithIgnoreCase(name, ".md");
 }
 
-bool isBmpFile(const char* name) { return endsWithIgnoreCase(name, ".bmp"); }
+bool isImageFile(const char* name) {
+  return endsWithIgnoreCase(name, ".bmp") || endsWithIgnoreCase(name, ".pxc");
+}
+
+bool isFavoriteImageFile(const char* name) {
+  return endsWithIgnoreCase(name, "_F.bmp") || endsWithIgnoreCase(name, "_F.pxc");
+}
 
 // Iterative directory scan — avoids deep recursion on ESP32 stack.
 // Feeds watchdog every 32 entries to prevent WDT reset on large SD cards.
@@ -128,7 +134,7 @@ void countFilesIterative(FsFile& root, uint32_t& bookCount, uint32_t& bmpCount, 
     if (countBooks && isBookFile(name)) {
       ++bookCount;
     }
-    if (countBmps && isBmpFile(name)) {
+    if (countBmps && isImageFile(name)) {
       ++bmpCount;
     }
     entry.close();
@@ -139,8 +145,8 @@ void countFilesIterative(FsFile& root, uint32_t& bookCount, uint32_t& bmpCount, 
   }
 }
 
-// Flat scan of a single directory (no recursion). Counts BMP files only.
-uint32_t countBmpsInDir(const char* path) {
+// Flat scan of a single directory (no recursion). Counts BMP and PXC files.
+uint32_t countImagesInDir(const char* path) {
   auto dir = Storage.open(path);
   if (!dir || !dir.isDirectory()) return 0;
 
@@ -149,7 +155,7 @@ uint32_t countBmpsInDir(const char* path) {
   char name[256];
   for (auto entry = dir.openNextFile(); entry; entry = dir.openNextFile()) {
     entry.getName(name, sizeof(name));
-    if (!entry.isDirectory() && isBmpFile(name)) {
+    if (!entry.isDirectory() && isImageFile(name)) {
       ++count;
     }
     entry.close();
@@ -282,7 +288,7 @@ void drawMoreIndicator(const GfxRenderer& renderer, int count, StrId formatKey, 
 
 struct HomeInfoStats {
   uint32_t bookCount = 0;
-  uint32_t sleepBmpCount = 0;
+  uint32_t sleepImageCount = 0;
   uint32_t sleepFavoriteCount = 0;
   uint32_t sleepPauseCount = 0;
   uint64_t freeBytes = 0;
@@ -294,7 +300,7 @@ HomeInfoStats gHomeInfoStats;
 
 void scanHomeInfoStats(HomeInfoStats& stats) {
   stats.bookCount = 0;
-  stats.sleepBmpCount = 0;
+  stats.sleepImageCount = 0;
   stats.sleepFavoriteCount = 0;
   stats.sleepPauseCount = 0;
   stats.freeBytes = Storage.freeBytes();
@@ -303,12 +309,12 @@ void scanHomeInfoStats(HomeInfoStats& stats) {
   // Count books recursively from root (skip hidden dirs)
   auto root = Storage.open("/");
   if (root && root.isDirectory()) {
-    countFilesIterative(root, stats.bookCount, stats.sleepBmpCount, true, false);
+    countFilesIterative(root, stats.bookCount, stats.sleepImageCount, true, false);
     // root closed by countFilesIterative
   }
 
-  // Count sleep BMPs + favorites in /sleep (flat scan).
-  // Favorite detection uses suffix-only check ("_F.bmp") — zero heap allocations.
+  // Count sleep images (BMP + PXC) + favorites in /sleep (flat scan).
+  // Favorite detection uses suffix-only check ("_F.bmp" / "_F.pxc") — zero heap allocations.
   {
     auto dir = Storage.open("/sleep");
     if (dir && dir.isDirectory()) {
@@ -316,9 +322,9 @@ void scanHomeInfoStats(HomeInfoStats& stats) {
       char name[256];
       for (auto entry = dir.openNextFile(); entry; entry = dir.openNextFile()) {
         entry.getName(name, sizeof(name));
-        if (!entry.isDirectory() && isBmpFile(name)) {
-          ++stats.sleepBmpCount;
-          if (endsWithIgnoreCase(name, "_F.bmp")) {
+        if (!entry.isDirectory() && isImageFile(name)) {
+          ++stats.sleepImageCount;
+          if (isFavoriteImageFile(name)) {
             ++stats.sleepFavoriteCount;
           }
         }
@@ -331,8 +337,8 @@ void scanHomeInfoStats(HomeInfoStats& stats) {
     }
   }
 
-  // Count BMPs in /sleep pause
-  stats.sleepPauseCount = countBmpsInDir("/sleep pause");
+  // Count images in /sleep pause (BMP + PXC)
+  stats.sleepPauseCount = countImagesInDir("/sleep pause");
 
   stats.valid = true;
 }
@@ -446,7 +452,7 @@ void BaseTheme::refreshHomeInfoStats() {
 uint64_t BaseTheme::homeInfoStatsSignature() {
   const auto& stats = getHomeInfoStats();
   // Compact signature from the three displayed values.
-  return (static_cast<uint64_t>(stats.bookCount) << 40) ^ (static_cast<uint64_t>(stats.sleepBmpCount) << 24) ^
+  return (static_cast<uint64_t>(stats.bookCount) << 40) ^ (static_cast<uint64_t>(stats.sleepImageCount) << 24) ^
          stats.freeBytes;
 }
 
@@ -1134,7 +1140,7 @@ void BaseTheme::drawHomeInfoStatsPopup(const GfxRenderer& renderer) const {
   // Content block.
   drawRow(y, "Books", std::to_string(stats.bookCount));
   y += lineStep;
-  drawRow(y, "Sleep images", std::to_string(stats.sleepBmpCount));
+  drawRow(y, "Sleep images", std::to_string(stats.sleepImageCount));
   y += lineStep;
   drawRow(y, "Sleep favorites", std::to_string(stats.sleepFavoriteCount));
   y += lineStep;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,7 +65,7 @@
 #include "sleep/WallpaperPlaylistV2.h"
 #endif
 #include "util/ButtonNavigator.h"
-#include "util/FavoriteBmp.h"
+#include "util/FavoriteImage.h"
 #include "util/TransitionFeedback.h"
 
 HalDisplay display;
@@ -334,9 +334,9 @@ static void wireWallpaperPlaylist() {
     return ok;
   };
   deps.randomFn = [](long mod) -> long { return ::random(mod); };
-  deps.isFavorite = [](const std::string& path) { return FavoriteBmp::isFavoritePath(path); };
+  deps.isFavorite = [](const std::string& path) { return FavoriteImage::isFavoritePath(path); };
   deps.onPathRenamed = [](const std::string& from, const std::string& to) {
-    FavoriteBmp::replacePathReferences(from, to);
+    FavoriteImage::replacePathReferences(from, to);
   };
   deps.onBeforeTrimMove = []() {};  // no popup in current call sites
   crosspoint::sleep::WallpaperPlaylist::instance().setDeps(deps);
@@ -358,9 +358,9 @@ static void wireWallpaperPlaylist() {
     return ok;
   };
   v2deps.randomFn = [](long mod) -> long { return ::random(mod); };
-  v2deps.isFavorite = [](const std::string& path) { return FavoriteBmp::isFavoritePath(path); };
+  v2deps.isFavorite = [](const std::string& path) { return FavoriteImage::isFavoritePath(path); };
   v2deps.onPathRenamed = [](const std::string& from, const std::string& to) {
-    FavoriteBmp::replacePathReferences(from, to);
+    FavoriteImage::replacePathReferences(from, to);
   };
   // PR2: wire to APP_STATE notification flags consumed by HomeActivity.
   v2deps.onTrimMoved = [](uint16_t /*moved*/) {};

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -828,35 +828,25 @@ void CrossPointWebServer::handleFileListData() const {
     }
   }
 
-  // Collect all entries first so we can apply the EPUB-cache PXC filter
-  // before serialization. The filter removes *_q.pxc cache files and
-  // <base>.pxc when a source image sibling (.jpg/.png/etc.) is present.
-  std::vector<FileInfo> entries;
-  scanFiles(currentPath.c_str(), [&entries](const FileInfo& info) {
-    entries.push_back(info);
+  // Pass 1: collect file basenames only (no full FileInfo heap cost) so we can
+  // run the EPUB-cache PXC filter. For a 1000-file /sleep folder this is ~32 KB
+  // of small strings — well within budget. The full vector<FileInfo> approach
+  // of commit 50f2b01 peaked ~150 KB transient, exceeding the ~54 KB free heap.
+  std::vector<std::string> names;
+  scanFiles(currentPath.c_str(), [&names](const FileInfo& info) {
+    if (!info.isDirectory) names.push_back(info.name.c_str());
   });
 
-  // Build flat name list (file entries only), run filter, then rebuild a
-  // fast-lookup set of surviving names (Option A from task spec).
-  {
-    std::vector<std::string> names;
-    names.reserve(entries.size());
-    for (const auto& e : entries) {
-      if (!e.isDirectory) names.push_back(e.name.c_str());
-    }
-    LibraryListingFilter::filterEpubCachePxc(names);
-    // Reconstruct as unordered_set for O(1) lookup during serialization.
-    std::unordered_set<std::string> surviving(names.begin(), names.end());
-    // Erase file entries that didn't survive the filter; keep directories.
-    entries.erase(
-        std::remove_if(entries.begin(), entries.end(),
-                       [&surviving](const FileInfo& e) {
-                         return !e.isDirectory &&
-                                surviving.find(e.name.c_str()) == surviving.end();
-                       }),
-        entries.end());
-  }
+  LibraryListingFilter::filterEpubCachePxc(names);
 
+  // Move survivors into a hash set for O(1) lookup; release the names vector
+  // before pass 2 so only the set is live during JSON streaming.
+  std::unordered_set<std::string> surviving(names.begin(), names.end());
+  std::vector<std::string>().swap(names);
+
+  // Pass 2: stream JSON directly from a second scanFiles pass — one FileInfo
+  // on the stack at a time. Directories always pass through (they are not
+  // subject to the EPUB-cache filter).
   server->setContentLength(CONTENT_LENGTH_UNKNOWN);
   server->send(200, "application/json", "");
   server->sendContent("[");
@@ -870,7 +860,12 @@ void CrossPointWebServer::handleFileListData() const {
   batch.reserve(3072);
   constexpr size_t kFlushAt = 2048;
 
-  for (const auto& info : entries) {
+  scanFiles(currentPath.c_str(), [this, &output, &doc, &seenFirst, &batch, &surviving](const FileInfo& info) {
+    // Skip file entries that didn't survive the filter; always emit directories.
+    if (!info.isDirectory && surviving.find(info.name.c_str()) == surviving.end()) {
+      return;
+    }
+
     doc.clear();
     doc["name"] = info.name;
     doc["size"] = info.size;
@@ -883,7 +878,7 @@ void CrossPointWebServer::handleFileListData() const {
     if (written >= outputSize) {
       // JSON output truncated; skip this entry to avoid sending malformed JSON
       LOG_DBG("WEB", "Skipping file entry with oversized JSON for name: %s", info.name.c_str());
-      continue;
+      return;
     }
 
     if (seenFirst) {
@@ -898,7 +893,7 @@ void CrossPointWebServer::handleFileListData() const {
       batch = "";
       batch.reserve(3072);
     }
-  }
+  });
 
   if (batch.length()) server->sendContent(batch);
   server->sendContent("]");

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <functional>
 #include <memory>
+#include <unordered_set>
 #include <utility>
 
 #include "CrossPointSettings.h"
@@ -25,6 +26,7 @@
 #include "RecentBooksStore.h"
 #include "SettingsList.h"
 #include "fonts/CustomBinFontManager.h"
+#include "../activities/home/LibraryListingFilter.h"
 #if __has_include("WebDAVHandler.h")
 #include "WebDAVHandler.h"
 #define CROSSPOINT_HAS_WEBDAV 1
@@ -771,10 +773,12 @@ void CrossPointWebServer::scanFiles(const char* path, const std::function<void(F
         info.size = 0;
         info.isEpub = false;
         info.isBmp = false;
+        info.isPxc = false;
       } else {
         info.size = file.size();
         info.isEpub = hasExtCI(name, nameLen, ".epub", 5);
         info.isBmp = hasExtCI(name, nameLen, ".bmp", 4);
+        info.isPxc = hasExtCI(name, nameLen, ".pxc", 4);
       }
 
       callback(info);
@@ -800,6 +804,10 @@ bool CrossPointWebServer::isBmpFile(const String& filename) const {
   return hasExtCI(filename.c_str(), filename.length(), ".bmp", 4);
 }
 
+bool CrossPointWebServer::isPxcFile(const String& filename) const {
+  return hasExtCI(filename.c_str(), filename.length(), ".pxc", 4);
+}
+
 void CrossPointWebServer::handleFileList() const {
   sendHtmlContent(server.get(), FilesPageHtml, sizeof(FilesPageHtml));
 }
@@ -820,6 +828,35 @@ void CrossPointWebServer::handleFileListData() const {
     }
   }
 
+  // Collect all entries first so we can apply the EPUB-cache PXC filter
+  // before serialization. The filter removes *_q.pxc cache files and
+  // <base>.pxc when a source image sibling (.jpg/.png/etc.) is present.
+  std::vector<FileInfo> entries;
+  scanFiles(currentPath.c_str(), [&entries](const FileInfo& info) {
+    entries.push_back(info);
+  });
+
+  // Build flat name list (file entries only), run filter, then rebuild a
+  // fast-lookup set of surviving names (Option A from task spec).
+  {
+    std::vector<std::string> names;
+    names.reserve(entries.size());
+    for (const auto& e : entries) {
+      if (!e.isDirectory) names.push_back(e.name.c_str());
+    }
+    LibraryListingFilter::filterEpubCachePxc(names);
+    // Reconstruct as unordered_set for O(1) lookup during serialization.
+    std::unordered_set<std::string> surviving(names.begin(), names.end());
+    // Erase file entries that didn't survive the filter; keep directories.
+    entries.erase(
+        std::remove_if(entries.begin(), entries.end(),
+                       [&surviving](const FileInfo& e) {
+                         return !e.isDirectory &&
+                                surviving.find(e.name.c_str()) == surviving.end();
+                       }),
+        entries.end());
+  }
+
   server->setContentLength(CONTENT_LENGTH_UNKNOWN);
   server->send(200, "application/json", "");
   server->sendContent("[");
@@ -833,19 +870,20 @@ void CrossPointWebServer::handleFileListData() const {
   batch.reserve(3072);
   constexpr size_t kFlushAt = 2048;
 
-  scanFiles(currentPath.c_str(), [this, &output, &doc, &seenFirst, &batch](const FileInfo& info) {
+  for (const auto& info : entries) {
     doc.clear();
     doc["name"] = info.name;
     doc["size"] = info.size;
     doc["isDirectory"] = info.isDirectory;
     doc["isEpub"] = info.isEpub;
     doc["isBmp"] = info.isBmp;
+    doc["isPxc"] = info.isPxc;
 
     const size_t written = serializeJson(doc, output, outputSize);
     if (written >= outputSize) {
       // JSON output truncated; skip this entry to avoid sending malformed JSON
       LOG_DBG("WEB", "Skipping file entry with oversized JSON for name: %s", info.name.c_str());
-      return;
+      continue;
     }
 
     if (seenFirst) {
@@ -860,7 +898,7 @@ void CrossPointWebServer::handleFileListData() const {
       batch = "";
       batch.reserve(3072);
     }
-  });
+  }
 
   if (batch.length()) server->sendContent(batch);
   server->sendContent("]");

--- a/src/network/CrossPointWebServer.h
+++ b/src/network/CrossPointWebServer.h
@@ -27,6 +27,7 @@ struct FileInfo {
   size_t size;
   bool isEpub;
   bool isBmp;
+  bool isPxc;
   bool isDirectory;
 };
 
@@ -105,6 +106,7 @@ class CrossPointWebServer {
   String formatFileSize(size_t bytes) const;
   bool isEpubFile(const String& filename) const;
   bool isBmpFile(const String& filename) const;
+  bool isPxcFile(const String& filename) const;
 
   // Request handlers
   void handleRoot() const;

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -257,6 +257,21 @@
       font-size: 0.75em;
       margin-left: 8px;
     }
+    .pxc-file {
+      background-color: #f5f0e8 !important;
+    }
+    .pxc-file:hover {
+      background-color: #ede3d0 !important;
+    }
+    .pxc-badge {
+      display: inline-block;
+      padding: 2px 8px;
+      background-color: #d97706;
+      color: white;
+      border-radius: 10px;
+      font-size: 0.75em;
+      margin-left: 8px;
+    }
     .folder-badge {
       display: inline-block;
       padding: 2px 8px;
@@ -1203,6 +1218,7 @@
       }
       .epub-badge,
       .bmp-badge,
+      .pxc-badge,
       .folder-badge,
       .quotes-badge {
         padding: 2px 5px;
@@ -1568,7 +1584,8 @@
        !important, which read as a giant white block on the dark page. */
     #folderContentsCard .folder-row,
     #folderContentsCard .epub-file,
-    #folderContentsCard .bmp-file {
+    #folderContentsCard .bmp-file,
+    #folderContentsCard .pxc-file {
       background: transparent !important;
     }
     #folderContentsCard .folder-row:hover {
@@ -1579,6 +1596,9 @@
     }
     #folderContentsCard .bmp-file:hover {
       background: rgba(77, 192, 255, 0.06) !important;
+    }
+    #folderContentsCard .pxc-file:hover {
+      background: rgba(217, 119, 6, 0.06) !important;
     }
     #folderContentsCard .folder-link,
     #folderContentsCard .file-link {
@@ -2597,7 +2617,9 @@
           filePath += file.name;
 
           // Checkbox cell + file row
-          const rowClass = file.isEpub ? 'epub-file' : (file.isBmp ? 'bmp-file' : '');
+          const rowClass = file.isEpub
+              ? 'epub-file'
+              : (file.isBmp ? 'bmp-file' : (file.isPxc ? 'pxc-file' : ''));
           fileTableContent += `<tr class="${rowClass}">`;
           fileTableContent += `<td><input type="checkbox" class="select-item" data-path="${encodeURIComponent(filePath)}" data-name="${escapeHtml(file.name)}" data-type="file"></td>`;
           if (file.isBmp) {
@@ -2605,9 +2627,10 @@
             fileTableContent += `<a href="#" onclick="openImagePreview('${filePath.replaceAll("'", "\\'")}', '${file.name.replaceAll("'", "\\'")}', ${file.size});return false;" class="file-link">${escapeHtml(file.name)}</a>`;
             fileTableContent += '<span class="bmp-badge">BMP</span>';
           } else {
-            fileTableContent += `<td><span class="file-icon">${file.isEpub ? '📗' : '📄'}</span>`;
+            fileTableContent += `<td><span class="file-icon">${file.isEpub ? '📗' : (file.isPxc ? '🖼️' : '📄')}</span>`;
             fileTableContent += `<a href="#" onclick="downloadFile('${filePath.replaceAll("'", "\\'")}', '${file.name.replaceAll("'", "\\'")}');return false;" class="file-link">${escapeHtml(file.name)}</a>`;
             if (file.isEpub) fileTableContent += '<span class="epub-badge">EPUB</span>';
+            if (file.isPxc) fileTableContent += '<span class="pxc-badge">PXC</span>';
             if (file.name.includes('QUOTES')) fileTableContent += '<span class="quotes-badge">QUOTES</span>';
           }
           fileTableContent += '</td>';

--- a/src/sleep/WallpaperPlaylist.h
+++ b/src/sleep/WallpaperPlaylist.h
@@ -54,11 +54,11 @@ class WallpaperPlaylist {
     // RNG. Defaults to Arduino random() in production. Tests inject seeded fn.
     std::function<long(long)> randomFn;
 
-    // Favorite predicate (delegates to FavoriteBmp in production).
+    // Favorite predicate (delegates to FavoriteImage in production).
     // Argument is a full /sleep/<filename> path.
     std::function<bool(const std::string&)> isFavorite;
 
-    // Called after a file is renamed during trim (for FavoriteBmp path updates).
+    // Called after a file is renamed during trim (for FavoriteImage path updates).
     std::function<void(const std::string& /*from*/, const std::string& /*to*/)> onPathRenamed;
 
     // Called by trimToLimit before moving overflow files (activity shows popup).

--- a/src/util/FavoriteImage.cpp
+++ b/src/util/FavoriteImage.cpp
@@ -14,7 +14,10 @@ namespace {
 
 constexpr const char* kFavoriteSuffix = "_F";
 
-bool isBmpPathInternal(const std::string& path) { return StringUtils::checkFileExtension(path, ".bmp"); }
+bool isImagePath(const std::string& path) {
+  return StringUtils::checkFileExtension(path, ".bmp") ||
+         StringUtils::checkFileExtension(path, ".pxc");
+}
 
 bool startsWith(const std::string& value, const char* prefix) { return value.rfind(prefix, 0) == 0; }
 
@@ -98,7 +101,7 @@ void removeSleepReferencesForPath(const std::string& path) {
 }  // namespace
 
 bool hasFavoriteSuffix(const std::string& filename) {
-  if (!isBmpPathInternal(filename) || filename.size() <= 6) {
+  if (!isImagePath(filename) || filename.size() <= 6) {
     return false;
   }
   const size_t extPos = filename.size() - 4;
@@ -106,7 +109,7 @@ bool hasFavoriteSuffix(const std::string& filename) {
 }
 
 std::string addFavoriteSuffix(const std::string& filename) {
-  if (!isBmpPathInternal(filename) || hasFavoriteSuffix(filename)) {
+  if (!isImagePath(filename) || hasFavoriteSuffix(filename)) {
     return filename;
   }
   return filename.substr(0, filename.size() - 4) + kFavoriteSuffix + filename.substr(filename.size() - 4);
@@ -125,7 +128,7 @@ bool isFavoritePath(const std::string& path) {
 }
 
 bool canPlacePathInSleep(const std::string& path) {
-  if (!isBmpPathInternal(path) || !isFavoritePath(path) || isInSleepFolder(path)) {
+  if (!isImagePath(path) || !isFavoritePath(path) || isInSleepFolder(path)) {
     return true;
   }
   return countProtectedSleepFavorites() < CrossPointState::SLEEP_FAVORITES_MAX;
@@ -152,7 +155,7 @@ size_t countProtectedSleepFavorites() {
 
     file.getName(name, sizeof(name));
     std::string filename(name);
-    if (!filename.empty() && filename[0] != '.' && isBmpPathInternal(filename) &&
+    if (!filename.empty() && filename[0] != '.' && isImagePath(filename) &&
         isFavoritePath("/sleep/" + filename)) {
       ++count;
     }
@@ -193,7 +196,7 @@ const char* limitReachedHomeMessage() {
 }
 
 SetFavoriteResult setFavorite(const std::string& path, const bool favorite, std::string* updatedPath) {
-  if (!isBmpPathInternal(path)) {
+  if (!isImagePath(path)) {
     return SetFavoriteResult::NotImage;
   }
   if (!Storage.exists(path.c_str())) {

--- a/src/util/FavoriteImage.cpp
+++ b/src/util/FavoriteImage.cpp
@@ -1,4 +1,4 @@
-#include "FavoriteBmp.h"
+#include "FavoriteImage.h"
 
 #include <HalStorage.h>
 
@@ -9,7 +9,7 @@
 #include "CrossPointState.h"
 #include "util/StringUtils.h"
 
-namespace FavoriteBmp {
+namespace FavoriteImage {
 namespace {
 
 constexpr const char* kFavoriteSuffix = "_F";
@@ -194,7 +194,7 @@ const char* limitReachedHomeMessage() {
 
 SetFavoriteResult setFavorite(const std::string& path, const bool favorite, std::string* updatedPath) {
   if (!isBmpPathInternal(path)) {
-    return SetFavoriteResult::NotBmp;
+    return SetFavoriteResult::NotImage;
   }
   if (!Storage.exists(path.c_str())) {
     return SetFavoriteResult::Missing;
@@ -255,4 +255,4 @@ void removePathReferences(const std::string& path) {
   removeSleepReferencesForPath(path);
 }
 
-}  // namespace FavoriteBmp
+}  // namespace FavoriteImage

--- a/src/util/FavoriteImage.cpp
+++ b/src/util/FavoriteImage.cpp
@@ -12,8 +12,6 @@
 namespace FavoriteImage {
 namespace {
 
-constexpr const char* kFavoriteSuffix = "_F";
-
 bool isImagePath(const std::string& path) {
   return StringUtils::checkFileExtension(path, ".bmp") ||
          StringUtils::checkFileExtension(path, ".pxc");
@@ -100,28 +98,8 @@ void removeSleepReferencesForPath(const std::string& path) {
 
 }  // namespace
 
-bool hasFavoriteSuffix(const std::string& filename) {
-  if (!isImagePath(filename) || filename.size() <= 6) {
-    return false;
-  }
-  const size_t extPos = filename.size() - 4;
-  return filename.substr(extPos - 2, 2) == "_F";
-}
-
-std::string addFavoriteSuffix(const std::string& filename) {
-  if (!isImagePath(filename) || hasFavoriteSuffix(filename)) {
-    return filename;
-  }
-  return filename.substr(0, filename.size() - 4) + kFavoriteSuffix + filename.substr(filename.size() - 4);
-}
-
-std::string stripFavoriteSuffix(const std::string& filename) {
-  if (!hasFavoriteSuffix(filename)) {
-    return filename;
-  }
-  const size_t extPos = filename.size() - 4;
-  return filename.substr(0, extPos - 2) + filename.substr(extPos);
-}
+// hasFavoriteSuffix, addFavoriteSuffix, stripFavoriteSuffix are defined in
+// FavoriteImageNames.cpp (pure helpers, no Arduino/APP_STATE deps).
 
 bool isFavoritePath(const std::string& path) {
   return vectorContains(APP_STATE.favoriteBmpPaths, path) || hasFavoriteSuffix(getBasename(path));

--- a/src/util/FavoriteImage.cpp
+++ b/src/util/FavoriteImage.cpp
@@ -7,14 +7,13 @@
 #include <string>
 
 #include "CrossPointState.h"
-#include "util/StringUtils.h"
+#include "util/FavoriteImageNames.h"
 
 namespace FavoriteImage {
 namespace {
 
 bool isImagePath(const std::string& path) {
-  return StringUtils::checkFileExtension(path, ".bmp") ||
-         StringUtils::checkFileExtension(path, ".pxc");
+  return FavoriteImage::isImageExtension(path);
 }
 
 bool startsWith(const std::string& value, const char* prefix) { return value.rfind(prefix, 0) == 0; }

--- a/src/util/FavoriteImage.h
+++ b/src/util/FavoriteImage.h
@@ -3,11 +3,11 @@
 #include <cstddef>
 #include <string>
 
-namespace FavoriteBmp {
+namespace FavoriteImage {
 
 enum class SetFavoriteResult {
   Success,
-  NotBmp,
+  NotImage,
   Missing,
   LimitReached,
   RenameConflict,
@@ -28,4 +28,4 @@ SetFavoriteResult setFavorite(const std::string& path, bool favorite, std::strin
 void replacePathReferences(const std::string& oldPath, const std::string& newPath);
 void removePathReferences(const std::string& path);
 
-}  // namespace FavoriteBmp
+}  // namespace FavoriteImage

--- a/src/util/FavoriteImage.h
+++ b/src/util/FavoriteImage.h
@@ -3,6 +3,11 @@
 #include <cstddef>
 #include <string>
 
+// Pure suffix helpers (hasFavoriteSuffix, addFavoriteSuffix, stripFavoriteSuffix)
+// live in FavoriteImageNames.h / FavoriteImageNames.cpp so they can be compiled
+// host-side for unit tests without pulling in Arduino / APP_STATE / Storage.
+#include "FavoriteImageNames.h"
+
 namespace FavoriteImage {
 
 enum class SetFavoriteResult {
@@ -19,9 +24,6 @@ bool canPlacePathInSleep(const std::string& path);
 bool isSleepFavoritesFull();
 size_t countProtectedSleepFavorites();
 std::string displayNameForPath(const std::string& path);
-bool hasFavoriteSuffix(const std::string& filename);
-std::string stripFavoriteSuffix(const std::string& filename);
-std::string addFavoriteSuffix(const std::string& filename);
 const char* limitReachedPopupMessage();
 const char* limitReachedHomeMessage();
 SetFavoriteResult setFavorite(const std::string& path, bool favorite, std::string* updatedPath = nullptr);

--- a/src/util/FavoriteImageNames.cpp
+++ b/src/util/FavoriteImageNames.cpp
@@ -9,9 +9,10 @@
 #include <string>
 
 namespace FavoriteImage {
-namespace {
 
+namespace {
 constexpr const char* kFavoriteSuffix = "_F";
+}  // namespace
 
 bool isImageExtension(const std::string& filename) {
   if (filename.size() < 4) return false;
@@ -25,8 +26,6 @@ bool isImageExtension(const std::string& filename) {
   const std::string extLc = lc(ext);
   return extLc == ".bmp" || extLc == ".pxc";
 }
-
-}  // namespace
 
 bool hasFavoriteSuffix(const std::string& filename) {
   if (!isImageExtension(filename) || filename.size() <= 6) {

--- a/src/util/FavoriteImageNames.cpp
+++ b/src/util/FavoriteImageNames.cpp
@@ -1,0 +1,54 @@
+// Pure suffix helpers for sleep-image filenames (.bmp / .pxc).
+// Deliberately free of Arduino types, APP_STATE, and Storage so this
+// translation unit can be compiled in the host test environment.
+
+#include "FavoriteImageNames.h"
+
+#include <cctype>
+#include <cstring>
+#include <string>
+
+namespace FavoriteImage {
+namespace {
+
+constexpr const char* kFavoriteSuffix = "_F";
+
+bool isImageExtension(const std::string& filename) {
+  if (filename.size() < 4) return false;
+  const std::string ext = filename.substr(filename.size() - 4);
+  // Case-insensitive compare against .bmp and .pxc
+  auto lc = [](const std::string& s) {
+    std::string r = s;
+    for (char& c : r) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    return r;
+  };
+  const std::string extLc = lc(ext);
+  return extLc == ".bmp" || extLc == ".pxc";
+}
+
+}  // namespace
+
+bool hasFavoriteSuffix(const std::string& filename) {
+  if (!isImageExtension(filename) || filename.size() <= 6) {
+    return false;
+  }
+  const size_t extPos = filename.size() - 4;
+  return filename.substr(extPos - 2, 2) == "_F";
+}
+
+std::string addFavoriteSuffix(const std::string& filename) {
+  if (!isImageExtension(filename) || hasFavoriteSuffix(filename)) {
+    return filename;
+  }
+  return filename.substr(0, filename.size() - 4) + kFavoriteSuffix + filename.substr(filename.size() - 4);
+}
+
+std::string stripFavoriteSuffix(const std::string& filename) {
+  if (!hasFavoriteSuffix(filename)) {
+    return filename;
+  }
+  const size_t extPos = filename.size() - 4;
+  return filename.substr(0, extPos - 2) + filename.substr(extPos);
+}
+
+}  // namespace FavoriteImage

--- a/src/util/FavoriteImageNames.h
+++ b/src/util/FavoriteImageNames.h
@@ -8,6 +8,12 @@
 
 namespace FavoriteImage {
 
+// Returns true if `filename` has a recognized favorite-eligible image
+// extension (.bmp or .pxc, case-insensitive). Single source of truth for
+// the supported-extension list; FavoriteImage.cpp::isImagePath delegates
+// here.
+bool isImageExtension(const std::string& filename);
+
 bool hasFavoriteSuffix(const std::string& filename);
 std::string stripFavoriteSuffix(const std::string& filename);
 std::string addFavoriteSuffix(const std::string& filename);

--- a/src/util/FavoriteImageNames.h
+++ b/src/util/FavoriteImageNames.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// Pure suffix helpers for sleep-image filenames.
+// No Arduino types, no APP_STATE, no Storage — safe for host-side testing.
+// FavoriteImage.h re-exports these; FavoriteImage.cpp includes this header.
+
+#include <string>
+
+namespace FavoriteImage {
+
+bool hasFavoriteSuffix(const std::string& filename);
+std::string stripFavoriteSuffix(const std::string& filename);
+std::string addFavoriteSuffix(const std::string& filename);
+
+}  // namespace FavoriteImage

--- a/src/util/PxcRenderer.cpp
+++ b/src/util/PxcRenderer.cpp
@@ -1,7 +1,6 @@
 #include "PxcRenderer.h"
 
 #include <Epub/converters/DirectPixelWriter.h>
-#include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <Logging.h>
 #include <esp_task_wdt.h>
@@ -9,11 +8,9 @@
 #include <cstdint>
 #include <cstdlib>
 
-#include "../CrossPointSettings.h"
-
 namespace PxcRenderer {
 
-bool renderPxc(GfxRenderer& renderer, const std::string& path) {
+bool renderPxc(GfxRenderer& renderer, const std::string& path, GfxRenderer::GrayscaleMode mode) {
   FsFile file;
   if (!Storage.openFileForRead("PXC", path, file)) {
     LOG_ERR("PXC", "Cannot open: %s", path.c_str());
@@ -43,9 +40,6 @@ bool renderPxc(GfxRenderer& renderer, const std::string& path) {
     return false;
   }
 
-  const auto mode = SETTINGS.useFactoryLUT
-                        ? GfxRenderer::GrayscaleMode::FactoryQuality
-                        : GfxRenderer::GrayscaleMode::Differential;
   const int width = static_cast<int>(pxcWidth);
   const int height = static_cast<int>(pxcHeight);
   renderer.renderGrayscale(mode, [&]() {

--- a/src/util/PxcRenderer.cpp
+++ b/src/util/PxcRenderer.cpp
@@ -1,0 +1,71 @@
+#include "PxcRenderer.h"
+
+#include <Epub/converters/DirectPixelWriter.h>
+#include <GfxRenderer.h>
+#include <HalStorage.h>
+#include <Logging.h>
+#include <esp_task_wdt.h>
+
+#include <cstdint>
+#include <cstdlib>
+
+#include "../CrossPointSettings.h"
+
+namespace PxcRenderer {
+
+bool renderPxc(GfxRenderer& renderer, const std::string& path) {
+  FsFile file;
+  if (!Storage.openFileForRead("PXC", path, file)) {
+    LOG_ERR("PXC", "Cannot open: %s", path.c_str());
+    return false;
+  }
+  uint16_t pxcWidth = 0, pxcHeight = 0;
+  if (file.read(&pxcWidth, 2) != 2 || file.read(&pxcHeight, 2) != 2) {
+    LOG_ERR("PXC", "Header read failed: %s", path.c_str());
+    file.close();
+    return false;
+  }
+  const int sw = renderer.getScreenWidth();
+  const int sh = renderer.getScreenHeight();
+  if (std::abs(static_cast<int>(pxcWidth) - sw) > 1 ||
+      std::abs(static_cast<int>(pxcHeight) - sh) > 1) {
+    LOG_ERR("PXC", "Size mismatch %dx%d (screen %dx%d): %s",
+            pxcWidth, pxcHeight, sw, sh, path.c_str());
+    file.close();
+    return false;
+  }
+  const uint32_t dataOffset = file.position();
+  const int bytesPerRow = (pxcWidth + 3) / 4;
+  uint8_t* rowBuf = static_cast<uint8_t*>(malloc(bytesPerRow));
+  if (!rowBuf) {
+    LOG_ERR("PXC", "Row alloc failed (%d bytes)", bytesPerRow);
+    file.close();
+    return false;
+  }
+
+  const auto mode = SETTINGS.useFactoryLUT
+                        ? GfxRenderer::GrayscaleMode::FactoryQuality
+                        : GfxRenderer::GrayscaleMode::Differential;
+  const int width = static_cast<int>(pxcWidth);
+  const int height = static_cast<int>(pxcHeight);
+  renderer.renderGrayscale(mode, [&]() {
+    file.seek(dataOffset);
+    DirectPixelWriter pw;
+    pw.init(renderer);
+    for (int row = 0; row < height; row++) {
+      if (file.read(rowBuf, bytesPerRow) != bytesPerRow) break;
+      pw.beginRow(row);
+      for (int col = 0; col < width; col++) {
+        const uint8_t pv = (rowBuf[col >> 2] >> (6 - (col & 3) * 2)) & 0x03;
+        pw.writePixel(col, pv);
+      }
+      if ((row & 31) == 0) esp_task_wdt_reset();
+    }
+  });
+
+  free(rowBuf);
+  file.close();
+  return true;
+}
+
+}  // namespace PxcRenderer

--- a/src/util/PxcRenderer.cpp
+++ b/src/util/PxcRenderer.cpp
@@ -62,4 +62,55 @@ bool renderPxc(GfxRenderer& renderer, const std::string& path, GfxRenderer::Gray
   return true;
 }
 
+bool streamPxcAsBw(GfxRenderer& renderer, const std::string& path) {
+  FsFile file;
+  if (!Storage.openFileForRead("PXC", path, file)) {
+    LOG_ERR("PXC", "Cannot open (BW pass): %s", path.c_str());
+    return false;
+  }
+  uint16_t pxcWidth = 0, pxcHeight = 0;
+  if (file.read(&pxcWidth, 2) != 2 || file.read(&pxcHeight, 2) != 2) {
+    LOG_ERR("PXC", "Header read failed (BW pass): %s", path.c_str());
+    file.close();
+    return false;
+  }
+  const int sw = renderer.getScreenWidth();
+  const int sh = renderer.getScreenHeight();
+  if (std::abs(static_cast<int>(pxcWidth) - sw) > 1 ||
+      std::abs(static_cast<int>(pxcHeight) - sh) > 1) {
+    LOG_ERR("PXC", "Size mismatch (BW pass) %dx%d (screen %dx%d): %s",
+            pxcWidth, pxcHeight, sw, sh, path.c_str());
+    file.close();
+    return false;
+  }
+  const int bytesPerRow = (pxcWidth + 3) / 4;
+  uint8_t* rowBuf = static_cast<uint8_t*>(malloc(bytesPerRow));
+  if (!rowBuf) {
+    LOG_ERR("PXC", "Row alloc failed in BW pass (%d bytes)", bytesPerRow);
+    file.close();
+    return false;
+  }
+
+  const int width = static_cast<int>(pxcWidth);
+  const int height = static_cast<int>(pxcHeight);
+  renderer.setRenderMode(GfxRenderer::BW);
+  DirectPixelWriter pw;
+  pw.init(renderer);
+  for (int row = 0; row < height; row++) {
+    if (file.read(rowBuf, bytesPerRow) != bytesPerRow) break;
+    pw.beginRow(row);
+    for (int col = 0; col < width; col++) {
+      const uint8_t pv = (rowBuf[col >> 2] >> (6 - (col & 3) * 2)) & 0x03;
+      // BW threshold matches Bitmap::drawBitmap in BW mode: pv < 3 -> black
+      // (writePixel selects the appropriate action via renderMode).
+      pw.writePixel(col, pv);
+    }
+    if ((row & 31) == 0) esp_task_wdt_reset();
+  }
+
+  free(rowBuf);
+  file.close();
+  return true;
+}
+
 }  // namespace PxcRenderer

--- a/src/util/PxcRenderer.h
+++ b/src/util/PxcRenderer.h
@@ -27,4 +27,14 @@ namespace PxcRenderer {
 // 2=LightGray, 3=White (matches Bitmap::readNextRow).
 bool renderPxc(GfxRenderer& renderer, const std::string& path, GfxRenderer::GrayscaleMode mode);
 
+// Streams the PXC and writes a 1-bit BW representation into the renderer's
+// current frameBuffer. Pixels with pv < 3 (Black/DarkGray/LightGray) are
+// drawn black; pv == 3 (White) is left as background. Caller is responsible
+// for clearScreen() before and displayBuffer() after — this just populates
+// the frameBuffer. Used to prime the panel before a Differential grayscale
+// overlay so stark Black pixels transition cleanly (Differential mode
+// encodes Black and White identically as LSB=0,MSB=0, so it relies on the
+// pre-existing panel state to disambiguate them).
+bool streamPxcAsBw(GfxRenderer& renderer, const std::string& path);
+
 }  // namespace PxcRenderer

--- a/src/util/PxcRenderer.h
+++ b/src/util/PxcRenderer.h
@@ -1,23 +1,30 @@
 #pragma once
 
-#include <string>
+#include <GfxRenderer.h>
 
-class GfxRenderer;
+#include <string>
 
 namespace PxcRenderer {
 
-// Streams a screen-sized .pxc into the framebuffer using the configured
-// grayscale mode (FactoryQuality if SETTINGS.useFactoryLUT, else
-// Differential). Returns false if the file cannot be opened, the header
-// cannot be read, the declared dimensions diverge from the current screen
-// by more than 1 px, or the per-row buffer cannot be allocated.
+// Streams a screen-sized .pxc into the LSB/MSB grayscale planes and pushes
+// the composite via the supplied `mode`. Returns false on open / header /
+// size-mismatch / row-buffer-alloc failure. The caller picks the mode:
 //
-// Does NOT call displayBuffer — caller picks the refresh mode after this
-// returns.
+//  - FactoryQuality / FactoryFast: pre-flashes white via HALF_REFRESH then
+//    drives the panel absolutely with the LUT. Best image quality, ~2.2 s.
+//    Suitable when nothing else is on screen (sleep wallpaper without
+//    overlays).
+//  - Differential: composites on top of whatever the panel already shows.
+//    Skips the pre-flash, ~0.5 s faster. Required when a BW base layer
+//    (e.g. button hints) was just pushed and must remain visible under
+//    the grayscale image.
+//
+// Does NOT call displayBuffer afterward — the grayscale composite is
+// pushed inside renderGrayscale via displayGrayBuffer.
 //
 // PXC layout: uint16_t width, uint16_t height, then packed 2 bpp payload
 // (4 px/byte, MSB first). Pixel convention: 0=Black, 1=DarkGray,
 // 2=LightGray, 3=White (matches Bitmap::readNextRow).
-bool renderPxc(GfxRenderer& renderer, const std::string& path);
+bool renderPxc(GfxRenderer& renderer, const std::string& path, GfxRenderer::GrayscaleMode mode);
 
 }  // namespace PxcRenderer

--- a/src/util/PxcRenderer.h
+++ b/src/util/PxcRenderer.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+
+class GfxRenderer;
+
+namespace PxcRenderer {
+
+// Streams a screen-sized .pxc into the framebuffer using the configured
+// grayscale mode (FactoryQuality if SETTINGS.useFactoryLUT, else
+// Differential). Returns false if the file cannot be opened, the header
+// cannot be read, the declared dimensions diverge from the current screen
+// by more than 1 px, or the per-row buffer cannot be allocated.
+//
+// Does NOT call displayBuffer — caller picks the refresh mode after this
+// returns.
+//
+// PXC layout: uint16_t width, uint16_t height, then packed 2 bpp payload
+// (4 px/byte, MSB first). Pixel convention: 0=Black, 1=DarkGray,
+// 2=LightGray, 3=White (matches Bitmap::readNextRow).
+bool renderPxc(GfxRenderer& renderer, const std::string& path);
+
+}  // namespace PxcRenderer

--- a/test/test_favorite_image/test_main.cpp
+++ b/test/test_favorite_image/test_main.cpp
@@ -16,12 +16,14 @@ void test_has_favorite_suffix_bmp() {
   TEST_ASSERT_TRUE(FavoriteImage::hasFavoriteSuffix("foo_F.bmp"));
   TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("foo.bmp"));
   TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("F.bmp"));
+  TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("_F.bmp"));  // no stem, reject
 }
 
 void test_has_favorite_suffix_pxc() {
   TEST_ASSERT_TRUE(FavoriteImage::hasFavoriteSuffix("foo_F.pxc"));
   TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("foo.pxc"));
   TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("F.pxc"));
+  TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("_F.pxc"));  // no stem, reject
 }
 
 void test_has_favorite_suffix_rejects_non_image() {
@@ -53,6 +55,21 @@ void test_strip_favorite_suffix_pxc() {
   TEST_ASSERT_EQUAL_STRING("foo.pxc", FavoriteImage::stripFavoriteSuffix("foo.pxc").c_str());
 }
 
+void test_extensions_case_insensitive() {
+  TEST_ASSERT_TRUE(FavoriteImage::hasFavoriteSuffix("foo_F.BMP"));
+  TEST_ASSERT_TRUE(FavoriteImage::hasFavoriteSuffix("foo_F.Pxc"));
+  TEST_ASSERT_EQUAL_STRING("foo_F.BMP", FavoriteImage::addFavoriteSuffix("foo.BMP").c_str());
+}
+
+void test_helpers_handle_paths_with_directories() {
+  TEST_ASSERT_TRUE(FavoriteImage::hasFavoriteSuffix("/sleep/foo_F.bmp"));
+  TEST_ASSERT_TRUE(FavoriteImage::hasFavoriteSuffix("/sleep/foo_F.pxc"));
+  TEST_ASSERT_EQUAL_STRING("/sleep/foo.bmp",
+                           FavoriteImage::stripFavoriteSuffix("/sleep/foo_F.bmp").c_str());
+  TEST_ASSERT_EQUAL_STRING("/sleep/foo_F.pxc",
+                           FavoriteImage::addFavoriteSuffix("/sleep/foo.pxc").c_str());
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -65,5 +82,7 @@ int main(int argc, char** argv) {
   RUN_TEST(test_add_favorite_suffix_passthrough_for_non_image);
   RUN_TEST(test_strip_favorite_suffix_bmp);
   RUN_TEST(test_strip_favorite_suffix_pxc);
+  RUN_TEST(test_extensions_case_insensitive);
+  RUN_TEST(test_helpers_handle_paths_with_directories);
   return UNITY_END();
 }

--- a/test/test_favorite_image/test_main.cpp
+++ b/test/test_favorite_image/test_main.cpp
@@ -1,0 +1,69 @@
+// Host-side tests for FavoriteImage suffix helpers.
+// Run via: pio test -e test_host -f test_favorite_image
+
+#include <unity.h>
+
+#include <string>
+
+#include "util/FavoriteImageNames.h"
+
+void setUp() {}
+void tearDown() {}
+
+namespace {
+
+void test_has_favorite_suffix_bmp() {
+  TEST_ASSERT_TRUE(FavoriteImage::hasFavoriteSuffix("foo_F.bmp"));
+  TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("foo.bmp"));
+  TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("F.bmp"));
+}
+
+void test_has_favorite_suffix_pxc() {
+  TEST_ASSERT_TRUE(FavoriteImage::hasFavoriteSuffix("foo_F.pxc"));
+  TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("foo.pxc"));
+  TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("F.pxc"));
+}
+
+void test_has_favorite_suffix_rejects_non_image() {
+  TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("foo_F.txt"));
+  TEST_ASSERT_FALSE(FavoriteImage::hasFavoriteSuffix("foo_F.epub"));
+}
+
+void test_add_favorite_suffix_bmp() {
+  TEST_ASSERT_EQUAL_STRING("foo_F.bmp", FavoriteImage::addFavoriteSuffix("foo.bmp").c_str());
+  TEST_ASSERT_EQUAL_STRING("foo_F.bmp", FavoriteImage::addFavoriteSuffix("foo_F.bmp").c_str());
+}
+
+void test_add_favorite_suffix_pxc() {
+  TEST_ASSERT_EQUAL_STRING("foo_F.pxc", FavoriteImage::addFavoriteSuffix("foo.pxc").c_str());
+  TEST_ASSERT_EQUAL_STRING("foo_F.pxc", FavoriteImage::addFavoriteSuffix("foo_F.pxc").c_str());
+}
+
+void test_add_favorite_suffix_passthrough_for_non_image() {
+  TEST_ASSERT_EQUAL_STRING("foo.txt", FavoriteImage::addFavoriteSuffix("foo.txt").c_str());
+}
+
+void test_strip_favorite_suffix_bmp() {
+  TEST_ASSERT_EQUAL_STRING("foo.bmp", FavoriteImage::stripFavoriteSuffix("foo_F.bmp").c_str());
+  TEST_ASSERT_EQUAL_STRING("foo.bmp", FavoriteImage::stripFavoriteSuffix("foo.bmp").c_str());
+}
+
+void test_strip_favorite_suffix_pxc() {
+  TEST_ASSERT_EQUAL_STRING("foo.pxc", FavoriteImage::stripFavoriteSuffix("foo_F.pxc").c_str());
+  TEST_ASSERT_EQUAL_STRING("foo.pxc", FavoriteImage::stripFavoriteSuffix("foo.pxc").c_str());
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+  RUN_TEST(test_has_favorite_suffix_bmp);
+  RUN_TEST(test_has_favorite_suffix_pxc);
+  RUN_TEST(test_has_favorite_suffix_rejects_non_image);
+  RUN_TEST(test_add_favorite_suffix_bmp);
+  RUN_TEST(test_add_favorite_suffix_pxc);
+  RUN_TEST(test_add_favorite_suffix_passthrough_for_non_image);
+  RUN_TEST(test_strip_favorite_suffix_bmp);
+  RUN_TEST(test_strip_favorite_suffix_pxc);
+  return UNITY_END();
+}

--- a/test/test_library_filter/test_main.cpp
+++ b/test/test_library_filter/test_main.cpp
@@ -1,0 +1,93 @@
+// Host-side tests for the EPUB-cache PXC filter on library listings.
+// Run via: pio test -e test_host -f test_library_filter
+
+#include <unity.h>
+
+#include <string>
+#include <vector>
+
+#include "activities/home/LibraryListingFilter.h"
+
+void setUp() {}
+void tearDown() {}
+
+namespace {
+
+std::vector<std::string> sampleListing() {
+  return {
+      "wallpaper1.pxc",
+      "wallpaper1.bmp",
+      "lonely.pxc",
+      "image1.jpg",
+      "image1.pxc",
+      "anything_q.pxc",
+      "book.epub",
+      "notes.txt",
+      "subdir/",
+  };
+}
+
+void test_filter_drops_q_pxc() {
+  std::vector<std::string> files = sampleListing();
+  LibraryListingFilter::filterEpubCachePxc(files);
+  for (const auto& name : files) {
+    TEST_ASSERT_FALSE_MESSAGE(name.size() >= 6 && name.compare(name.size() - 6, 6, "_q.pxc") == 0,
+                              name.c_str());
+  }
+}
+
+void test_filter_drops_shadowed_pxc() {
+  std::vector<std::string> files = sampleListing();
+  LibraryListingFilter::filterEpubCachePxc(files);
+  for (const auto& name : files) {
+    TEST_ASSERT_NOT_EQUAL_MESSAGE(0, name.compare("image1.pxc"), "image1.pxc should be filtered");
+  }
+}
+
+void test_filter_keeps_user_pxc_alongside_bmp() {
+  std::vector<std::string> files = sampleListing();
+  LibraryListingFilter::filterEpubCachePxc(files);
+  bool keptPxc = false, keptBmp = false;
+  for (const auto& name : files) {
+    if (name == "wallpaper1.pxc") keptPxc = true;
+    if (name == "wallpaper1.bmp") keptBmp = true;
+  }
+  TEST_ASSERT_TRUE(keptPxc);
+  TEST_ASSERT_TRUE(keptBmp);
+}
+
+void test_filter_keeps_lonely_pxc() {
+  std::vector<std::string> files = sampleListing();
+  LibraryListingFilter::filterEpubCachePxc(files);
+  bool kept = false;
+  for (const auto& name : files) {
+    if (name == "lonely.pxc") kept = true;
+  }
+  TEST_ASSERT_TRUE(kept);
+}
+
+void test_filter_leaves_non_image_files_alone() {
+  std::vector<std::string> files = sampleListing();
+  LibraryListingFilter::filterEpubCachePxc(files);
+  bool keptEpub = false, keptTxt = false, keptDir = false;
+  for (const auto& name : files) {
+    if (name == "book.epub") keptEpub = true;
+    if (name == "notes.txt") keptTxt = true;
+    if (name == "subdir/") keptDir = true;
+  }
+  TEST_ASSERT_TRUE(keptEpub);
+  TEST_ASSERT_TRUE(keptTxt);
+  TEST_ASSERT_TRUE(keptDir);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+  RUN_TEST(test_filter_drops_q_pxc);
+  RUN_TEST(test_filter_drops_shadowed_pxc);
+  RUN_TEST(test_filter_keeps_user_pxc_alongside_bmp);
+  RUN_TEST(test_filter_keeps_lonely_pxc);
+  RUN_TEST(test_filter_leaves_non_image_files_alone);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary

- Treats `.pxc` (pre-dithered 2 bpp screen-sized image) as a first-class viewable image format anywhere `.bmp` is treated as one today: library browser visibility / opening / viewing / favoriting (`_F.pxc`) / renaming / moving / deleting, sleep folder browser + sleep-pause flow, home screen sleep counters, web `/files` listing with PXC badge.
- EPUB cache `.pxc` files (`*_q.pxc` and source-shadowed `*.pxc` next to `.jpg/.jpeg/.png/.gif/.webp`) are filtered out from both the native library browser and the web `/files` listing so book cache files stay invisible.
- Library viewer renders PXC via the same BW pass + Differential grayscale pipeline that the BMP viewer uses — verified on device with full 4-level grayscale and button hints visible.
- Sleep wallpapers continue to use Factory grayscale quality (`SETTINGS.useFactoryLUT`).

## Files

- New: `src/util/PxcRenderer.{h,cpp}` (shared PXC streamer, `streamPxcAsBw` + `renderPxc`), `src/util/FavoriteImage.{h,cpp}` + `src/util/FavoriteImageNames.{h,cpp}` (renamed from `FavoriteBmp`, single source of truth for image extensions), `src/activities/home/LibraryListingFilter.{h,cpp}` (host-testable EPUB-cache filter).
- Renamed: `FavoriteBmp` → `FavoriteImage`, `Mode::BMP_VIEW` → `IMAGE_VIEW`, `enterBmpView`/`renderBmpView`/etc. → image-named equivalents. JSON state key `favoriteBmpPaths` deliberately kept to avoid migration.
- Updated: `MyLibraryActivity` (extension predicates, image-aware actions, EPUB-cache filter, viewer split with PXC fast-path, extension-aware rename), `SleepActivity` (PxcRenderer mode parameter), `BaseTheme` (sleep counters now count `.pxc` + `_F.pxc`), `CrossPointWebServer` + `FilesPage.html` (PXC badge, two-pass listing to keep heap bounded).

## Test plan

- [x] `pio run -e default` clean (Flash 87.9% / RAM 55.9%, no regression)
- [x] Host tests: `pio test -e test_host -f test_favorite_image` 10/10, `pio test -e test_host -f test_library_filter` 5/5, existing `test_wallpaper_playlist_v2` 7/7
- [x] On-device: PXC files visible in `/sleep` and elsewhere, open/favorite/rename/move/delete all work
- [x] On-device: PXC viewer renders cleanly with full 4-level grayscale and button hints (BW pass + Differential overlay)
- [x] On-device: EPUB cache `.pxc` siblings invisible after opening a book
- [x] On-device: web `/files` shows PXC badge, no `_q.pxc` or shadowed `.pxc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)