### PR TITLE
Upstream picks batch 3: footnote orientation

### DIFF
--- a/src/activities/reader/EpubReaderFootnotesActivity.cpp
+++ b/src/activities/reader/EpubReaderFootnotesActivity.cpp
@@ -53,27 +53,43 @@ void EpubReaderFootnotesActivity::loop() {
 void EpubReaderFootnotesActivity::render(Activity::RenderLock&&) {
   renderer.clearScreen();
 
-  renderer.drawCenteredText(UI_12_FONT_ID, 15, tr(STR_FOOTNOTES), true, EpdFontFamily::BOLD);
+  const auto pageWidth = renderer.getScreenWidth();
+  const auto orientation = renderer.getOrientation();
+  // Landscape orientation: reserve a horizontal gutter for button hints.
+  const bool isLandscapeCw = orientation == GfxRenderer::Orientation::LandscapeClockwise;
+  const bool isLandscapeCcw = orientation == GfxRenderer::Orientation::LandscapeCounterClockwise;
+  // Inverted portrait: reserve vertical space for hints at the top.
+  const bool isPortraitInverted = orientation == GfxRenderer::Orientation::PortraitInverted;
+  const int hintGutterWidth = (isLandscapeCw || isLandscapeCcw) ? 30 : 0;
+  // Landscape CW places hints on the left edge; CCW keeps them on the right.
+  const int contentX = isLandscapeCw ? hintGutterWidth : 0;
+  const int contentWidth = pageWidth - hintGutterWidth;
+  const int hintGutterHeight = isPortraitInverted ? 50 : 0;
+  const int contentY = hintGutterHeight;
+
+  // Manual centering to honor content gutters.
+  const int titleX =
+      contentX + (contentWidth - renderer.getTextWidth(UI_12_FONT_ID, tr(STR_FOOTNOTES), EpdFontFamily::BOLD)) / 2;
+  renderer.drawText(UI_12_FONT_ID, titleX, 15 + contentY, tr(STR_FOOTNOTES), true, EpdFontFamily::BOLD);
 
   if (footnotes.empty()) {
-    renderer.drawCenteredText(UI_10_FONT_ID, 90, tr(STR_NO_FOOTNOTES));
+    renderer.drawCenteredText(UI_10_FONT_ID, 90 + contentY, tr(STR_NO_FOOTNOTES));
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
     renderer.displayBuffer();
     return;
   }
 
-  constexpr int startY = 50;
   constexpr int lineHeight = 36;
   const int screenWidth = renderer.getScreenWidth();
-  constexpr int marginLeft = 20;
+  const int marginLeft = contentX + 20;
 
-  const int visibleCount = std::max(1, (renderer.getScreenHeight() - startY) / lineHeight);
+  const int visibleCount = std::max(1, (renderer.getScreenHeight() - contentY) / lineHeight);
   if (selectedIndex < scrollOffset) scrollOffset = selectedIndex;
   if (selectedIndex >= scrollOffset + visibleCount) scrollOffset = selectedIndex - visibleCount + 1;
 
   for (int i = scrollOffset; i < static_cast<int>(footnotes.size()) && i < scrollOffset + visibleCount; i++) {
-    const int y = startY + (i - scrollOffset) * lineHeight;
+    const int y = 60 + contentY + (i - scrollOffset) * lineHeight;
     const bool isSelected = (i == selectedIndex);
 
     if (isSelected) {


### PR DESCRIPTION
## Summary

Single upstream cherry-pick. Most batch-3 candidates had to be skipped due to fork divergence.

- `47551ce` fix: make footnotes consider orientation for gutters (#1665) — footnote viewer now reads the correct margin set when device is rotated.

## Skipped (fork drift too large for clean cherry-pick — would need real port)
- `64f5ef0` proportional numeral spacing — massive Bookerly font header diff, our font pipeline is different
- `075ad7d` combining-mark positioning — 6 conflicts in `GfxRenderer.cpp` (heavy local custom-font work)
- `4e9c7a7` full path bar in file browser — `UITheme.cpp/h` deleted in our fork (refactored to `themes/`)
- `907e14d` space cursor fix — `KeyboardEntryActivity` uses different APIs locally (`UI_10_FONT_ID`, no `getTextAdvanceX`)
- `1a145fe` keyboard feedback — references `Lyra3CoversTheme.h` / `LyraTheme.cpp` which we deleted
- `198b9d7` swedish translations — yaml diverged
- `14ec53a` slovenian translation — already in our tree

## Risk
Low. 1 file, footnote viewer only.

## Test plan
- [ ] Flash debug
- [ ] Open footnote in landscape, then rotate to portrait — confirm gutter respects orientation

## Build status
RAM/Flash unchanged from main.