### PR TITLE
perf(library): use cached RECENT_BOOKS percent in row rendering

### DIFF
--- a/src/RecentBooksStore.cpp
+++ b/src/RecentBooksStore.cpp
@@ -139,6 +139,16 @@ void RecentBooksStore::setPercent(const std::string& path, int percent) {
   saveToFile();
 }
 
+int RecentBooksStore::getCachedPercent(const std::string& path) const {
+  const std::string normalizedKey = makeRecentPathKey(normalizeRecentPath(path));
+  for (const auto& book : recentBooks) {
+    if (makeRecentPathKey(book.path) == normalizedKey) {
+      return book.percent;
+    }
+  }
+  return -1;
+}
+
 void RecentBooksStore::removeBook(const std::string& path) {
   const std::string normalizedPath = normalizeRecentPath(path);
   const std::string normalizedKey = makeRecentPathKey(normalizedPath);

--- a/src/RecentBooksStore.h
+++ b/src/RecentBooksStore.h
@@ -52,6 +52,11 @@ class RecentBooksStore {
   // not registered. Used by the reader on exit / progress save so the home
   // screen can show progress without re-opening every recent EPUB.
   void setPercent(const std::string& path, int percent);
+
+  // Lookup cached reading percent. Returns 0-100 if known and the book is
+  // tracked in recents, or -1 otherwise. Library list rendering uses this
+  // to avoid re-opening every visible EPUB on every scroll tick.
+  int getCachedPercent(const std::string& path) const;
   void removeBook(const std::string& path);
 
   // Move a book file (and its QUOTES sidecar) to /recents/.

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -481,8 +481,20 @@ std::string MyLibraryActivity::getRowTextForListIndex(const size_t listIndex) {
     const std::string fullPath = makeAbsolutePath(name);
     auto cached = progressPrefixCache.find(fullPath);
     if (cached == progressPrefixCache.end()) {
-      cached =
-          progressPrefixCache.emplace(fullPath, formatLibraryProgressPrefix(BookProgress::getPercent(fullPath))).first;
+      // Most library entries are also in RECENT_BOOKS (any book ever opened
+      // is tracked), and the reader keeps that percent fresh on exit and
+      // page turn. Hitting it first avoids the per-row EPUB spine+TOC parse
+      // + progress.bin read that BookProgress::getPercent does, which was
+      // the dominant cost on library scroll.
+      const int recentPercent = RECENT_BOOKS.getCachedPercent(fullPath);
+      std::optional<int> percent;
+      if (recentPercent >= 0) {
+        percent = recentPercent;
+      } else {
+        // Untracked book (never opened): fall back to disk parse.
+        percent = BookProgress::getPercent(fullPath);
+      }
+      cached = progressPrefixCache.emplace(fullPath, formatLibraryProgressPrefix(percent)).first;
     }
     rowText = cached->second + "  " + rowText;
   }


### PR DESCRIPTION
## Summary

Library scrolling currently pays a per-row \`BookProgress::getPercent\` call, which for an EPUB **opens the book + parses spine/TOC + opens progress.bin** every render. With ~10 visible rows the cumulative SD I/O dominates scroll latency.

\`RECENT_BOOKS\` already keeps the same percent in RAM (updated by the reader on exit and on every page turn — see \`EpubReaderActivity::flushProgressIfNeeded\`). Library rows now hit that cache first; only books that have **never been opened** (and therefore aren't in recents) fall back to the disk parse.

## Changes

- \`RecentBooksStore::getCachedPercent(path)\` — linear scan over the recents vector (capped at \`MAX_RECENT_BOOKS = 100\`), using the same path normalization as \`setPercent\` / \`removeBook\`. Returns -1 on miss.
- \`MyLibraryActivity::getRowText\` consults \`RECENT_BOOKS\` first; falls back to \`BookProgress::getPercent\` on a miss.
- \`progressPrefixCache\` itself unchanged (still cleared on folder switch); the win is that each cache-fill is now a vector lookup, not an SD round-trip + EPUB parse.

## Build deltas

Production env unchanged at RAM 54.1% / Flash 84.8%. Logic-only change.

## Out of scope (next snappiness pass)

- Async folder scan in \`MyLibraryActivity::loadFiles\` (currently sync, shows \"OPENING\" toast on every folder enter)
- \`HomeActivity::loadRecentBooks\` Storage.exists batch (12 SD round-trips per home entry)

## Test plan

- [x] Build \`default\` clean
- [ ] Reviewer: scroll a folder with many EPUBs — should feel noticeably crisper
- [ ] Reviewer: scroll into a folder with EPUBs that have never been opened — should still show percent (fallback path), but slower for those rows
- [ ] Reviewer: confirm percent prefix shows correctly for recently-read books

🤖 Generated with [Claude Code](https://claude.com/claude-code)