### PR TITLE
fix(web/sleep-converter): break long iOS filenames on mobile so editor stays in viewport

### DIFF
--- a/src/network/html/SleepConverterPage.html
+++ b/src/network/html/SleepConverterPage.html
@@ -34,7 +34,12 @@
         color: var(--muted);
         text-transform: uppercase;
         font-weight: 700;
+        overflow-wrap: anywhere;
+        word-break: break-word;
       }
+      /* Defensive: never let a stray long token (iOS NSItemProvider names,
+         error strings) push the page wider than the viewport. */
+      body { overflow-x: hidden; }
       .drop {
         padding: 32px var(--pad);
         text-align: center;
@@ -80,7 +85,9 @@
         display: grid;
         grid-template-columns: 1fr;
         gap: var(--pad);
+        min-width: 0;
       }
+      .editor > * { min-width: 0; }
       @media (min-width: 800px) {
         .editor { grid-template-columns: 1fr 1.2fr; }
       }
@@ -114,15 +121,15 @@
           border-bottom: 1px dashed var(--dash);
         }
         .preview-wrap canvas {
+          width: 100%;
+          height: auto;
           max-height: calc(50vh - 8px);
-          width: auto;
-          max-width: 100%;
           object-fit: contain;
         }
       }
 
-      .controls { display: grid; gap: var(--gap); align-content: start; }
-      .row { display: grid; grid-template-columns: 1fr; gap: 8px; }
+      .controls { display: grid; gap: var(--gap); align-content: start; min-width: 0; }
+      .row { display: grid; grid-template-columns: 1fr; gap: 8px; min-width: 0; }
       .row label {
         font-size: 10px;
         letter-spacing: 0.2em;
@@ -187,6 +194,7 @@
         color: var(--muted);
         text-transform: uppercase;
         margin-top: 8px;
+        overflow-wrap: anywhere;
       }
       .status.err { color: var(--red); }
       .status.ok { color: var(--green); }


### PR DESCRIPTION
## Summary

Mobile sleep-converter editor still looked off after #74d9692 because iOS Safari's NSItemProvider filenames (e.g. `_com.apple.foundation.nsitemprovider.d9bjp8.png`) are space-less single tokens. The editor `<h2>` and `.status` had no `overflow-wrap`, and grid children had no `min-width: 0`, so the long token forced the panel wider than the viewport and pushed the right dashed border off-screen.

- `section.panel h2`, `.status`: `overflow-wrap: anywhere` + `word-break: break-word` so long filenames break at any character.
- `.editor`, `.editor > *`, `.controls`, `.row`: `min-width: 0` so grid children can shrink below their min-content width (CSS grid default `min-width: auto` was silently keeping overflow alive even after wrap rules).
- `body`: `overflow-x: hidden` as a defensive backstop.
- Mobile preview canvas: switched to `width: 100% + height: auto + max-height: calc(50vh - 8px) + object-fit: contain`. Old `width: auto + max-height` produced a ~240 px column on a 393 px iPhone (40 % wasted black bars on portrait 480×800 sources); now fills the panel width and letterboxes vertically only when the cap kicks in.

Desktop (≥800 px, two-column editor) unchanged. CSS-only — no JS or behavioural changes.

## Test plan

- [ ] DevTools device toolbar at 320 / 393 / 480 / 799 / 800 / 1200 px — no horizontal page scroll on any width.
- [ ] Drop a file renamed to `_com.apple.foundation.nsitemprovider.d9bjp8.png`; confirm `EDIT · <name>` and `READY · <name>` both wrap inside their dashed panels.
- [ ] Preview canvas spans the full panel width on mobile, with vertical letterboxing only.
- [ ] Queue still scrolls horizontally; thumbnails remain inside the queue panel.
- [ ] Drag-to-pan in fill mode still tracks pointer correctly (canvas sizing changed; pan math reads `getBoundingClientRect()` so should be unaffected).
- [ ] Full upload flow on one image still produces the expected `.pxc` at `/sleep/<name>.pxc`.

https://claude.ai/code/session_01XBZYAJXek1gsXRgV3RZkot

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBZYAJXek1gsXRgV3RZkot)_