### PR TITLE
Upstream picks batch 1: heap/HAL fixes

### DIFF
--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -102,7 +102,7 @@ bool Xtc::hasChapters() const {
   return parser->hasChapters();
 }
 
-const std::vector<xtc::ChapterInfo>& Xtc::getChapters() const {
+const std::vector<xtc::ChapterInfo>& Xtc::getChapters() {
   static const std::vector<xtc::ChapterInfo> kEmpty;
   if (!loaded || !parser) {
     return kEmpty;

--- a/lib/Xtc/Xtc.h
+++ b/lib/Xtc/Xtc.h
@@ -61,7 +61,7 @@ class Xtc {
   std::string getTitle() const;
   std::string getAuthor() const;
   bool hasChapters() const;
-  const std::vector<xtc::ChapterInfo>& getChapters() const;
+  const std::vector<xtc::ChapterInfo>& getChapters();
 
   // Cover image support (for sleep screen)
   std::string getCoverBmpPath() const;

--- a/lib/Xtc/Xtc/XtcParser.cpp
+++ b/lib/Xtc/Xtc/XtcParser.cpp
@@ -21,6 +21,7 @@ XtcParser::XtcParser()
       m_defaultHeight(DISPLAY_HEIGHT),
       m_bitDepth(1),
       m_hasChapters(false),
+      m_chaptersLoaded(false),
       m_lastError(XtcError::OK) {
   memset(&m_header, 0, sizeof(m_header));
 }
@@ -32,6 +33,8 @@ XtcError XtcParser::open(const char* filepath) {
   if (m_isOpen) {
     close();
   }
+
+  m_filepath = filepath;
 
   // Open file
   if (!Storage.openFileForRead("XTC", filepath, m_file)) {
@@ -61,23 +64,29 @@ XtcError XtcParser::open(const char* filepath) {
       m_file.close();
       return m_lastError;
     }
+    // Trim excess capacity from metadata strings
+    m_title.shrink_to_fit();
+    m_author.shrink_to_fit();
   }
 
-  // Read page table
-  m_lastError = readPageTable();
+  // Read first page info for default dimensions (no bulk page table allocation)
+  m_lastError = readFirstPageInfo();
   if (m_lastError != XtcError::OK) {
-    LOG_DBG("XTC", "Failed to read page table: %s", errorToString(m_lastError));
+    LOG_DBG("XTC", "Failed to read first page info: %s", errorToString(m_lastError));
+    // Explicit close() required: member variable persists beyond function scope
     m_file.close();
     return m_lastError;
   }
 
-  // Read chapters if present
-  m_lastError = readChapters();
-  if (m_lastError != XtcError::OK) {
-    LOG_DBG("XTC", "Failed to read chapters: %s", errorToString(m_lastError));
-    m_file.close();
-    return m_lastError;
-  }
+  // Defer chapter parsing until actually needed (lazy load).
+  // Chapter strings can use significant heap; keeping them out of memory
+  // during rendering leaves more room for the page bitmap buffer.
+  m_hasChapters = (m_header.hasChapters == 1);
+  m_chaptersLoaded = false;
+
+  // Close the source file to free its internal SdFat buffers.
+  // It will be reopened on-demand for page table lookups and bitmap reads.
+  m_file.close();
 
   m_isOpen = true;
   LOG_DBG("XTC", "Opened file: %s (%u pages, %dx%d)", filepath, m_header.pageCount, m_defaultWidth, m_defaultHeight);
@@ -85,15 +94,27 @@ XtcError XtcParser::open(const char* filepath) {
 }
 
 void XtcParser::close() {
-  if (m_isOpen) {
-    m_file.close();
-    m_isOpen = false;
-  }
-  m_pageTable.clear();
+  closeFile();
+  m_isOpen = false;
+  m_chaptersLoaded = false;
   m_chapters.clear();
   m_title.clear();
+  m_author.clear();
   m_hasChapters = false;
   memset(&m_header, 0, sizeof(m_header));
+}
+
+bool XtcParser::ensureFileOpen() {
+  if (m_file.isOpen()) {
+    return true;
+  }
+  return Storage.openFileForRead("XTC", m_filepath.c_str(), m_file);
+}
+
+void XtcParser::closeFile() {
+  if (m_file.isOpen()) {
+    m_file.close();
+  }
 }
 
 XtcError XtcParser::readHeader() {
@@ -163,49 +184,80 @@ XtcError XtcParser::readAuthor() {
   return XtcError::OK;
 }
 
-XtcError XtcParser::readPageTable() {
+XtcError XtcParser::readFirstPageInfo() {
   if (m_header.pageTableOffset == 0) {
     LOG_DBG("XTC", "Page table offset is 0, cannot read");
     return XtcError::CORRUPTED_HEADER;
   }
 
-  // Seek to page table
+  // Verify the file is large enough to contain the full page table
+  const uint64_t fileSize = m_file.size();
+  const uint64_t pageTableSize = static_cast<uint64_t>(m_header.pageCount) * sizeof(PageTableEntry);
+  if (m_header.pageTableOffset < sizeof(XtcHeader) || m_header.pageTableOffset > fileSize ||
+      pageTableSize > fileSize - m_header.pageTableOffset) {
+    LOG_DBG("XTC", "Page table exceeds file bounds");
+    return XtcError::CORRUPTED_HEADER;
+  }
+
+  // Read only the first entry to get default page dimensions
+  // All other entries are read on-demand via readPageTableEntry()
+  // This avoids allocating pageCount * 16 bytes (e.g. 65KB for 4000+ pages)
+  PageTableEntry entry;
   if (!m_file.seek(m_header.pageTableOffset)) {
     LOG_DBG("XTC", "Failed to seek to page table at %llu", m_header.pageTableOffset);
     return XtcError::READ_ERROR;
   }
-
-  m_pageTable.resize(m_header.pageCount);
-
-  // Read page table entries
-  for (uint16_t i = 0; i < m_header.pageCount; i++) {
-    PageTableEntry entry;
-    size_t bytesRead = m_file.read(reinterpret_cast<uint8_t*>(&entry), sizeof(PageTableEntry));
-    if (bytesRead != sizeof(PageTableEntry)) {
-      LOG_DBG("XTC", "Failed to read page table entry %u", i);
-      return XtcError::READ_ERROR;
-    }
-
-    m_pageTable[i].offset = static_cast<uint32_t>(entry.dataOffset);
-    m_pageTable[i].size = entry.dataSize;
-    m_pageTable[i].width = entry.width;
-    m_pageTable[i].height = entry.height;
-    m_pageTable[i].bitDepth = m_bitDepth;
-
-    // Update default dimensions from first page
-    if (i == 0) {
-      m_defaultWidth = entry.width;
-      m_defaultHeight = entry.height;
-    }
+  size_t bytesRead = m_file.read(reinterpret_cast<uint8_t*>(&entry), sizeof(PageTableEntry));
+  if (bytesRead != sizeof(PageTableEntry)) {
+    LOG_DBG("XTC", "Failed to read first page table entry");
+    return XtcError::READ_ERROR;
   }
 
-  LOG_DBG("XTC", "Read %u page table entries", m_header.pageCount);
+  m_defaultWidth = entry.width;
+  m_defaultHeight = entry.height;
+
+  LOG_DBG("XTC", "Page table validated: %u pages, default %dx%d", m_header.pageCount, m_defaultWidth, m_defaultHeight);
   return XtcError::OK;
 }
 
+bool XtcParser::readPageTableEntry(uint32_t pageIndex, PageInfo& info) {
+  if (pageIndex >= m_header.pageCount) {
+    return false;
+  }
+
+  if (!ensureFileOpen()) {
+    LOG_DBG("XTC", "Failed to reopen file for page table read");
+    return false;
+  }
+
+  // Seek to the specific page table entry on the SD card
+  const uint64_t entryOffset = m_header.pageTableOffset + static_cast<uint64_t>(pageIndex) * sizeof(PageTableEntry);
+  if (!m_file.seek(entryOffset)) {
+    LOG_DBG("XTC", "Failed to seek to page table entry %lu at %llu", pageIndex, entryOffset);
+    return false;
+  }
+
+  PageTableEntry entry;
+  size_t bytesRead = m_file.read(reinterpret_cast<uint8_t*>(&entry), sizeof(PageTableEntry));
+  if (bytesRead != sizeof(PageTableEntry)) {
+    LOG_DBG("XTC", "Failed to read page table entry %lu", pageIndex);
+    return false;
+  }
+
+  info.offset = static_cast<uint32_t>(entry.dataOffset);
+  info.size = entry.dataSize;
+  info.width = entry.width;
+  info.height = entry.height;
+  info.bitDepth = m_bitDepth;
+  return true;
+}
+
 XtcError XtcParser::readChapters() {
-  m_hasChapters = false;
   m_chapters.clear();
+
+  if (!ensureFileOpen()) {
+    return XtcError::READ_ERROR;
+  }
 
   uint8_t hasChaptersFlag = 0;
   if (!m_file.seek(0x0B)) {
@@ -236,13 +288,12 @@ XtcError XtcParser::readChapters() {
     return XtcError::OK;
   }
 
-  uint64_t maxOffset = 0;
-  if (m_header.pageTableOffset > chapterOffset) {
+  // Clamp maxOffset to fileSize so bogus header values can't inflate chapterCount
+  uint64_t maxOffset = fileSize;
+  if (m_header.pageTableOffset > chapterOffset && m_header.pageTableOffset <= fileSize) {
     maxOffset = m_header.pageTableOffset;
-  } else if (m_header.dataOffset > chapterOffset) {
+  } else if (m_header.dataOffset > chapterOffset && m_header.dataOffset <= fileSize) {
     maxOffset = m_header.dataOffset;
-  } else {
-    maxOffset = fileSize;
   }
 
   if (maxOffset <= chapterOffset) {
@@ -260,6 +311,7 @@ XtcError XtcParser::readChapters() {
     return XtcError::READ_ERROR;
   }
 
+  m_chapters.reserve(chapterCount);
   std::vector<uint8_t> chapterBuf(chapterSize);
   for (size_t i = 0; i < chapterCount; i++) {
     if (m_file.read(chapterBuf.data(), chapterSize) != chapterSize) {
@@ -309,13 +361,23 @@ XtcError XtcParser::readChapters() {
   return XtcError::OK;
 }
 
-bool XtcParser::getPageInfo(uint32_t pageIndex, PageInfo& info) const {
-  if (pageIndex >= m_pageTable.size()) {
-    return false;
+const std::vector<ChapterInfo>& XtcParser::getChapters() {
+  // Lazy load chapters on first access
+  if (!m_chaptersLoaded && m_hasChapters) {
+    const XtcError err = readChapters();
+    if (err != XtcError::OK) {
+      LOG_ERR("XTC", "Failed to lazy-load chapters: %s", errorToString(err));
+      m_hasChapters = false;
+      m_chapters.clear();
+    }
+    m_chaptersLoaded = true;
+    // Close file after chapter read to free buffers for rendering
+    closeFile();
   }
-  info = m_pageTable[pageIndex];
-  return true;
+  return m_chapters;
 }
+
+bool XtcParser::getPageInfo(uint32_t pageIndex, PageInfo& info) { return readPageTableEntry(pageIndex, info); }
 
 size_t XtcParser::loadPage(uint32_t pageIndex, uint8_t* buffer, size_t bufferSize) {
   if (!m_isOpen) {
@@ -328,7 +390,16 @@ size_t XtcParser::loadPage(uint32_t pageIndex, uint8_t* buffer, size_t bufferSiz
     return 0;
   }
 
-  const PageInfo& page = m_pageTable[pageIndex];
+  PageInfo page;
+  if (!readPageTableEntry(pageIndex, page)) {
+    m_lastError = XtcError::READ_ERROR;
+    return 0;
+  }
+
+  if (!ensureFileOpen()) {
+    m_lastError = XtcError::FILE_NOT_FOUND;
+    return 0;
+  }
 
   // Seek to page data
   if (!m_file.seek(page.offset)) {
@@ -396,7 +467,14 @@ XtcError XtcParser::loadPageStreaming(uint32_t pageIndex,
     return XtcError::PAGE_OUT_OF_RANGE;
   }
 
-  const PageInfo& page = m_pageTable[pageIndex];
+  PageInfo page;
+  if (!readPageTableEntry(pageIndex, page)) {
+    return XtcError::READ_ERROR;
+  }
+
+  if (!ensureFileOpen()) {
+    return XtcError::FILE_NOT_FOUND;
+  }
 
   // Seek to page data
   if (!m_file.seek(page.offset)) {

--- a/lib/Xtc/Xtc/XtcParser.h
+++ b/lib/Xtc/Xtc/XtcParser.h
@@ -23,6 +23,9 @@ namespace xtc {
  *
  * Reads XTC files from SD card and extracts page data.
  * Designed for ESP32-C3's limited RAM (~380KB) using streaming.
+ *
+ * The source file is kept closed between reads to free heap for rendering.
+ * It is reopened on-demand for page table lookups and bitmap data reads.
  */
 class XtcParser {
  public:
@@ -42,7 +45,7 @@ class XtcParser {
   uint8_t getBitDepth() const { return m_bitDepth; }  // 1 = XTC/XTG, 2 = XTCH/XTH
 
   // Page information
-  bool getPageInfo(uint32_t pageIndex, PageInfo& info) const;
+  bool getPageInfo(uint32_t pageIndex, PageInfo& info);
 
   /**
    * Load page bitmap (raw 1-bit data, skipping XTG header)
@@ -72,7 +75,7 @@ class XtcParser {
   std::string getAuthor() const { return m_author; }
 
   bool hasChapters() const { return m_hasChapters; }
-  const std::vector<ChapterInfo>& getChapters() const { return m_chapters; }
+  const std::vector<ChapterInfo>& getChapters();
 
   // Validation
   static bool isValidXtcFile(const char* filepath);
@@ -82,9 +85,9 @@ class XtcParser {
 
  private:
   FsFile m_file;
+  std::string m_filepath;
   bool m_isOpen;
   XtcHeader m_header;
-  std::vector<PageInfo> m_pageTable;
   std::vector<ChapterInfo> m_chapters;
   std::string m_title;
   std::string m_author;
@@ -92,14 +95,20 @@ class XtcParser {
   uint16_t m_defaultHeight;
   uint8_t m_bitDepth;  // 1 = XTC/XTG (1-bit), 2 = XTCH/XTH (2-bit)
   bool m_hasChapters;
+  bool m_chaptersLoaded;
   XtcError m_lastError;
 
   // Internal helper functions
   XtcError readHeader();
-  XtcError readPageTable();
+  XtcError readFirstPageInfo();
   XtcError readTitle();
   XtcError readAuthor();
   XtcError readChapters();
+  bool readPageTableEntry(uint32_t pageIndex, PageInfo& info);
+
+  // File handle management — reopen on demand, close after use
+  bool ensureFileOpen();
+  void closeFile();
 };
 
 }  // namespace xtc

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -86,7 +86,14 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
 
 int HalPowerManager::getBatteryPercentage() const {
   static const BatteryMonitor battery = BatteryMonitor(BAT_GPIO0);
-  return battery.readPercentage();
+
+  // smooth the battery %.
+  if (_batteryCachedPercent == 0) {
+    _batteryCachedPercent = 10 * battery.readPercentage();
+  } else {
+    _batteryCachedPercent = (_batteryCachedPercent * 9 + battery.readPercentage() * 10) / 10;
+  }
+  return _batteryCachedPercent / 10;
 }
 
 HalPowerManager::Lock::Lock() {

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -20,6 +20,9 @@ class HalPowerManager {
   LockMode currentLockMode = None;
   SemaphoreHandle_t modeMutex = nullptr;  // Protect access to currentLockMode
 
+  // EMA-smoothed battery percent, scaled x10 (0 = uninitialised)
+  mutable int _batteryCachedPercent = 0;
+
  public:
   static constexpr int LOW_POWER_FREQ = 10;                    // MHz
   static constexpr unsigned long IDLE_POWER_SAVING_MS = 3000;  // ms

--- a/platformio.ini
+++ b/platformio.ini
@@ -58,6 +58,7 @@ board_build.partitions = partitions.csv
 extra_scripts =
   pre:scripts/build_html.py
   pre:scripts/gen_i18n.py
+  pre:scripts/patch_jpegdec.py
 
 ; Libraries
 lib_deps =

--- a/scripts/patch_jpegdec.py
+++ b/scripts/patch_jpegdec.py
@@ -1,0 +1,68 @@
+"""
+PlatformIO pre-build script: patch JPEGDEC for MCU_SKIP wild pointer crash.
+
+Problem:
+  JPEGDecodeMCU_P computes pMCU = &sMCUs[iMCU & 0xffffff].  When iMCU is
+  MCU_SKIP (-8), the bitmask produces index 0xFFFFF8 (16 777 208), creating a
+  pointer ~33 MB past the 392-entry sMCUs array.  If the progressive JPEG's
+  first scan includes AC coefficients (iScanEnd > 0), the AC decode loop writes
+  through this wild pointer and crashes with a store-access fault.
+
+  Upstream commit 8628297 guarded the DC coefficient write (pMCU[0]) but not the
+  AC coefficient writes at indices 1-63.
+
+Fix:
+  Redirect pMCU to sMCUs[0] when MCU_SKIP is active.  Writes to sMCUs[1..63]
+  are harmless: for JPEG_SCALE_EIGHTH only sMCUs[0] is read for output, and
+  the DC write at sMCUs[0] is already guarded by the existing `if (iMCU >= 0)`
+  check.
+
+Applied idempotently — safe to run on every build.
+"""
+
+Import("env")
+import os
+
+
+def patch_jpegdec(env):
+    libdeps_dir = os.path.join(env["PROJECT_DIR"], ".pio", "libdeps")
+    if not os.path.isdir(libdeps_dir):
+        return
+    for env_dir in os.listdir(libdeps_dir):
+        jpeg_inl = os.path.join(libdeps_dir, env_dir, "JPEGDEC", "src", "jpeg.inl")
+        if os.path.isfile(jpeg_inl):
+            _apply_mcu_skip_pointer_fix(jpeg_inl)
+
+
+def _apply_mcu_skip_pointer_fix(filepath):
+    MARKER = "// CrossPoint patch: safe pMCU for MCU_SKIP"
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    if MARKER in content:
+        return  # already patched
+
+    # The wild-pointer line in JPEGDecodeMCU_P:
+    OLD = "    signed short *pMCU = &pJPEG->sMCUs[iMCU & 0xffffff];"
+
+    NEW = (
+        "    " + MARKER + "\n"
+        "    signed short *pMCU = (iMCU < 0) ? pJPEG->sMCUs\n"
+        "                                     : &pJPEG->sMCUs[iMCU & 0xffffff];"
+    )
+
+    if OLD not in content:
+        print(
+            "WARNING: JPEGDEC MCU_SKIP pointer patch target not found in %s "
+            "— library may have been updated" % filepath
+        )
+        return
+
+    content = content.replace(OLD, NEW, 1)
+    with open(filepath, "w") as f:
+        f.write(content)
+    print("Patched JPEGDEC: safe pMCU for MCU_SKIP in JPEGDecodeMCU_P: %s" % filepath)
+
+
+# Run immediately at script import time (before compilation).
+patch_jpegdec(env)


### PR DESCRIPTION
## Summary

Cherry-picks 3 upstream commits (heap + HAL fixes). Built clean on `default` env. Not yet flash-tested.

- `8735040` fix: Wild pointer crash in JPEGDEC MCU_SKIP handling (#1627) — patches JPEGDEC at build time via new `scripts/patch_jpegdec.py`. Fixes wild-pointer crash on progressive JPEGs (cover art).
- `ca1c8f7` feat: smooth battery percentage for x4 (#1635) — EMA smoothing on battery %, 10-line patch in `HalPowerManager`. Adds `mutable int _batteryCachedPercent` member.
- `32411f9` fix: boot looping when opening large XTC files (#1648) — XTC parser switched from in-RAM page table (`vector::resize`) to streaming-from-disk lookups. Unbricks 4000+ page XTC books on ESP32-C3.

## Risk
- JPEGDEC: very low (build-time patch, no source touch)
- Battery: low (cosmetic smoothing)
- XTC: medium (page seek now hits SD on every lookup; slower on huge XTCs but no longer OOMs)

## Test plan
- [ ] Flash `debug` build, capture serial
- [ ] Open library — confirm cover art renders without crashes
- [ ] Open large XTC (>3000 pages) — confirm no boot loop, page seek responsive
- [ ] Watch battery % over an hour — confirm no jitter, slow drift only
- [ ] Verify RAM/Flash budget unchanged: 54.3% / 92.5%

## Build status
RAM: 54.3% (177772 / 327680)
Flash: 92.5% (6060374 / 6553600)