### PR TITLE
Upstream picks batch 2: reader/footnote fixes

### DIFF
--- a/lib/Epub/Epub/FootnoteEntry.h
+++ b/lib/Epub/Epub/FootnoteEntry.h
@@ -2,9 +2,12 @@
 
 #include <cstring>
 
+#define FOOTNOTE_NUMBER_LEN 32
+#define FOOTNOTE_HREF_LEN 96
+
 struct FootnoteEntry {
-  char number[24];
-  char href[64];
+  char number[FOOTNOTE_NUMBER_LEN];
+  char href[FOOTNOTE_HREF_LEN];
 
   FootnoteEntry() {
     number[0] = '\0';

--- a/lib/Epub/Epub/blocks/BlockStyle.h
+++ b/lib/Epub/Epub/blocks/BlockStyle.h
@@ -9,6 +9,12 @@
  * BlockStyle - Block-level styling properties
  */
 struct BlockStyle {
+  // Upper bound (in em) for any single side's horizontal margin or padding.
+  // Some EPUBs apply huge em-based insets to chapter-opener classes; without a
+  // cap, effectiveWidth collapses to 1-2 words per line and justification dumps
+  // the remaining space into a single gap.
+  static constexpr float MAX_HORIZONTAL_INSET_EM = 2.0f;
+
   CssTextAlign alignment = CssTextAlign::Justify;
 
   // Spacing (in pixels)
@@ -102,16 +108,17 @@ struct BlockStyle {
                                  const uint16_t viewportWidth = 0) {
     BlockStyle blockStyle;
     const float vw = viewportWidth;
+    const auto maxHorizontalInsetPx = static_cast<int16_t>(emSize * MAX_HORIZONTAL_INSET_EM);
     // Resolve all CssLength values to pixels using the current font's em size and viewport width
     blockStyle.marginTop = cssStyle.marginTop.toPixelsInt16(emSize, vw);
     blockStyle.marginBottom = cssStyle.marginBottom.toPixelsInt16(emSize, vw);
-    blockStyle.marginLeft = cssStyle.marginLeft.toPixelsInt16(emSize, vw);
-    blockStyle.marginRight = cssStyle.marginRight.toPixelsInt16(emSize, vw);
+    blockStyle.marginLeft = std::min(cssStyle.marginLeft.toPixelsInt16(emSize, vw), maxHorizontalInsetPx);
+    blockStyle.marginRight = std::min(cssStyle.marginRight.toPixelsInt16(emSize, vw), maxHorizontalInsetPx);
 
     blockStyle.paddingTop = cssStyle.paddingTop.toPixelsInt16(emSize, vw);
     blockStyle.paddingBottom = cssStyle.paddingBottom.toPixelsInt16(emSize, vw);
-    blockStyle.paddingLeft = cssStyle.paddingLeft.toPixelsInt16(emSize, vw);
-    blockStyle.paddingRight = cssStyle.paddingRight.toPixelsInt16(emSize, vw);
+    blockStyle.paddingLeft = std::min(cssStyle.paddingLeft.toPixelsInt16(emSize, vw), maxHorizontalInsetPx);
+    blockStyle.paddingRight = std::min(cssStyle.paddingRight.toPixelsInt16(emSize, vw), maxHorizontalInsetPx);
 
     // For textIndent: if it's a percentage we can't resolve (no viewport width),
     // leave textIndentDefined=false so the EmSpace fallback in applyParagraphIndent() is used

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -623,14 +623,29 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
   // Collect footnote link display text (for the number label)
   // Skip whitespace and brackets to normalize noterefs like "[1]" → "1"
   if (self->insideFootnoteLink) {
-    for (int i = 0; i < len; i++) {
-      unsigned char c = static_cast<unsigned char>(s[i]);
-      if (isWhitespace(c) || c == '[' || c == ']') continue;
-      if (self->currentFootnoteLinkTextLen < static_cast<int>(sizeof(self->currentFootnoteLinkText)) - 1) {
-        self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen++] = c;
-        self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen] = '\0';
-      }
+    int start = 0;
+    int end = len - 1;
+
+    // Example input and output texts:
+    // "     [  12  ]   " => "12"
+    // "   turn to 256  " => "turn to 256"
+
+    // Ignore leading whitespaces and left square brackets
+    while (start < len && (isWhitespace(s[start]) || (s[start] == '['))) {
+      ++start;
     }
+
+    // Ignore trailing whitespaces and right square brackets
+    while (end >= start && (isWhitespace(s[end]) || (s[end] == ']'))) {
+      --end;
+    }
+
+    // Extract footnote link text
+    for (int i = start; (self->currentFootnoteLinkTextLen < sizeof(self->currentFootnoteLinkText) - 1) && (i <= end);
+         ++i) {
+      self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen++] = s[i];
+    }
+    self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen] = '\0';
   }
 
   for (int i = 0; i < len; i++) {

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -440,9 +440,9 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       }
       self->insideFootnoteLink = true;
       self->footnoteLinkDepth = self->depth;
-      strncpy(self->currentFootnoteLinkHref, href, sizeof(self->currentFootnoteLinkHref) - 1);
-      self->currentFootnoteLinkHref[sizeof(self->currentFootnoteLinkHref) - 1] = '\0';
-      self->currentFootnoteLinkText[0] = '\0';
+      strncpy(self->currentFootnote.href, href, sizeof(self->currentFootnote.href) - 1);
+      self->currentFootnote.href[sizeof(self->currentFootnote.href) - 1] = '\0';
+      self->currentFootnote.number[0] = '\0';
       self->currentFootnoteLinkTextLen = 0;
 
       // Apply underline style to visually indicate the link
@@ -641,11 +641,11 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
     }
 
     // Extract footnote link text
-    for (int i = start; (self->currentFootnoteLinkTextLen < sizeof(self->currentFootnoteLinkText) - 1) && (i <= end);
+    for (int i = start; (self->currentFootnoteLinkTextLen < sizeof(self->currentFootnote.number) - 1) && (i <= end);
          ++i) {
-      self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen++] = s[i];
+      self->currentFootnote.number[self->currentFootnoteLinkTextLen++] = s[i];
     }
-    self->currentFootnoteLinkText[self->currentFootnoteLinkTextLen] = '\0';
+    self->currentFootnote.number[self->currentFootnoteLinkTextLen] = '\0';
   }
 
   for (int i = 0; i < len; i++) {
@@ -774,11 +774,11 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
 
   // Closing a footnote link — create entry from collected text and href
   if (self->insideFootnoteLink && self->depth == self->footnoteLinkDepth) {
-    if (self->currentFootnoteLinkText[0] != '\0' && self->currentFootnoteLinkHref[0] != '\0') {
+    if (self->currentFootnote.number[0] != '\0' && self->currentFootnote.href[0] != '\0') {
       FootnoteEntry entry;
-      strncpy(entry.number, self->currentFootnoteLinkText, sizeof(entry.number) - 1);
+      strncpy(entry.number, self->currentFootnote.number, sizeof(entry.number) - 1);
       entry.number[sizeof(entry.number) - 1] = '\0';
-      strncpy(entry.href, self->currentFootnoteLinkHref, sizeof(entry.href) - 1);
+      strncpy(entry.href, self->currentFootnote.href, sizeof(entry.href) - 1);
       entry.href[sizeof(entry.href) - 1] = '\0';
       int wordIndex =
           self->wordsExtractedInBlock + (self->currentTextBlock ? static_cast<int>(self->currentTextBlock->size()) : 0);

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -82,9 +82,8 @@ class ChapterHtmlSlimParser {
   // Footnote link tracking
   bool insideFootnoteLink = false;
   int footnoteLinkDepth = -1;
-  char currentFootnoteLinkText[24] = {};
+  FootnoteEntry currentFootnote = {};
   int currentFootnoteLinkTextLen = 0;
-  char currentFootnoteLinkHref[64] = {};
   std::vector<std::pair<int, FootnoteEntry>> pendingFootnotes;  // <wordIndex, entry>
   int wordsExtractedInBlock = 0;
 


### PR DESCRIPTION
## Summary

Cherry-picks 3 upstream reader fixes. Built clean on `default` env. Not yet flash-tested.

- `05e4dc5` fix: cap per-side horizontal CSS inset at 2em (#1694) — prevents pathological CSS margins/paddings from collapsing reader columns.
- `ba9684e` fix: footnote link text (#1666) — parser now captures footnote anchor text correctly.
- `7dcf075` fix: Erroneous navigation with long filenames in footnote links (#1723) — `FootnoteEntry` href buffer 64 → 96 chars, number 24 → 32. Kept our `SECTION_FILE_VERSION = 22` (no v21 regression).

## Risk
- CSS inset: low (1 file, layout cap)
- Footnote text: low (parser only)
- Footnote long-filename: low-medium (in-memory FootnoteEntry size grew ~40 B per entry × 16 max = ~600 B static; section cache version untouched)

## Skipped during attempt
- `5c12f2f` chapter-skip after screenshot — already present in our tree (mapped-input variant)
- `e28918b` plural file/folder counts — would lose i18n, needs new translation keys instead
- `8154f88` already taken above

## Test plan
- [ ] Flash debug, capture serial
- [ ] Open EPUB with long footnote filenames (e.g. *Sacred and Terrible Air*) — confirm footnote nav lands correctly
- [ ] Open EPUB with deep nested CSS — confirm columns not collapsed
- [ ] Tap footnote link — confirm text rendered

## Build status
RAM: 54.2%
Flash: 92.5%