### PR TITLE
perf(reader): debounce per-tap SD writes + offload to background task

### DIFF
--- a/src/activities/reader/EpubProgressSink.cpp
+++ b/src/activities/reader/EpubProgressSink.cpp
@@ -5,11 +5,18 @@
 
 #include <cstdint>
 
+#include "../../persist/AsyncWriter.h"
+
 namespace crosspoint {
 namespace reader {
 
-bool EpubProgressSink::write(const ReaderPosition& pos) {
-  if (spineCount_ <= 0) {
+namespace {
+
+// The actual blocking SD work. Runs on either the AsyncWriter task (typical)
+// or the caller (boot fallback before AsyncWriter::start()). Storage.* is
+// mutex-serialized internally so concurrent main-thread access is safe.
+bool writeProgressSync(const std::string& cachePath, int spineCount, ReaderPosition pos) {
+  if (spineCount <= 0) {
     return false;
   }
 
@@ -18,17 +25,17 @@ bool EpubProgressSink::write(const ReaderPosition& pos) {
   int32_t pageCount = pos.pageCount;
   if (spineIndex < 0) {
     spineIndex = 0;
-  } else if (spineIndex >= spineCount_) {
-    spineIndex = spineCount_ - 1;
+  } else if (spineIndex >= spineCount) {
+    spineIndex = spineCount - 1;
     page = UINT16_MAX;  // legacy past-end sentinel preserved for byte-compat
   }
   if (pageCount <= 0) {
     pageCount = 1;
   }
 
-  const std::string progPath = cachePath_ + "/progress.bin";
-  const std::string tmpPath = cachePath_ + "/progress_tmp.bin";
-  const std::string bakPath = cachePath_ + "/progress.bin.bak";
+  const std::string progPath = cachePath + "/progress.bin";
+  const std::string tmpPath = cachePath + "/progress_tmp.bin";
+  const std::string bakPath = cachePath + "/progress.bin.bak";
 
   if (Storage.exists(tmpPath.c_str())) {
     Storage.remove(tmpPath.c_str());
@@ -50,9 +57,6 @@ bool EpubProgressSink::write(const ReaderPosition& pos) {
   f.write(data, 6);
   f.close();
 
-  // Rotate current progress.bin to progress.bin.bak before replacing.
-  // Defence-in-depth: survives an interrupted write, and survives an accidental
-  // removal of progress.bin as long as the .bak is still on disk.
   if (Storage.exists(progPath.c_str())) {
     if (Storage.exists(bakPath.c_str())) {
       Storage.remove(bakPath.c_str());
@@ -62,6 +66,26 @@ bool EpubProgressSink::write(const ReaderPosition& pos) {
   Storage.rename(tmpPath.c_str(), progPath.c_str());
 
   LOG_DBG("ERS", "Progress saved: Chapter %d, Page %d", static_cast<int>(spineIndex), static_cast<int>(page));
+  return true;
+}
+
+}  // namespace
+
+bool EpubProgressSink::write(const ReaderPosition& pos) {
+  // Capture by value so the lambda is self-contained on the AsyncWriter task.
+  // EpubProgressSink instances may be destroyed while a write is in flight
+  // (e.g. user closes book mid-debounce); copying state avoids dangling refs.
+  // Lifecycle drain (AsyncWriter::drainBlocking) at onExit / enterDeepSleep
+  // guarantees no in-flight write outlives the device powering down.
+  const std::string cachePath = cachePath_;
+  const int spineCount = spineCount_;
+  ReaderPosition snap = pos;
+  ::crosspoint::persist::AsyncWriter::instance().submit(
+      [cachePath, spineCount, snap]() { writeProgressSync(cachePath, spineCount, snap); });
+  // Optimistic success: tracker advances lastSaved immediately. If the async
+  // write later fails, the next observe() with the same position will not
+  // re-dirty the tracker — same risk window as previous synchronous
+  // best-effort behaviour (we never retried failed writes either).
   return true;
 }
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -17,6 +17,7 @@
 #include <new>
 #include <vector>
 
+#include "../../persist/AsyncWriter.h"
 #include "BookmarkListActivity.h"
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
@@ -801,7 +802,7 @@ void EpubReaderActivity::loopPageTurn(bool prevTriggered, bool nextTriggered) {
   if (prevTriggered) {
     if (section->currentPage > 0) {
       section->currentPage--;
-      flushProgressIfNeeded(true);
+      flushProgressIfNeeded(false);
     } else if (currentSpineIndex > 0) {
       TransitionFeedback::show(renderer, tr(STR_LOADING));
       {
@@ -818,7 +819,7 @@ void EpubReaderActivity::loopPageTurn(bool prevTriggered, bool nextTriggered) {
     if (section->currentPage < section->pageCount - 1) {
       section->currentPage++;
       addSessionPagesRead();
-      flushProgressIfNeeded(true);
+      flushProgressIfNeeded(false);
     } else {
       TransitionFeedback::show(renderer, tr(STR_LOADING));
       {
@@ -853,6 +854,7 @@ void EpubReaderActivity::openReaderMenu() {
   const std::string quotesPath = getQuotesFilePath();
   const bool hasQuotes = !quotesPath.empty() && Storage.exists(quotesPath.c_str());
   boldSwapAtMenuOpen = RECENT_BOOKS.getBoldSwap(epub->getPath());
+  flushProgressIfNeeded(true);
   exitActivity();
   enterNewActivity(new EpubReaderMenuActivity(
       this->renderer, this->mappedInput, epub->getTitle(), epub->getPath(), currentPage, totalPages,
@@ -1864,6 +1866,12 @@ void EpubReaderActivity::flushProgressIfNeeded(const bool force) {
                      static_cast<int32_t>(section->pageCount)},
                     now);
   progress_.flush(now, force);
+  if (force) {
+    // Force-flush callers (onExit, theme/font change, openReaderMenu, deep
+    // sleep) need persistence guarantee, not just enqueue. Drain the async
+    // task before returning.
+    ::crosspoint::persist::AsyncWriter::instance().drainBlocking();
+  }
 
   // Keep the home-screen percent cache fresh. setPercent is a no-op when
   // the value hasn't changed (no SD write), so this is cheap on every

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -285,6 +285,7 @@ void TxtReaderActivity::drawFlowLine(const FlowLine& line, const int x, const in
 }
 
 void TxtReaderActivity::openReadingThemes() {
+  flushProgressIfNeeded(true);
   exitActivity();
   enterNewActivity(new ReadingThemesActivity(renderer, mappedInput, txt ? txt->getCachePath() : std::string(),
                                              [this](const bool changed) {
@@ -434,7 +435,7 @@ void TxtReaderActivity::loop() {
     currentPage--;
     progressDirty = true;
     lastProgressChangeMs = millis();
-    flushProgressIfNeeded(true);
+    flushProgressIfNeeded(false);
     requestUpdate();
   } else if (nextTriggered) {
     if (currentPage < totalPages - 1) {
@@ -442,7 +443,7 @@ void TxtReaderActivity::loop() {
       APP_STATE.sessionPagesRead++;
       progressDirty = true;
       lastProgressChangeMs = millis();
-      flushProgressIfNeeded(true);
+      flushProgressIfNeeded(false);
       requestUpdate();
     } else {
       onGoHome();

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -218,7 +218,7 @@ void XtcReaderActivity::loop() {
     }
     progressDirty = true;
     lastProgressChangeMs = millis();
-    flushProgressIfNeeded(true);
+    flushProgressIfNeeded(false);
     requestUpdate();
   } else if (nextTriggered) {
     const uint32_t previousPage = currentPage;
@@ -231,7 +231,7 @@ void XtcReaderActivity::loop() {
     }
     progressDirty = true;
     lastProgressChangeMs = millis();
-    flushProgressIfNeeded(true);
+    flushProgressIfNeeded(false);
     requestUpdate();
   }
 }
@@ -240,6 +240,7 @@ void XtcReaderActivity::openChapterMenu() {
   if (!xtc || !xtc->hasChapters() || xtc->getChapters().empty()) {
     return;
   }
+  flushProgressIfNeeded(true);
   exitActivity();
   enterNewActivity(new XtcReaderChapterSelectionActivity(
       this->renderer, this->mappedInput, xtc, currentPage,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,7 @@
 #include "fonts/CustomBinFontManager.h"
 #include "lifecycle/ActivityRouter.h"
 #include "persist/AppStateStore.h"
+#include "persist/AsyncWriter.h"
 #include "persist/PersistManager.h"
 #include "persist/SdFatFileIO.h"
 #include "persist/Trash.h"
@@ -243,6 +244,10 @@ bool persistAppState(const char* context) {
   // crash-safety boundary — debounce only coalesces within an activity,
   // never across one.
   (void)context;
+  // Drain any background SD writes (reader progress) first so the store
+  // mutex isn't contended by a half-finished async write when we go to
+  // commit app state.
+  crosspoint::persist::AsyncWriter::instance().drainBlocking();
   const size_t flushed = crosspoint::persist::PersistManager().flushAll();
   (void)flushed;
   return true;
@@ -625,6 +630,11 @@ void setup() {
         new FullScreenMessageActivity(renderer, mappedInputManager, "SD card error", EpdFontFamily::REGULAR));
     return;
   }
+
+  // Background SD-write task. Must come up after Storage.begin() so submitted
+  // jobs can use HalStorage; lifecycle drains in persistAppState() and force-
+  // flush callers ensure no in-flight write outlives a deep sleep.
+  crosspoint::persist::AsyncWriter::instance().start();
 
   // Dump crash report to SD card if we rebooted from a panic
   HalSystem::checkPanic();

--- a/src/persist/AsyncWriter.cpp
+++ b/src/persist/AsyncWriter.cpp
@@ -1,0 +1,102 @@
+#include "AsyncWriter.h"
+
+#include <Arduino.h>
+#include <Logging.h>
+
+namespace crosspoint {
+namespace persist {
+
+AsyncWriter& AsyncWriter::instance() {
+  static AsyncWriter s;
+  return s;
+}
+
+void AsyncWriter::start() {
+  if (task_ != nullptr) {
+    return;
+  }
+  if (mtx_ == nullptr) {
+    mtx_ = xSemaphoreCreateMutex();
+  }
+  // Stack 4 KB: holds std::function captures + SD ops. HalStorage already
+  // serializes SdFat via its own mutex, so the SD write call chain is safe
+  // here. Priority 1 = same as main loopTask; FreeRTOS preemptive scheduling
+  // (configUSE_TIME_SLICING) splits the single CPU between us so neither
+  // task blocks the other for the full 120 ms write.
+  const BaseType_t ok = xTaskCreate(&AsyncWriter::taskEntry, "asyncwriter", 4096, this, 1, &task_);
+  if (ok != pdPASS) {
+    LOG_ERR("AWR", "xTaskCreate failed");
+    task_ = nullptr;
+  }
+}
+
+void AsyncWriter::submit(std::function<void()> fn) {
+  if (mtx_ == nullptr || task_ == nullptr) {
+    // Not started — execute synchronously as a degraded fallback so we never
+    // silently drop writes during boot before start() is called.
+    if (fn) fn();
+    return;
+  }
+  xSemaphoreTake(mtx_, portMAX_DELAY);
+  if (count_ == kMaxQueue) {
+    // Drop oldest. Latest snapshot is what matters; older positions are stale.
+    queue_[head_] = std::function<void()>();
+    head_ = (head_ + 1) % kMaxQueue;
+    --count_;
+    ++dropped_;
+  }
+  queue_[tail_] = std::move(fn);
+  tail_ = (tail_ + 1) % kMaxQueue;
+  ++count_;
+  xSemaphoreGive(mtx_);
+  xTaskNotifyGive(task_);
+}
+
+void AsyncWriter::drainBlocking() {
+  if (mtx_ == nullptr) {
+    return;
+  }
+  while (true) {
+    xSemaphoreTake(mtx_, portMAX_DELAY);
+    const bool done = (count_ == 0) && !busy_;
+    xSemaphoreGive(mtx_);
+    if (done) {
+      return;
+    }
+    vTaskDelay(pdMS_TO_TICKS(1));
+  }
+}
+
+void AsyncWriter::taskEntry(void* arg) { static_cast<AsyncWriter*>(arg)->taskLoop(); }
+
+void AsyncWriter::taskLoop() {
+  while (true) {
+    ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+    while (true) {
+      std::function<void()> job;
+      xSemaphoreTake(mtx_, portMAX_DELAY);
+      if (count_ == 0) {
+        busy_ = false;
+        xSemaphoreGive(mtx_);
+        break;
+      }
+      job = std::move(queue_[head_]);
+      queue_[head_] = std::function<void()>();
+      head_ = (head_ + 1) % kMaxQueue;
+      --count_;
+      busy_ = true;
+      xSemaphoreGive(mtx_);
+
+      if (job) {
+        job();
+      }
+
+      xSemaphoreTake(mtx_, portMAX_DELAY);
+      busy_ = false;
+      xSemaphoreGive(mtx_);
+    }
+  }
+}
+
+}  // namespace persist
+}  // namespace crosspoint

--- a/src/persist/AsyncWriter.h
+++ b/src/persist/AsyncWriter.h
@@ -1,0 +1,68 @@
+/**
+ * @file AsyncWriter.h
+ * @brief Background SD-write task that unblocks the main loop.
+ *
+ * Singleton FreeRTOS task that drains submitted callbacks. Lets per-page-turn
+ * progress saves return immediately from the main loop; the actual ~120 ms
+ * SD atomic-rename happens on a background task that time-shares the single
+ * ESP32-C3 CPU with the main loopTask via FreeRTOS preemptive scheduling.
+ *
+ * Lifecycle paths (onExit, enterDeepSleep) MUST call drainBlocking() before
+ * powering down to guarantee queued writes hit SD.
+ */
+#pragma once
+
+#include <cstddef>
+#include <functional>
+
+extern "C" {
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+}
+
+namespace crosspoint {
+namespace persist {
+
+class AsyncWriter {
+ public:
+  static AsyncWriter& instance();
+
+  // Idempotent. Creates the task on first call. Safe to call from setup().
+  void start();
+
+  // Enqueue a callback. Returns immediately. If queue at capacity, the
+  // OLDEST pending job is dropped (latest write always wins; older snapshots
+  // are stale anyway).
+  void submit(std::function<void()> fn);
+
+  // Block caller until queue empty AND any in-flight job has completed.
+  // Use at lifecycle boundaries before powering down or destroying captured
+  // state. Polls every 1 ms; cheap on lifecycle paths.
+  void drainBlocking();
+
+  size_t droppedCount() const { return dropped_; }
+
+ private:
+  AsyncWriter() = default;
+  AsyncWriter(const AsyncWriter&) = delete;
+  AsyncWriter& operator=(const AsyncWriter&) = delete;
+
+  static void taskEntry(void* arg);
+  void taskLoop();
+
+  TaskHandle_t task_ = nullptr;
+  SemaphoreHandle_t mtx_ = nullptr;
+  // Small ring buffer (size = kMaxQueue + 1). Older entries dropped at cap.
+  // std::function lives on heap; queue itself is fixed size to bound memory.
+  static constexpr size_t kMaxQueue = 4;
+  std::function<void()> queue_[kMaxQueue];
+  size_t head_ = 0;  // next pop
+  size_t tail_ = 0;  // next push
+  size_t count_ = 0;
+  size_t dropped_ = 0;
+  bool busy_ = false;
+};
+
+}  // namespace persist
+}  // namespace crosspoint


### PR DESCRIPTION
## Summary

Page-turn button clicks were synchronously paying a ~120 ms atomic SD-rename on every tap. On the single-core ESP32-C3 this blocked the main loop (including button polling) once per tap — the source of the sluggish / occasionally-missed clicks reported since the v2.0.0-dx34-upstream-sync. PR #120 was step 1 (rip BLE); this is step 2.

Two changes:

1. **Demote per-tap force-flush to debounced.** Page-back / page-forward call `flushProgressIfNeeded(false)`; ReaderProgressTracker's existing 800 ms debounce coalesces writes. Applied to Epub, Xtc, Txt. Lifecycle force-flushes (onExit, theme/font change, chapter-skip nav) preserved.
2. **Offload the SD write to a background FreeRTOS task.** New `crosspoint::persist::AsyncWriter` singleton drains submitted callbacks; `EpubProgressSink::write` now enqueues + returns immediately. FreeRTOS preemptive scheduling time-shares the single CPU between AsyncWriter and main loopTask, so neither blocks the other for the full 120 ms. HalStorage's own mutex keeps concurrent Storage.* safe.

A new explicit force-flush was added at each reader's menu-entry hook (openReaderMenu / openChapterMenu / openReadingThemes) to close the Reader→Settings persistence gap (that transition has `persistBefore=false`).

## Save trigger inventory

Page progress still persists on: idle 800 ms post-tap (debounce drain → AsyncWriter), back-to-Home / back-to-Library transitions (drain + flushAll), deep sleep auto-timeout or power-button hold (drain + flushAll), reader menu open (NEW), theme/font/render-mode change, spine boundary cross. Worst-case data loss on hard-reset mid-tap remains bounded by the existing 800 ms debounce window.

## Build deltas

- Production env: RAM 54.0% → 54.1% (+AsyncWriter singleton + 4 KB task stack from heap once `start()` runs). Flash unchanged.
- Built clean on \`pio run -e default\` and \`pio run -e debug\`.

## Subjective

Page turns now feel substantially crisper on a Wolfe-class EPUB. Typical in-chapter tap returns in single-digit ms (validated on debug build with PERF instrumentation, since stripped). Chapter boundaries (~700 ms – 5 s) are pre-existing render/layout cost, untouched here.

## Out of scope (follow-up)

- \`RECENT_BOOKS.setPercent\` debounce
- Reader \`skipLoopDelay()\` opt-in
- Xtc/Txt inline \`saveProgress\` async-offload (those still write inline; per-tap demote applies but AsyncWriter does not yet)
- Home / Library / Settings activity-transition latency (separate PR per user request)

## Test plan

- [x] Build \`debug\` clean
- [x] Build \`default\` clean
- [x] Flash to device, tap forward 10× rapidly — visibly crisper, no missed taps
- [x] Tap forward N pages, hold power → sleep → wake → reopen → reopens at page N (drainBlocking on enterDeepSleep)
- [x] Tap forward N pages, back-to-Library → reopen → reopens at page N (flushAll on transition)
- [x] Open reader menu → confirm position persisted (new openReaderMenu force-flush)
- [ ] Reviewer: yank-test (hard reset > 1 s after last tap) — should land on new page
- [ ] Reviewer: yank-test < 500 ms after last tap — acceptable to lose that page (within debounce window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)