### PR TITLE
feat: port upstream OTA streaming JSON + wifi self-heal (#1810, #1780)

### DIFF
--- a/docs/PR-PLAN-ota-wifi-buttons.md
+++ b/docs/PR-PLAN-ota-wifi-buttons.md
@@ -1,0 +1,191 @@
+# PR Plan — Upstream OTA/WiFi Port + Button Detection Investigation
+
+## Scope
+
+Two related but independent workstreams bundled into one tracking doc:
+
+1. **Upstream port** (branch `port/upstream-ota-wifi`, already pushed) — three high-value upstream commits adapted for DX34. Ready for review/flash once smoke-tested.
+2. **Button detection flakiness investigation** — root-cause investigation for intermittent button miss-detection. Evidence-gathering phase, no code change yet.
+
+---
+
+## Workstream 1 — `port/upstream-ota-wifi`
+
+### Branch
+`port/upstream-ota-wifi` → 2 commits ahead of `main`.
+
+### Commits ported
+
+#### 1. `25157e4f` — `fix: Read GH release JSON as stream in OTA updater (#1810)` (upstream `aa7a31b3`)
+
+**Problem upstream solved:** `/releases/latest` JSON ballooned past ~30 KB once release notes grew. Single-buffer ArduinoJson parse on ESP32-C3 ran out of heap → OTA check failure.
+
+**What landed:**
+- New `lib/JsonParser/StreamingJsonParser.{h,cpp}` — SAX-style incremental parser.
+- New `lib/JsonParser/ReleaseJsonParser.{h,cpp}` — release-JSON-specific extractor (tag, firmware URL, size).
+- `OtaUpdater::checkForUpdate()` rewritten to feed HTTP chunks into the streaming parser, drop ArduinoJson dependency, drop `local_buf` cleanup struct.
+- Host unit tests for both parsers under `test/streaming_json_parser/` and `test/release_json_parser/` plus `run_*.sh` runners.
+
+**DX34 adaptations preserved:**
+- DX34 release URL (`diogo7dias/crosspoint-reader-DX34`).
+- `CrossPoint-Mod-DX34-ESP32-` user-agent.
+- `findSemverStart()` for `DX34-x.y.z` tag parsing.
+- HTTP status-code check (`403/429 → RATE_LIMITED`, non-200 → `HTTP_ERROR`).
+- `extern "C" esp_crt_bundle_attach` arduino-platform workaround retained (upstream switched to `<esp_crt_bundle.h>` include; DX34 toolchain may be older).
+- `installUpdate(std::function<void()>)` callback kept (DX34's prior cleanup vs upstream's `void(*)(void*) + ctx`).
+
+#### 2. `82e69c54` — `feat: self-heal from transient WiFi loss, add dBm indicator during WebServerActivity (#1780)` (upstream `adcd7961`)
+
+**Problem upstream solved:** Brief router/STA blips kicked the file-transfer activity into `SHUTTING_DOWN` and left it hung. No on-device signal-strength readout — required serial.
+
+**What landed:**
+- WiFi state machine in `CrossPointWebServerActivity::loop()`: `consecutiveDisconnects` counter + `firstDisconnectAt` timestamp; activity stays alive while driver retries; only abandons (returns to network selection) after `WIFI_ABANDON_MS = 5 min`.
+- 4-bar dBm indicator drawn top-right via `renderWifiIndicator(int subHeaderTop)`. Hysteresis (`barsForRssi`) avoids rapid screen redraw at threshold boundaries.
+- Periodic RSSI logging when `< -75 dBm`.
+
+**DX34 adaptations:**
+- DX34 has no `UITheme::getInstance().getMetrics()` struct → `renderWifiIndicator` rewritten with hardcoded layout constants (`CONTENT_SIDE_PADDING = 12`, anchored to title row at `y=15`).
+- DX34 has `onGoBack` (not upstream's `onGoHome`) → switched.
+- DX34's existing "Reconnecting to Wi-Fi…" banner kept; condition switched from old `wifiDropped` flag to `consecutiveDisconnects > 0`.
+- DX34's STA-only `WiFi.setAutoReconnect(true)` + heap diag log preserved in `CrossPointWebServer.cpp` (upstream made it unconditional and dropped the diag).
+
+#### 3. `ba4a361d` — `fix: OTA on x3 and progress bar on x4 and x3 (#1805)` — **SKIPPED**
+
+Reason: X3-specific (`skip_efuse_blk_check.c` + `bootloader_common_check_efuse_blk_validity` linker wrap). Remaining changes refactor the OTA progress callback API in the opposite direction from DX34's existing `std::function` migration. Net value for DX34: a small UX win (3-second hold on the "Update complete" screen before shutdown). Document as a candidate for separate later port if users report flashing-completion UX.
+
+#### 4. `5717374e` — `feat(update): SD-card firmware update + X3 bootloader compatibility (#1786)` — **PARKED**
+
+Too large for this PR (928 insertions, 13 files, new `SdFirmwareUpdateActivity`, `FirmwareFlasher`, `OtaBootSwitch`). Strip X3 bootloader compatibility, keep SD update path. Track separately.
+
+### Risk surface
+
+| Area | Likelihood of regression | Mitigation |
+|---|---|---|
+| OTA check (release JSON) | Low — new parser has unit tests, DX34 release shape matches assumption (`tag_name`, `assets[].name == "firmware.bin"`, `browser_download_url`, `size`) | Smoke test: trigger update check on device, confirm tag + URL parsed correctly |
+| OTA install (binary download) | None — `installUpdate()` untouched | n/a |
+| WiFi self-heal | Medium — new state machine; abandon timeout 5 min may surprise users on flaky networks | Smoke test: connect, kill router for 30 s, restore — should auto-recover; kill router for 6 min — should return to network selection |
+| dBm indicator | Low — pure render addition, hardcoded layout may collide with existing top-right elements on STA mode | Visual check on real screen for both AP and STA modes |
+| Heap diag log retained | None | n/a |
+
+### Smoke-test plan (pre-merge)
+
+| Test | Action | Pass criterion |
+|---|---|---|
+| Build | `pio run` | Compiles, links, no new warnings |
+| OTA check warm | Settings → check for update | Toast shows current vs latest; no crash; serial shows `OTA: Found update: tag=… size=…` |
+| OTA check rate-limited | Hammer endpoint to provoke 403/429 | Returns `RATE_LIMITED`, no crash |
+| WiFi blip recovery | Start file-transfer, power-cycle router for ≤30 s | Banner appears, clears on reconnect, IP refreshed |
+| WiFi sustained loss | Start file-transfer, kill router for ≥6 min | Activity exits cleanly to network selection |
+| dBm indicator | Connect at varying distances | Bars track signal, no flicker at threshold |
+| Memory | Free heap before/after OTA check | No regression vs current main |
+
+### Merge strategy
+
+Rebase + FF onto `main` after smoke tests pass (matches existing `(#NN)` linear history).
+
+---
+
+## Workstream 2 — Button detection flakiness
+
+### Symptom
+User reports buttons "not always detected." Intermittent miss-detection. Suspect either firmware or device.
+
+### Verdict so far: **mostly firmware, with hardware contributing**
+
+### Architecture (relevant facts)
+- 6 directional buttons share **2 ADC pins** (GPIO1, GPIO2) via resistor ladder. Each button presents a distinct voltage.
+- Power button on GPIO3 — digital, active LOW, **also a strapping pin** (boot-mode select; affects boot only, not runtime).
+- All input handling lives in submodule `open-x4-sdk` (fork: `diogo7dias/community-sdk`), `libs/hardware/InputManager/src/InputManager.cpp`. Unmodified from upstream-baseline.
+- `InputManager::getState()` takes **one** `analogRead()` per pin per call.
+- `InputManager::update()` invoked once per `loop()` iteration in `src/main.cpp:967`.
+- `DEBOUNCE_DELAY = 5 ms` (`InputManager.h:112`) — must remain stable for >5 ms before commit.
+- ADC quiescent threshold `ADC_NO_BUTTON = 3800`; ranges have generous margins vs recorded values. Boundary collision unlikely under nominal noise.
+
+### Suspect ranking
+
+| # | Hypothesis | Likelihood | Why |
+|---|---|---|---|
+| 1 | No ADC oversampling + 5 ms debounce too short for ESP32-C3 noise | **High** | ESP32-C3 ADC has ±50-100 LSB jitter; single sample at edges of resistor-ladder window can land in wrong bucket; flickering reads keep resetting `lastDebounceTime` so press never commits |
+| 2 | Variable loop cadence | **Medium-High** | `gpio.update()` ticks once per main loop. Heavy frames (EPD redraw, file I/O, OTA, large JSON) push iteration to 100-300 ms. Tap shorter than that is lost outright. Existing commit `4a210823 "Manually trigger GPIO update in File Browser mode"` is prior evidence this category has bitten DX34 before |
+| 3 | Power button strapping-pin interference (GPIO3) | Low | Boot-time only; does not explain runtime flakiness |
+| 4 | Mechanical contact wear / device defect | Low | Cannot rule out without per-button stats; but same SDK serves many devices, so widespread firmware issue more likely than per-device hardware |
+
+### Pre-fix evidence to gather (Phase 1)
+
+Goal: distinguish hypothesis 1 vs 2 vs 4 before changing anything. Three artifacts to add temporarily, then revert after capture.
+
+#### Probe A — Raw ADC trace
+Add to `InputManager::update()` (open-x4-sdk fork):
+```cpp
+#if BUTTON_DEBUG_TRACE
+static unsigned long lastTrace = 0;
+const unsigned long now = millis();
+if (now - lastTrace >= 20) {  // 50 Hz max
+  Serial.printf("[BTN] adc1=%4d adc2=%4d gpio3=%d state=0x%02X commit=0x%02X dt=%lums\n",
+                adcValue1, adcValue2, digitalRead(POWER_BUTTON_PIN),
+                state, currentState, now - lastTrace);
+  lastTrace = now;
+}
+#endif
+```
+Build with `-DBUTTON_DEBUG_TRACE=1`. Run device, attach serial, press each button 5×, capture log.
+
+**Reads from log:**
+- Spread of `adc1`/`adc2` while button held → ADC noise envelope.
+- Bucket flips during a single press → confirms hypothesis 1.
+- `dt` consistently > 50 ms with missed presses → confirms hypothesis 2.
+- Clean stable reads but `state` wrong → device-side ladder voltage off (hypothesis 4).
+
+#### Probe B — Update cadence histogram
+Counters in `InputManager::update()`:
+```cpp
+#if BUTTON_DEBUG_CADENCE
+static uint16_t buckets[8] = {0};  // <10ms, 10-20, 20-50, 50-100, 100-200, 200-500, 500-1000, >1000
+static unsigned long lastUpdate = 0;
+static unsigned long lastReport = 0;
+const unsigned long dt = millis() - lastUpdate;
+lastUpdate = millis();
+int b = (dt < 10) ? 0 : (dt < 20) ? 1 : (dt < 50) ? 2 : (dt < 100) ? 3
+      : (dt < 200) ? 4 : (dt < 500) ? 5 : (dt < 1000) ? 6 : 7;
+buckets[b]++;
+if (millis() - lastReport > 5000) {
+  Serial.printf("[BTN-CADENCE] <10:%u 10-20:%u 20-50:%u 50-100:%u 100-200:%u 200-500:%u 500-1k:%u >1k:%u\n",
+                buckets[0],buckets[1],buckets[2],buckets[3],buckets[4],buckets[5],buckets[6],buckets[7]);
+  lastReport = millis();
+}
+#endif
+```
+
+**Reads from log:**
+- Mass below 50 ms → cadence is fine, hypothesis 2 demoted.
+- Tail in 100-500 ms during reading/transfer → confirms hypothesis 2.
+
+#### Probe C — Press counter (user-driven)
+Hold one button (say BACK) and press exactly **20 times** at ~1 Hz. Log `wasPressed(BACK)` count. If <20, miss rate quantified per session. Repeat for each button.
+
+### Decision tree after evidence
+
+| Evidence pattern | Hypothesis confirmed | Fix |
+|---|---|---|
+| Probe A shows bucket flips during press | #1 (ADC noise) | Add 8× oversample (mean) + raise `DEBOUNCE_DELAY` to 15 ms |
+| Probe B histogram has fat 100-500 ms tail during heavy frames | #2 (cadence) | Add `gpio.update()` calls inside long-running activities; consider FreeRTOS task for input polling |
+| Probe A clean, Probe C miss rate > 0 only on specific button | #4 (hardware) | Per-button calibration / replace device |
+| Probe A shows quiescent `adc1/adc2` drift toward thresholds | sub-#1 (component drift) | Recalibrate `ADC_RANGES_*` |
+
+Fixes #1 and #2 are independent and complementary. Likely both are partially true.
+
+### Out of scope for this PR
+Actual fixes are deferred until after evidence capture. This PR is the **port** PR. Button work tracked separately:
+- Branch (planned): `debug/button-detection-trace` for Probes A+B+C
+- Branch (planned): `fix/input-oversample-debounce` after evidence
+
+### Rollback
+Both port commits are isolated to OTA + WebServer activity files. Revert is a single `git revert` per commit if a regression surfaces post-merge.
+
+---
+
+## Open questions for reviewer
+
+1. Confirm DX34 release-asset name is exactly `firmware.bin` (ReleaseJsonParser only matches that string).
+2. Confirm `WIFI_ABANDON_MS = 5 min` is the desired UX (vs e.g. 2 min) before sending file-transfer back to network selection.
+3. Approve adding the `BUTTON_DEBUG_TRACE` build flag temporarily, or prefer a separate `debug/` branch with the probes always-on.

--- a/lib/JsonParser/ReleaseJsonParser.cpp
+++ b/lib/JsonParser/ReleaseJsonParser.cpp
@@ -1,0 +1,208 @@
+#include "ReleaseJsonParser.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+void safeCopy(char* dst, size_t dstSize, const char* src, size_t srcLen) {
+  size_t n = srcLen < dstSize - 1 ? srcLen : dstSize - 1;
+  memcpy(dst, src, n);
+  dst[n] = '\0';
+}
+
+}  // namespace
+
+ReleaseJsonParser::ReleaseJsonParser()
+    : parser(JsonCallbacks{this, sOnKey, sOnString, sOnNumber, sOnBool, sOnNull, sOnObjectStart, sOnObjectEnd,
+                           sOnArrayStart, sOnArrayEnd}) {
+  reset();
+}
+
+void ReleaseJsonParser::reset() {
+  parser.reset();
+  position = Position::TOP_LEVEL;
+  lastKey = LastKey::NONE;
+  depth = 0;
+  assetDepth = 0;
+  tagName[0] = '\0';
+  firmwareUrl[0] = '\0';
+  firmwareSize = 0;
+  tagFound = false;
+  firmwareFound = false;
+  currentAssetName[0] = '\0';
+  currentAssetUrl[0] = '\0';
+  currentAssetSize = 0;
+}
+
+void ReleaseJsonParser::feed(const char* data, size_t len) { parser.feed(data, len); }
+
+bool ReleaseJsonParser::foundTag() const { return tagFound; }
+bool ReleaseJsonParser::foundFirmware() const { return firmwareFound; }
+const char* ReleaseJsonParser::getTagName() const { return tagName; }
+const char* ReleaseJsonParser::getFirmwareUrl() const { return firmwareUrl; }
+size_t ReleaseJsonParser::getFirmwareSize() const { return firmwareSize; }
+
+void ReleaseJsonParser::commitAsset() {
+  if (strcmp(currentAssetName, "firmware.bin") == 0) {
+    memcpy(firmwareUrl, currentAssetUrl, sizeof(firmwareUrl));
+    firmwareSize = currentAssetSize;
+    firmwareFound = true;
+  }
+  currentAssetName[0] = '\0';
+  currentAssetUrl[0] = '\0';
+  currentAssetSize = 0;
+}
+
+// -- SAX callbacks (static trampolines) -------------------------------------
+
+void ReleaseJsonParser::sOnKey(void* ctx, const char* key, size_t len) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      if (self->depth == 1) {
+        if (len == 8 && memcmp(key, "tag_name", 8) == 0)
+          self->lastKey = LastKey::TAG_NAME;
+        else if (len == 6 && memcmp(key, "assets", 6) == 0)
+          self->lastKey = LastKey::ASSETS;
+        else
+          self->lastKey = LastKey::NONE;
+      }
+      break;
+    case Position::IN_ASSET_OBJECT:
+      if (self->assetDepth == 1) {
+        if (len == 4 && memcmp(key, "name", 4) == 0)
+          self->lastKey = LastKey::ASSET_NAME;
+        else if (len == 20 && memcmp(key, "browser_download_url", 20) == 0)
+          self->lastKey = LastKey::ASSET_URL;
+        else if (len == 4 && memcmp(key, "size", 4) == 0)
+          self->lastKey = LastKey::ASSET_SIZE;
+        else
+          self->lastKey = LastKey::NONE;
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+void ReleaseJsonParser::sOnString(void* ctx, const char* value, size_t len) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->lastKey) {
+    case LastKey::TAG_NAME:
+      if (self->position == Position::TOP_LEVEL && self->depth == 1) {
+        safeCopy(self->tagName, sizeof(self->tagName), value, len);
+        self->tagFound = true;
+      }
+      break;
+    case LastKey::ASSET_NAME:
+      if (self->position == Position::IN_ASSET_OBJECT && self->assetDepth == 1)
+        safeCopy(self->currentAssetName, sizeof(self->currentAssetName), value, len);
+      break;
+    case LastKey::ASSET_URL:
+      if (self->position == Position::IN_ASSET_OBJECT && self->assetDepth == 1)
+        safeCopy(self->currentAssetUrl, sizeof(self->currentAssetUrl), value, len);
+      break;
+    default:
+      break;
+  }
+  self->lastKey = LastKey::NONE;
+}
+
+void ReleaseJsonParser::sOnNumber(void* ctx, const char* value, size_t /*len*/) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  if (self->lastKey == LastKey::ASSET_SIZE && self->position == Position::IN_ASSET_OBJECT && self->assetDepth == 1) {
+    self->currentAssetSize = static_cast<size_t>(strtoul(value, nullptr, 10));
+  }
+  self->lastKey = LastKey::NONE;
+}
+
+void ReleaseJsonParser::sOnBool(void* ctx, bool /*value*/) {
+  static_cast<ReleaseJsonParser*>(ctx)->lastKey = LastKey::NONE;
+}
+
+void ReleaseJsonParser::sOnNull(void* ctx) { static_cast<ReleaseJsonParser*>(ctx)->lastKey = LastKey::NONE; }
+
+void ReleaseJsonParser::sOnObjectStart(void* ctx) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      self->depth++;
+      self->lastKey = LastKey::NONE;
+      break;
+    case Position::IN_ASSETS_ARRAY:
+      self->position = Position::IN_ASSET_OBJECT;
+      self->assetDepth = 1;
+      self->currentAssetName[0] = '\0';
+      self->currentAssetUrl[0] = '\0';
+      self->currentAssetSize = 0;
+      self->lastKey = LastKey::NONE;
+      break;
+    case Position::IN_ASSET_OBJECT:
+      self->assetDepth++;
+      self->lastKey = LastKey::NONE;
+      break;
+  }
+}
+
+void ReleaseJsonParser::sOnObjectEnd(void* ctx) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      if (self->depth > 0) self->depth--;
+      break;
+    case Position::IN_ASSET_OBJECT:
+      self->assetDepth--;
+      if (self->assetDepth == 0) {
+        self->commitAsset();
+        self->position = Position::IN_ASSETS_ARRAY;
+      }
+      self->lastKey = LastKey::NONE;
+      break;
+    default:
+      break;
+  }
+}
+
+void ReleaseJsonParser::sOnArrayStart(void* ctx) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      if (self->lastKey == LastKey::ASSETS && self->depth == 1) {
+        self->position = Position::IN_ASSETS_ARRAY;
+      } else {
+        self->depth++;
+      }
+      self->lastKey = LastKey::NONE;
+      break;
+    case Position::IN_ASSET_OBJECT:
+      self->assetDepth++;
+      self->lastKey = LastKey::NONE;
+      break;
+    default:
+      break;
+  }
+}
+
+void ReleaseJsonParser::sOnArrayEnd(void* ctx) {
+  auto* self = static_cast<ReleaseJsonParser*>(ctx);
+
+  switch (self->position) {
+    case Position::TOP_LEVEL:
+      if (self->depth > 0) self->depth--;
+      break;
+    case Position::IN_ASSETS_ARRAY:
+      self->position = Position::TOP_LEVEL;
+      break;
+    case Position::IN_ASSET_OBJECT:
+      self->assetDepth--;
+      self->lastKey = LastKey::NONE;
+      break;
+  }
+}

--- a/lib/JsonParser/ReleaseJsonParser.h
+++ b/lib/JsonParser/ReleaseJsonParser.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "StreamingJsonParser.h"
+
+class ReleaseJsonParser {
+ public:
+  ReleaseJsonParser();
+
+  ReleaseJsonParser(const ReleaseJsonParser&) = delete;
+  ReleaseJsonParser& operator=(const ReleaseJsonParser&) = delete;
+
+  void reset();
+  void feed(const char* data, size_t len);
+
+  bool foundTag() const;
+  bool foundFirmware() const;
+  const char* getTagName() const;
+  const char* getFirmwareUrl() const;
+  size_t getFirmwareSize() const;
+
+ private:
+  enum class Position : uint8_t {
+    TOP_LEVEL,
+    IN_ASSETS_ARRAY,
+    IN_ASSET_OBJECT,
+  };
+
+  enum class LastKey : uint8_t {
+    NONE,
+    TAG_NAME,
+    ASSETS,
+    ASSET_NAME,
+    ASSET_URL,
+    ASSET_SIZE,
+  };
+
+  static void sOnKey(void* ctx, const char* key, size_t len);
+  static void sOnString(void* ctx, const char* value, size_t len);
+  static void sOnNumber(void* ctx, const char* value, size_t len);
+  static void sOnBool(void* ctx, bool value);
+  static void sOnNull(void* ctx);
+  static void sOnObjectStart(void* ctx);
+  static void sOnObjectEnd(void* ctx);
+  static void sOnArrayStart(void* ctx);
+  static void sOnArrayEnd(void* ctx);
+
+  void commitAsset();
+
+  StreamingJsonParser parser;
+
+  Position position;
+  LastKey lastKey;
+  uint8_t depth;
+  uint8_t assetDepth;
+
+  char tagName[32];
+  char firmwareUrl[512];
+  size_t firmwareSize;
+  bool tagFound;
+  bool firmwareFound;
+
+  char currentAssetName[32];
+  char currentAssetUrl[512];
+  size_t currentAssetSize;
+};

--- a/lib/JsonParser/StreamingJsonParser.cpp
+++ b/lib/JsonParser/StreamingJsonParser.cpp
@@ -1,0 +1,249 @@
+#include "StreamingJsonParser.h"
+
+#include <cstring>
+
+StreamingJsonParser::StreamingJsonParser(const JsonCallbacks& callbacks) : cb(callbacks) { reset(); }
+
+void StreamingJsonParser::reset() {
+  tokenLen = 0;
+  state = State::SCANNING;
+  expectingValue = false;
+  escaped = false;
+  tokenOverflow = false;
+  error = false;
+  nestingDepth = 0;
+  literalLen = 0;
+  literalPos = 0;
+}
+
+void StreamingJsonParser::feed(const char* data, size_t len) {
+  for (size_t i = 0; i < len && !error; ++i) {
+    char c = data[i];
+    switch (state) {
+      case State::SCANNING:
+        handleScanning(c);
+        break;
+      case State::IN_STRING_KEY:
+      case State::IN_STRING_VALUE:
+        handleStringChar(c);
+        break;
+      case State::IN_NUMBER:
+        handleNumber(c);
+        break;
+      case State::IN_LITERAL:
+        handleLiteral(c);
+        break;
+      case State::SKIP_STRING:
+        handleSkipString(c);
+        break;
+    }
+  }
+}
+
+void StreamingJsonParser::handleScanning(char c) {
+  switch (c) {
+    case '"':
+      tokenLen = 0;
+      tokenOverflow = false;
+      if (expectingValue || inArray()) {
+        state = State::IN_STRING_VALUE;
+      } else {
+        state = State::IN_STRING_KEY;
+      }
+      break;
+    case '{':
+      if (nestingDepth < MAX_NESTING) {
+        nestingStack[nestingDepth++] = Container::OBJECT;
+      } else {
+        error = true;
+        return;
+      }
+      if (cb.onObjectStart) cb.onObjectStart(cb.ctx);
+      expectingValue = false;
+      break;
+    case '}':
+      if (cb.onObjectEnd) cb.onObjectEnd(cb.ctx);
+      if (nestingDepth > 0) --nestingDepth;
+      expectingValue = false;
+      break;
+    case '[':
+      if (nestingDepth < MAX_NESTING) {
+        nestingStack[nestingDepth++] = Container::ARRAY;
+      } else {
+        error = true;
+        return;
+      }
+      if (cb.onArrayStart) cb.onArrayStart(cb.ctx);
+      expectingValue = false;
+      break;
+    case ']':
+      if (cb.onArrayEnd) cb.onArrayEnd(cb.ctx);
+      if (nestingDepth > 0) --nestingDepth;
+      expectingValue = false;
+      break;
+    case ':':
+      expectingValue = true;
+      break;
+    case ',':
+      expectingValue = false;
+      break;
+    case 't':
+      if (expectingValue || inArray()) {
+        memcpy(literalExpected, "true", 4);
+        literalLen = 4;
+        literalPos = 1;
+        state = State::IN_LITERAL;
+      }
+      break;
+    case 'f':
+      if (expectingValue || inArray()) {
+        memcpy(literalExpected, "false", 5);
+        literalLen = 5;
+        literalPos = 1;
+        state = State::IN_LITERAL;
+      }
+      break;
+    case 'n':
+      if (expectingValue || inArray()) {
+        memcpy(literalExpected, "null", 4);
+        literalLen = 4;
+        literalPos = 1;
+        state = State::IN_LITERAL;
+      }
+      break;
+    default:
+      if ((expectingValue || inArray()) && (c == '-' || (c >= '0' && c <= '9'))) {
+        tokenLen = 0;
+        tokenOverflow = false;
+        appendToken(c);
+        state = State::IN_NUMBER;
+      }
+      break;
+  }
+}
+
+void StreamingJsonParser::handleStringChar(char c) {
+  if (escaped) {
+    escaped = false;
+    switch (c) {
+      case '"':
+      case '\\':
+      case '/':
+        appendToken(c);
+        break;
+      case 'b':
+        appendToken('\b');
+        break;
+      case 'f':
+        appendToken('\f');
+        break;
+      case 'n':
+        appendToken('\n');
+        break;
+      case 'r':
+        appendToken('\r');
+        break;
+      case 't':
+        appendToken('\t');
+        break;
+      case 'u':
+        // Pass \uXXXX through as literal characters -- we don't decode
+        // Unicode escapes since our use case only needs ASCII field matching.
+        appendToken('\\');
+        appendToken('u');
+        break;
+      default:
+        appendToken('\\');
+        appendToken(c);
+        break;
+    }
+    return;
+  }
+
+  if (c == '\\') {
+    escaped = true;
+    return;
+  }
+
+  if (c == '"') {
+    emitToken();
+    return;
+  }
+
+  appendToken(c);
+}
+
+void StreamingJsonParser::handleNumber(char c) {
+  if ((c >= '0' && c <= '9') || c == '.' || c == '-' || c == '+' || c == 'e' || c == 'E') {
+    appendToken(c);
+    return;
+  }
+
+  if (!tokenOverflow && cb.onNumber) {
+    tokenBuf[tokenLen] = '\0';
+    cb.onNumber(cb.ctx, tokenBuf, tokenLen);
+  }
+  state = State::SCANNING;
+  expectingValue = false;
+
+  handleScanning(c);
+}
+
+void StreamingJsonParser::handleLiteral(char c) {
+  if (c == literalExpected[literalPos]) {
+    ++literalPos;
+    if (literalPos == literalLen) {
+      if (literalExpected[0] == 't') {
+        if (cb.onBool) cb.onBool(cb.ctx, true);
+      } else if (literalExpected[0] == 'f') {
+        if (cb.onBool) cb.onBool(cb.ctx, false);
+      } else {
+        if (cb.onNull) cb.onNull(cb.ctx);
+      }
+      state = State::SCANNING;
+      expectingValue = false;
+    }
+  } else {
+    error = true;
+  }
+}
+
+void StreamingJsonParser::handleSkipString(char c) {
+  if (escaped) {
+    escaped = false;
+    return;
+  }
+  if (c == '\\') {
+    escaped = true;
+    return;
+  }
+  if (c == '"') {
+    state = State::SCANNING;
+    expectingValue = false;
+  }
+}
+
+void StreamingJsonParser::appendToken(char c) {
+  if (tokenLen < TOKEN_BUF_SIZE - 1) {
+    tokenBuf[tokenLen++] = c;
+  } else {
+    tokenOverflow = true;
+  }
+}
+
+void StreamingJsonParser::emitToken() {
+  if (state == State::IN_STRING_KEY) {
+    if (!tokenOverflow && cb.onKey) {
+      tokenBuf[tokenLen] = '\0';
+      cb.onKey(cb.ctx, tokenBuf, tokenLen);
+    }
+    state = State::SCANNING;
+  } else {
+    if (!tokenOverflow && cb.onString) {
+      tokenBuf[tokenLen] = '\0';
+      cb.onString(cb.ctx, tokenBuf, tokenLen);
+    }
+    state = State::SCANNING;
+    expectingValue = false;
+  }
+}

--- a/lib/JsonParser/StreamingJsonParser.h
+++ b/lib/JsonParser/StreamingJsonParser.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+struct JsonCallbacks {
+  void* ctx;
+  void (*onKey)(void* ctx, const char* key, size_t len);
+  void (*onString)(void* ctx, const char* value, size_t len);
+  void (*onNumber)(void* ctx, const char* value, size_t len);
+  void (*onBool)(void* ctx, bool value);
+  void (*onNull)(void* ctx);
+  void (*onObjectStart)(void* ctx);
+  void (*onObjectEnd)(void* ctx);
+  void (*onArrayStart)(void* ctx);
+  void (*onArrayEnd)(void* ctx);
+};
+
+class StreamingJsonParser {
+ public:
+  static constexpr size_t TOKEN_BUF_SIZE = 512;
+  static constexpr size_t MAX_NESTING = 32;
+
+  explicit StreamingJsonParser(const JsonCallbacks& callbacks);
+
+  void reset();
+  void feed(const char* data, size_t len);
+
+  bool hasError() const { return error; }
+
+ private:
+  enum class State : uint8_t {
+    SCANNING,
+    IN_STRING_KEY,
+    IN_STRING_VALUE,
+    IN_NUMBER,
+    IN_LITERAL,
+    SKIP_STRING,
+  };
+
+  enum class Container : uint8_t {
+    NONE,
+    OBJECT,
+    ARRAY,
+  };
+
+  void handleScanning(char c);
+  void handleStringChar(char c);
+  void handleNumber(char c);
+  void handleLiteral(char c);
+  void handleSkipString(char c);
+
+  void appendToken(char c);
+  void emitToken();
+
+  bool inArray() const { return nestingDepth > 0 && nestingStack[nestingDepth - 1] == Container::ARRAY; }
+
+  JsonCallbacks cb;
+  char tokenBuf[TOKEN_BUF_SIZE];
+  size_t tokenLen;
+  State state;
+  bool expectingValue;
+  bool escaped;
+  bool tokenOverflow;
+  bool error;
+
+  Container nestingStack[MAX_NESTING];
+  uint8_t nestingDepth;
+
+  char literalExpected[6];
+  uint8_t literalLen;
+  uint8_t literalPos;
+};

--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -29,6 +29,16 @@ constexpr uint8_t AP_MAX_CONNECTIONS = 4;
 // DNS server for captive portal (redirects all DNS queries to our IP)
 std::unique_ptr<DNSServer> dnsServer;
 constexpr uint16_t DNS_PORT = 53;
+
+// 0..4 bars from RSSI (dBm), with 3 dBm hysteresis on currentBars to suppress flicker.
+int barsForRssi(int rssi, int currentBars) {
+  static constexpr int RISE_DBM[] = {-85, -75, -65, -55};
+  static constexpr int FALL_DBM[] = {-88, -78, -68, -58};
+  int bars = std::clamp(currentBars, 0, 4);
+  while (bars < 4 && rssi >= RISE_DBM[bars]) bars++;
+  while (bars > 0 && rssi < FALL_DBM[bars - 1]) bars--;
+  return bars;
+}
 }  // namespace
 
 void CrossPointWebServerActivity::onEnter() {
@@ -231,6 +241,7 @@ void CrossPointWebServerActivity::startWebServer() {
   if (webServer->isRunning()) {
     state = WebServerActivityState::SERVER_RUNNING;
     LOG_DBG("WEBACT", "Web server started successfully");
+    lastWifiBars = isApMode ? 0 : barsForRssi(WiFi.RSSI(), 0);
 
     // Force an immediate render since we're transitioning from a subactivity
     // that had its own rendering task. We need to make sure our display is shown.
@@ -280,21 +291,48 @@ void CrossPointWebServerActivity::loop() {
       static unsigned long lastWifiCheck = 0;
       if (millis() - lastWifiCheck > 2000) {
         lastWifiCheck = millis();
-        const bool up = (WiFi.status() == WL_CONNECTED);
-        if (!up && !wifiDropped) {
-          LOG_DBG("WEBACT", "WiFi link lost; showing reconnect banner");
-          wifiDropped = true;
-          requestUpdate();
-        } else if (up && wifiDropped) {
-          LOG_DBG("WEBACT", "WiFi link restored");
-          wifiDropped = false;
-          // IP may have changed on DHCP renewal — refresh the label.
-          const auto ip = WiFi.localIP();
-          char ipStr[16];
-          snprintf(ipStr, sizeof(ipStr), "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
-          connectedIP = ipStr;
-          requestUpdate();
+        const wl_status_t wifiStatus = WiFi.status();
+        // Driver auto-reconnect handles retries; abandon (via onGoBack) only
+        // after WIFI_ABANDON_MS, otherwise the activity freezes on a blip.
+        bool repaint = false;
+        if (wifiStatus != WL_CONNECTED) {
+          if (consecutiveDisconnects == 0) {
+            firstDisconnectAt = millis();
+            repaint = true;
+          }
+          consecutiveDisconnects++;
+          LOG_DBG("WEBACT", "WiFi not connected (status=%d, consecutive=%d, total=%lu ms)", wifiStatus,
+                  consecutiveDisconnects, millis() - firstDisconnectAt);
+          if (millis() - firstDisconnectAt > WIFI_ABANDON_MS) {
+            LOG_DBG("WEBACT", "WiFi unavailable for >%lu s; returning to network selection", WIFI_ABANDON_MS / 1000UL);
+            state = WebServerActivityState::SHUTTING_DOWN;
+            onGoBack();
+            return;
+          }
+        } else {
+          if (consecutiveDisconnects > 0) {
+            LOG_DBG("WEBACT", "WiFi recovered after %d failed checks (%lu ms)", consecutiveDisconnects,
+                    millis() - firstDisconnectAt);
+            // IP may have changed on DHCP renewal — refresh the label.
+            const auto ip = WiFi.localIP();
+            char ipStr[16];
+            snprintf(ipStr, sizeof(ipStr), "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
+            connectedIP = ipStr;
+            repaint = true;
+          }
+          consecutiveDisconnects = 0;
+          firstDisconnectAt = 0;
+          const int rssi = WiFi.RSSI();
+          if (rssi < -75) {
+            LOG_DBG("WEBACT", "Warning: Weak WiFi signal: %d dBm", rssi);
+          }
+          const int bars = barsForRssi(rssi, lastWifiBars);
+          if (bars != lastWifiBars) {
+            lastWifiBars = bars;
+            repaint = true;
+          }
         }
+        if (repaint) requestUpdate();
       }
     }
 
@@ -382,6 +420,10 @@ void CrossPointWebServerActivity::renderServerRunning() const {
 
   renderer.drawCenteredText(UI_12_FONT_ID, 15, tr(STR_FILE_TRANSFER), true, EpdFontFamily::REGULAR);
 
+  if (!isApMode) {
+    renderWifiIndicator(15);
+  }
+
   if (isApMode) {
     // AP mode display - center the content block
     int startY = 55;
@@ -446,7 +488,41 @@ void CrossPointWebServerActivity::renderServerRunning() const {
   // STA-only link-loss banner. Sits under the title so it doesn't
   // push the QR code around. Disappears automatically when the link
   // comes back.
-  if (wifiDropped && !isApMode) {
+  if (consecutiveDisconnects > 0 && !isApMode) {
     renderer.drawCenteredText(SMALL_FONT_ID, 36, "Reconnecting to Wi-Fi...", true, EpdFontFamily::REGULAR);
+  }
+}
+
+void CrossPointWebServerActivity::renderWifiIndicator(int subHeaderTop) const {
+  constexpr int BAR_COUNT = 4;
+  constexpr int BAR_WIDTH = 4;
+  constexpr int BAR_GAP = 2;
+  constexpr int ICON_HEIGHT = 14;
+  // DX34 has no UITheme metrics; use hardcoded layout to anchor indicator
+  // in the top-right corner near the title.
+  constexpr int CONTENT_SIDE_PADDING = 12;
+  const int iconWidth = BAR_COUNT * BAR_WIDTH + (BAR_COUNT - 1) * BAR_GAP;
+  const int iconRight = renderer.getScreenWidth() - CONTENT_SIDE_PADDING;
+  const int iconLeft = iconRight - iconWidth;
+  const int iconBottom = subHeaderTop + ICON_HEIGHT;
+
+  const bool wifiUp = (WiFi.status() == WL_CONNECTED) && (consecutiveDisconnects == 0);
+  if (wifiUp) {
+    for (int i = 0; i < BAR_COUNT; i++) {
+      const int barHeight = (i + 1) * ICON_HEIGHT / BAR_COUNT;
+      const int x = iconLeft + i * (BAR_WIDTH + BAR_GAP);
+      const int y = iconBottom - barHeight;
+      if (i < lastWifiBars) {
+        renderer.fillRect(x, y, BAR_WIDTH, barHeight, true);
+      } else {
+        renderer.drawRect(x, y, BAR_WIDTH, barHeight, true);
+      }
+    }
+  } else {
+    const int xSize = ICON_HEIGHT;
+    const int x0 = iconRight - xSize;
+    const int y0 = iconBottom - xSize;
+    renderer.drawLine(x0, y0, x0 + xSize, y0 + xSize, 2, true);
+    renderer.drawLine(x0, y0 + xSize, x0 + xSize, y0, 2, true);
   }
 }

--- a/src/activities/network/CrossPointWebServerActivity.h
+++ b/src/activities/network/CrossPointWebServerActivity.h
@@ -49,11 +49,17 @@ class CrossPointWebServerActivity final : public ActivityWithSubactivity {
   // Performance monitoring
   unsigned long lastHandleClientTime = 0;
 
-  // STA-only: set when the WiFi link drops; cleared when it recovers.
-  // Drives the "Reconnecting…" overlay but never exits the activity.
-  bool wifiDropped = false;
+  // Sustained WiFi-loss tracking; abandon only after WIFI_ABANDON_MS.
+  // While consecutiveDisconnects>0, render shows the "Reconnecting…" banner.
+  int consecutiveDisconnects = 0;
+  unsigned long firstDisconnectAt = 0;
+  static constexpr unsigned long WIFI_ABANDON_MS = 5UL * 60UL * 1000UL;
+
+  // Cached signal-strength bracket (0..4) for the WiFi indicator.
+  int lastWifiBars = 0;
 
   void renderServerRunning() const;
+  void renderWifiIndicator(int subHeaderTop) const;
 
   void onNetworkModeSelected(NetworkMode mode);
   void onWifiSelectionComplete(bool connected);

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -223,8 +223,8 @@ void CrossPointWebServer::begin() {
 
   // Ensure the SDK reconnects the STA link if the router flickers or
   // the client device briefly drops. Keeps the web session alive
-  // across the blip; the activity's render path only shows a
-  // "Reconnecting…" banner rather than exiting.
+  // across the blip; the activity's loss-recovery loop relies on
+  // these driver retries before abandoning after WIFI_ABANDON_MS.
   if (!apMode) WiFi.setAutoReconnect(true);
 
   // Note: WebServer class doesn't have setNoDelay() in the standard ESP32 library.

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -1,7 +1,7 @@
 #include "OtaUpdater.h"
 
-#include <ArduinoJson.h>
 #include <Logging.h>
+#include <ReleaseJsonParser.h>
 
 #include "esp_http_client.h"
 #include "esp_https_ota.h"
@@ -26,12 +26,6 @@ const char* findSemverStart(const char* str) {
   return str;
 }
 
-/* Buffer and length tracker for incremental HTTP response from latestReleaseUrl.
- * Static storage is zero-initialized by C++, but explicit init makes intent clear
- * and guards against future refactors that might move these to non-static scope. */
-char* local_buf = nullptr;
-int output_len = 0;
-
 /*
  * When esp_crt_bundle.h included, it is pointing wrong header file
  * which is something under WifiClientSecure because of our framework based on
@@ -46,76 +40,34 @@ esp_err_t http_client_set_header_cb(esp_http_client_handle_t http_client) {
   return esp_http_client_set_header(http_client, "User-Agent", "CrossPoint-Mod-DX34-ESP32-" CROSSPOINT_VERSION);
 }
 
+size_t totalBytesReceived = 0;
+
 esp_err_t event_handler(esp_http_client_event_t* event) {
-  /* We do interested in only HTTP_EVENT_ON_DATA event only */
   if (event->event_id != HTTP_EVENT_ON_DATA) return ESP_OK;
-
-  if (!esp_http_client_is_chunked_response(event->client)) {
-    int content_len = esp_http_client_get_content_length(event->client);
-    int copy_len = 0;
-
-    if (local_buf == NULL) {
-      /* Guard against bogus or malicious content-length values.
-       * GitHub API /releases/latest JSON is typically 2-4 KB;
-       * 8 KB is generous while staying safe on ~180 KB free heap. */
-      if (content_len <= 0 || content_len > 8192) {
-        LOG_ERR("OTA", "Rejecting content_len %d (max 8192)", content_len);
-        return ESP_ERR_NO_MEM;
-      }
-      /* local_buf life span is tracked by caller checkForUpdate */
-      local_buf = static_cast<char*>(calloc(content_len + 1, sizeof(char)));
-      output_len = 0;
-      if (local_buf == NULL) {
-        LOG_ERR("OTA", "HTTP Client Out of Memory Failed, Allocation %d", content_len);
-        return ESP_ERR_NO_MEM;
-      }
-    }
-    copy_len = min(event->data_len, (content_len - output_len));
-    // Defensive: local_buf is null-checked above on first alloc, but guard
-    // here too in case a follow-up event fires after an intervening failure.
-    if (copy_len && local_buf != nullptr) {
-      memcpy(local_buf + output_len, event->data, copy_len);
-      output_len += copy_len;
-    }
-  } else {
-    /* Code might be hits here, It happened once (for version checking) but I
-     * need more logs to handle that */
-    int chunked_len;
-    esp_http_client_get_chunk_length(event->client, &chunked_len);
-    LOG_DBG("OTA", "esp_http_client_is_chunked_response failed, chunked_len: %d", chunked_len);
-  }
-
+  totalBytesReceived += event->data_len;
+  auto* parser = static_cast<ReleaseJsonParser*>(event->user_data);
+  parser->feed(static_cast<const char*>(event->data), event->data_len);
   return ESP_OK;
-} /* event_handler */
-} /* namespace */
+}
+}  // namespace
 
 OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
-  JsonDocument filter;
   esp_err_t esp_err;
-  JsonDocument doc;
+  ReleaseJsonParser releaseParser;
 
   esp_http_client_config_t client_config = {
       .url = latestReleaseUrl,
       .event_handler = event_handler,
-      /* Default HTTP client buffer size 512 byte only */
       .buffer_size = 8192,
       .buffer_size_tx = 8192,
+      .user_data = &releaseParser,
       .skip_cert_common_name_check = true,
       .crt_bundle_attach = esp_crt_bundle_attach,
       .keep_alive_enable = true,
   };
 
-  /* To track life time of local_buf, dtor will be called on exit from that
-   * function */
-  struct localBufCleaner {
-    char** bufPtr;
-    ~localBufCleaner() {
-      if (*bufPtr) {
-        free(*bufPtr);
-        *bufPtr = NULL;
-      }
-    }
-  } localBufCleaner = {&local_buf};
+  totalBytesReceived = 0;
+  LOG_DBG("OTA", "Checking for update (current: %s)", CROSSPOINT_VERSION);
 
   esp_http_client_handle_t client_handle = esp_http_client_init(&client_config);
   if (!client_handle) {
@@ -155,48 +107,25 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
     return HTTP_ERROR;
   }
 
-  filter["tag_name"] = true;
-  filter["assets"][0]["name"] = true;
-  filter["assets"][0]["browser_download_url"] = true;
-  filter["assets"][0]["size"] = true;
-  const DeserializationError error = deserializeJson(doc, local_buf, DeserializationOption::Filter(filter));
-  if (error) {
-    LOG_ERR("OTA", "JSON parse failed: %s", error.c_str());
+  LOG_DBG("OTA", "Response received: %zu bytes total", totalBytesReceived);
+
+  if (!releaseParser.foundTag()) {
+    LOG_ERR("OTA", "No tag_name in release JSON");
     return JSON_PARSE_ERROR;
   }
 
-  if (!doc["tag_name"].is<std::string>()) {
-    LOG_ERR("OTA", "No tag_name found");
-    return JSON_PARSE_ERROR;
-  }
-
-  if (!doc["assets"].is<JsonArray>()) {
-    LOG_ERR("OTA", "No assets found");
-    return JSON_PARSE_ERROR;
-  }
-
-  latestVersion = doc["tag_name"].as<std::string>();
-
-  for (int i = 0; i < doc["assets"].size(); i++) {
-    if (doc["assets"][i]["name"] == "firmware.bin") {
-      if (!doc["assets"][i]["browser_download_url"].is<std::string>() || !doc["assets"][i]["size"].is<size_t>()) {
-        LOG_ERR("OTA", "firmware.bin asset missing url or size fields");
-        return JSON_PARSE_ERROR;
-      }
-      otaUrl = doc["assets"][i]["browser_download_url"].as<std::string>();
-      otaSize = doc["assets"][i]["size"].as<size_t>();
-      totalSize = otaSize;
-      updateAvailable = true;
-      break;
-    }
-  }
-
-  if (!updateAvailable) {
+  if (!releaseParser.foundFirmware()) {
     LOG_ERR("OTA", "No firmware.bin asset found");
     return NO_UPDATE;
   }
 
-  LOG_DBG("OTA", "Found update: %s", latestVersion.c_str());
+  latestVersion = releaseParser.getTagName();
+  otaUrl = releaseParser.getFirmwareUrl();
+  otaSize = releaseParser.getFirmwareSize();
+  totalSize = otaSize;
+  updateAvailable = true;
+
+  LOG_DBG("OTA", "Found update: tag=%s size=%zu", latestVersion.c_str(), otaSize);
   return OK;
 }
 

--- a/test/release_json_parser/ReleaseJsonParserTest.cpp
+++ b/test/release_json_parser/ReleaseJsonParserTest.cpp
@@ -1,0 +1,833 @@
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "lib/JsonParser/ReleaseJsonParser.h"
+
+static int testsPassed = 0;
+static int testsFailed = 0;
+
+#define ASSERT_EQ(a, b)                                                           \
+  do {                                                                            \
+    auto _a = (a);                                                                \
+    auto _b = (b);                                                                \
+    if (_a != _b) {                                                               \
+      fprintf(stderr, "  FAIL: %s:%d: %s != expected\n", __FILE__, __LINE__, #a); \
+      testsFailed++;                                                              \
+      return;                                                                     \
+    }                                                                             \
+  } while (0)
+
+#define ASSERT_STREQ(a, b)                                                              \
+  do {                                                                                  \
+    const char* _a = (a);                                                               \
+    const char* _b = (b);                                                               \
+    if (strcmp(_a, _b) != 0) {                                                          \
+      fprintf(stderr, "  FAIL: %s:%d: \"%s\" != \"%s\"\n", __FILE__, __LINE__, _a, _b); \
+      testsFailed++;                                                                    \
+      return;                                                                           \
+    }                                                                                   \
+  } while (0)
+
+#define ASSERT_TRUE(cond)                                                \
+  do {                                                                   \
+    if (!(cond)) {                                                       \
+      fprintf(stderr, "  FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+      testsFailed++;                                                     \
+      return;                                                            \
+    }                                                                    \
+  } while (0)
+
+#define PASS() testsPassed++
+
+// ============================================================================
+// Realistic GitHub release JSON payloads
+// ============================================================================
+
+static const char* kRealisticPretty = R"({
+  "url": "https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/12345",
+  "assets_url": "https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/12345/assets",
+  "upload_url": "https://uploads.github.com/repos/crosspoint-reader/crosspoint-reader/releases/12345/assets{?name,label}",
+  "html_url": "https://github.com/crosspoint-reader/crosspoint-reader/releases/tag/v2.4.1",
+  "id": 12345,
+  "author": {
+    "login": "releasebot",
+    "id": 99887766,
+    "node_id": "MDQ6VXNlcjk5ODg3NzY2",
+    "avatar_url": "https://avatars.githubusercontent.com/u/99887766?v=4",
+    "url": "https://api.github.com/users/releasebot",
+    "type": "User",
+    "site_admin": false
+  },
+  "node_id": "RE_kwDOAbCdEf4AADBN",
+  "tag_name": "v2.4.1",
+  "target_commitish": "main",
+  "name": "CrossPoint Reader v2.4.1",
+  "draft": false,
+  "prerelease": false,
+  "created_at": "2026-04-28T10:00:00Z",
+  "published_at": "2026-04-28T10:30:00Z",
+  "assets": [
+    {
+      "url": "https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/assets/100001",
+      "id": 100001,
+      "node_id": "RA_kwDOAbCdEf4AAGHR",
+      "name": "crosspoint-reader-v2.4.1-source.zip",
+      "label": null,
+      "uploader": {
+        "login": "releasebot",
+        "id": 99887766,
+        "node_id": "MDQ6VXNlcjk5ODg3NzY2",
+        "type": "User"
+      },
+      "content_type": "application/zip",
+      "state": "uploaded",
+      "size": 2048576,
+      "download_count": 42,
+      "created_at": "2026-04-28T10:15:00Z",
+      "updated_at": "2026-04-28T10:15:30Z",
+      "browser_download_url": "https://github.com/crosspoint-reader/crosspoint-reader/releases/download/v2.4.1/crosspoint-reader-v2.4.1-source.zip"
+    },
+    {
+      "url": "https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/assets/100002",
+      "id": 100002,
+      "node_id": "RA_kwDOAbCdEf4AAGHS",
+      "name": "firmware.bin",
+      "label": "ESP32-C3 Firmware",
+      "uploader": {
+        "login": "releasebot",
+        "id": 99887766,
+        "node_id": "MDQ6VXNlcjk5ODg3NzY2",
+        "type": "User"
+      },
+      "content_type": "application/octet-stream",
+      "state": "uploaded",
+      "size": 1572864,
+      "download_count": 187,
+      "created_at": "2026-04-28T10:16:00Z",
+      "updated_at": "2026-04-28T10:16:45Z",
+      "browser_download_url": "https://github.com/crosspoint-reader/crosspoint-reader/releases/download/v2.4.1/firmware.bin"
+    },
+    {
+      "url": "https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/assets/100003",
+      "id": 100003,
+      "node_id": "RA_kwDOAbCdEf4AAGHR",
+      "name": "checksums.sha256",
+      "label": null,
+      "uploader": {
+        "login": "releasebot",
+        "id": 99887766,
+        "node_id": "MDQ6VXNlcjk5ODg3NzY2",
+        "type": "User"
+      },
+      "content_type": "text/plain",
+      "state": "uploaded",
+      "size": 192,
+      "download_count": 15,
+      "created_at": "2026-04-28T10:17:00Z",
+      "updated_at": "2026-04-28T10:17:10Z",
+      "browser_download_url": "https://github.com/crosspoint-reader/crosspoint-reader/releases/download/v2.4.1/checksums.sha256"
+    }
+  ],
+  "tarball_url": "https://api.github.com/repos/crosspoint-reader/crosspoint-reader/tarball/v2.4.1",
+  "zipball_url": "https://api.github.com/repos/crosspoint-reader/crosspoint-reader/zipball/v2.4.1",
+  "body": "## What's Changed\n\n* Fixed orientation crash (#123)\n* Improved EPUB rendering performance\n* Added Serbian translation\n\n**Full Changelog**: https://github.com/crosspoint-reader/crosspoint-reader/compare/v2.4.0...v2.4.1",
+  "reactions": {
+    "url": "https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/12345/reactions",
+    "total_count": 5,
+    "+1": 3,
+    "-1": 0,
+    "laugh": 1,
+    "hooray": 1,
+    "confused": 0,
+    "heart": 0,
+    "rocket": 0,
+    "eyes": 0
+  }
+})";
+
+static const char* kRealisticMinified =
+    R"({"url":"https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/12345","assets_url":"https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/12345/assets","id":12345,"author":{"login":"releasebot","id":99887766,"node_id":"MDQ6VXNlcjk5ODg3NzY2","type":"User","site_admin":false},"tag_name":"v2.4.1","target_commitish":"main","name":"CrossPoint Reader v2.4.1","draft":false,"prerelease":false,"assets":[{"url":"https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/assets/100001","id":100001,"name":"crosspoint-reader-v2.4.1-source.zip","uploader":{"login":"releasebot","id":99887766},"content_type":"application/zip","state":"uploaded","size":2048576,"download_count":42,"browser_download_url":"https://github.com/crosspoint-reader/crosspoint-reader/releases/download/v2.4.1/crosspoint-reader-v2.4.1-source.zip"},{"url":"https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/assets/100002","id":100002,"name":"firmware.bin","uploader":{"login":"releasebot","id":99887766},"content_type":"application/octet-stream","state":"uploaded","size":1572864,"download_count":187,"browser_download_url":"https://github.com/crosspoint-reader/crosspoint-reader/releases/download/v2.4.1/firmware.bin"},{"url":"https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/assets/100003","id":100003,"name":"checksums.sha256","uploader":{"login":"releasebot","id":99887766},"content_type":"text/plain","state":"uploaded","size":192,"download_count":15,"browser_download_url":"https://github.com/crosspoint-reader/crosspoint-reader/releases/download/v2.4.1/checksums.sha256"}],"body":"## What's Changed\n\n* Fixed orientation crash","reactions":{"url":"https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/12345/reactions","total_count":5,"+1":3}})";
+
+// Helper: feed JSON in fixed-size chunks
+static void feedChunked(ReleaseJsonParser& p, const char* json, size_t chunkSize) {
+  size_t len = strlen(json);
+  for (size_t off = 0; off < len; off += chunkSize) {
+    size_t n = len - off < chunkSize ? len - off : chunkSize;
+    p.feed(json + off, n);
+  }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+void testRealisticPrettyPrinted() {
+  printf("testRealisticPrettyPrinted...\n");
+
+  ReleaseJsonParser p;
+  p.feed(kRealisticPretty, strlen(kRealisticPretty));
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getTagName(), "v2.4.1");
+  ASSERT_STREQ(p.getFirmwareUrl(),
+               "https://github.com/crosspoint-reader/crosspoint-reader/releases/download/v2.4.1/firmware.bin");
+  ASSERT_EQ(p.getFirmwareSize(), 1572864u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testRealisticMinified() {
+  printf("testRealisticMinified...\n");
+
+  ReleaseJsonParser p;
+  p.feed(kRealisticMinified, strlen(kRealisticMinified));
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getTagName(), "v2.4.1");
+  ASSERT_STREQ(p.getFirmwareUrl(),
+               "https://github.com/crosspoint-reader/crosspoint-reader/releases/download/v2.4.1/firmware.bin");
+  ASSERT_EQ(p.getFirmwareSize(), 1572864u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testPrettyAndMinifiedAgree() {
+  printf("testPrettyAndMinifiedAgree...\n");
+
+  ReleaseJsonParser pretty;
+  pretty.feed(kRealisticPretty, strlen(kRealisticPretty));
+
+  ReleaseJsonParser minified;
+  minified.feed(kRealisticMinified, strlen(kRealisticMinified));
+
+  ASSERT_STREQ(pretty.getTagName(), minified.getTagName());
+  ASSERT_STREQ(pretty.getFirmwareUrl(), minified.getFirmwareUrl());
+  ASSERT_EQ(pretty.getFirmwareSize(), minified.getFirmwareSize());
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testFirmwareNotFirstAsset() {
+  printf("testFirmwareNotFirstAsset...\n");
+
+  // firmware.bin is the third of four assets
+  const char* json = R"({
+      "tag_name": "v1.0.0",
+      "assets": [
+        {"name": "source.tar.gz", "browser_download_url": "https://example.com/src.tar.gz", "size": 500000},
+        {"name": "docs.pdf", "browser_download_url": "https://example.com/docs.pdf", "size": 120000},
+        {"name": "firmware.bin", "browser_download_url": "https://example.com/firmware.bin", "size": 987654},
+        {"name": "checksums.txt", "browser_download_url": "https://example.com/checksums.txt", "size": 256}
+      ]
+    })";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getTagName(), "v1.0.0");
+  ASSERT_STREQ(p.getFirmwareUrl(), "https://example.com/firmware.bin");
+  ASSERT_EQ(p.getFirmwareSize(), 987654u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testFieldOrderUrlBeforeName() {
+  printf("testFieldOrderUrlBeforeName...\n");
+
+  const char* json = R"({
+      "tag_name": "v3.0",
+      "assets": [{
+        "browser_download_url": "https://example.com/fw.bin",
+        "name": "firmware.bin",
+        "size": 2222
+      }]
+    })";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getFirmwareUrl(), "https://example.com/fw.bin");
+  ASSERT_EQ(p.getFirmwareSize(), 2222u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testFieldOrderSizeBeforeUrl() {
+  printf("testFieldOrderSizeBeforeUrl...\n");
+
+  const char* json = R"({
+      "tag_name": "v3.1",
+      "assets": [{
+        "size": 3333,
+        "browser_download_url": "https://example.com/fw2.bin",
+        "name": "firmware.bin"
+      }]
+    })";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getFirmwareUrl(), "https://example.com/fw2.bin");
+  ASSERT_EQ(p.getFirmwareSize(), 3333u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testFieldOrderNameFirst() {
+  printf("testFieldOrderNameFirst...\n");
+
+  const char* json = R"({
+      "tag_name": "v3.2",
+      "assets": [{
+        "name": "firmware.bin",
+        "size": 4444,
+        "browser_download_url": "https://example.com/fw3.bin"
+      }]
+    })";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getFirmwareUrl(), "https://example.com/fw3.bin");
+  ASSERT_EQ(p.getFirmwareSize(), 4444u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testAssetsBeforeTagName() {
+  printf("testAssetsBeforeTagName...\n");
+
+  // tag_name appears after assets in the JSON
+  const char* json = R"({
+      "name": "Release",
+      "assets": [{
+        "name": "firmware.bin",
+        "browser_download_url": "https://example.com/fw.bin",
+        "size": 5555
+      }],
+      "tag_name": "v4.0"
+    })";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getTagName(), "v4.0");
+  ASSERT_STREQ(p.getFirmwareUrl(), "https://example.com/fw.bin");
+  ASSERT_EQ(p.getFirmwareSize(), 5555u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testChunkedFeedingRealisticSmallChunks() {
+  printf("testChunkedFeedingRealisticSmallChunks...\n");
+
+  // Simulate HTTP chunked transfer with small chunks (64 bytes)
+  ReleaseJsonParser p;
+  feedChunked(p, kRealisticPretty, 64);
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getTagName(), "v2.4.1");
+  ASSERT_STREQ(p.getFirmwareUrl(),
+               "https://github.com/crosspoint-reader/crosspoint-reader/releases/download/v2.4.1/firmware.bin");
+  ASSERT_EQ(p.getFirmwareSize(), 1572864u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testChunkedFeedingByteByByte() {
+  printf("testChunkedFeedingByteByByte...\n");
+
+  ReleaseJsonParser p;
+  feedChunked(p, kRealisticMinified, 1);
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getTagName(), "v2.4.1");
+  ASSERT_EQ(p.getFirmwareSize(), 1572864u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testChunkedFeedingVariousChunkSizes() {
+  printf("testChunkedFeedingVariousChunkSizes...\n");
+
+  for (size_t chunkSize : {3, 7, 13, 31, 97, 128, 256, 512, 1024}) {
+    ReleaseJsonParser p;
+    feedChunked(p, kRealisticPretty, chunkSize);
+
+    ASSERT_TRUE(p.foundTag());
+    ASSERT_TRUE(p.foundFirmware());
+    ASSERT_STREQ(p.getTagName(), "v2.4.1");
+    ASSERT_EQ(p.getFirmwareSize(), 1572864u);
+  }
+
+  printf("  passed (9 chunk sizes)\n");
+  PASS();
+}
+
+void testMissingTagName() {
+  printf("testMissingTagName...\n");
+
+  const char* json = R"({
+      "name": "Some Release",
+      "draft": false,
+      "assets": [{
+        "name": "firmware.bin",
+        "browser_download_url": "https://example.com/fw.bin",
+        "size": 1000
+      }]
+    })";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(!p.foundTag());
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getTagName(), "");
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testMissingFirmwareBinAsset() {
+  printf("testMissingFirmwareBinAsset...\n");
+
+  const char* json = R"({
+      "tag_name": "v1.0.0",
+      "assets": [
+        {"name": "source.zip", "browser_download_url": "https://example.com/src.zip", "size": 1000},
+        {"name": "docs.tar.gz", "browser_download_url": "https://example.com/docs.tar.gz", "size": 2000}
+      ]
+    })";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(!p.foundFirmware());
+  ASSERT_STREQ(p.getTagName(), "v1.0.0");
+  ASSERT_STREQ(p.getFirmwareUrl(), "");
+  ASSERT_EQ(p.getFirmwareSize(), 0u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testEmptyAssetsArray() {
+  printf("testEmptyAssetsArray...\n");
+
+  const char* json = R"({"tag_name": "v1.0.0", "assets": []})";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(!p.foundFirmware());
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testNoAssetsKey() {
+  printf("testNoAssetsKey...\n");
+
+  const char* json = R"({"tag_name": "v1.0.0", "name": "Release"})";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(!p.foundFirmware());
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testTruncatedBeforeTagValue() {
+  printf("testTruncatedBeforeTagValue...\n");
+
+  const char* json = R"({"tag_name": )";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(!p.foundTag());
+  ASSERT_TRUE(!p.foundFirmware());
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testTruncatedInsideTagValue() {
+  printf("testTruncatedInsideTagValue...\n");
+
+  const char* json = R"({"tag_name": "v2.4)";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(!p.foundTag());
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testTruncatedInsideAssetsArray() {
+  printf("testTruncatedInsideAssetsArray...\n");
+
+  const char* json = R"({"tag_name": "v2.4.1", "assets": [{"name": "firm)";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_STREQ(p.getTagName(), "v2.4.1");
+  ASSERT_TRUE(!p.foundFirmware());
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testTruncatedAfterFirmwareName() {
+  printf("testTruncatedAfterFirmwareName...\n");
+
+  // Found the name but connection dropped before URL/size
+  const char* json = R"({"tag_name":"v1.0","assets":[{"name":"firmware.bin","browser_dow)";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(!p.foundFirmware());
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testTruncatedRealisticJson() {
+  printf("testTruncatedRealisticJson...\n");
+
+  // Truncate the realistic JSON at various points; none should crash
+  std::string full(kRealisticPretty);
+  for (size_t cutPoint : {10u, 50u, 100u, 200u, 500u, 1000u, 1500u, 2000u}) {
+    if (cutPoint >= full.size()) continue;
+
+    ReleaseJsonParser p;
+    p.feed(full.c_str(), cutPoint);
+    // Just verify no crash; results depend on where we cut
+    (void)p.foundTag();
+    (void)p.foundFirmware();
+  }
+
+  printf("  passed (no crashes on truncated realistic JSON)\n");
+  PASS();
+}
+
+void testNestedObjectsInAsset() {
+  printf("testNestedObjectsInAsset...\n");
+
+  // Asset with deeply nested "uploader" object -- should not confuse depth tracking
+  const char* json = R"({
+      "tag_name": "v5.0",
+      "assets": [{
+        "name": "firmware.bin",
+        "uploader": {
+          "login": "bot",
+          "id": 42,
+          "permissions": {"admin": false, "push": true, "pull": true}
+        },
+        "browser_download_url": "https://example.com/fw5.bin",
+        "size": 8888
+      }]
+    })";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getFirmwareUrl(), "https://example.com/fw5.bin");
+  ASSERT_EQ(p.getFirmwareSize(), 8888u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testNestedObjectsAtTopLevel() {
+  printf("testNestedObjectsAtTopLevel...\n");
+
+  // Multiple nested objects at the top level before/after tag_name and assets
+  const char* json = R"({
+      "author": {"login": "dev", "id": 1, "nested": {"deep": true}},
+      "tag_name": "v6.0",
+      "reactions": {"url": "https://reactions", "total_count": 0, "+1": 0},
+      "assets": [{"name": "firmware.bin", "browser_download_url": "https://fw6", "size": 1111}],
+      "mentions_count": 3
+    })";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getTagName(), "v6.0");
+  ASSERT_EQ(p.getFirmwareSize(), 1111u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testArraysAtTopLevel() {
+  printf("testArraysAtTopLevel...\n");
+
+  // A non-assets array at the top level should not interfere
+  const char* json = R"({
+      "tag_name": "v7.0",
+      "labels": ["release", "stable"],
+      "assets": [{"name": "firmware.bin", "browser_download_url": "https://fw7", "size": 7070}]
+    })";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getTagName(), "v7.0");
+  ASSERT_EQ(p.getFirmwareSize(), 7070u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testResetAndReuse() {
+  printf("testResetAndReuse...\n");
+
+  ReleaseJsonParser p;
+
+  const char* json1 =
+      R"({"tag_name":"v1.0","assets":[{"name":"firmware.bin","browser_download_url":"https://a","size":1}]})";
+  p.feed(json1, strlen(json1));
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_STREQ(p.getTagName(), "v1.0");
+  ASSERT_STREQ(p.getFirmwareUrl(), "https://a");
+  ASSERT_EQ(p.getFirmwareSize(), 1u);
+
+  p.reset();
+
+  // Second document with different values
+  const char* json2 =
+      R"({"tag_name":"v2.0","assets":[{"name":"firmware.bin","browser_download_url":"https://b","size":2}]})";
+  p.feed(json2, strlen(json2));
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_STREQ(p.getTagName(), "v2.0");
+  ASSERT_STREQ(p.getFirmwareUrl(), "https://b");
+  ASSERT_EQ(p.getFirmwareSize(), 2u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testResetClearsState() {
+  printf("testResetClearsState...\n");
+
+  ReleaseJsonParser p;
+
+  const char* json =
+      R"({"tag_name":"v1.0","assets":[{"name":"firmware.bin","browser_download_url":"https://a","size":100}]})";
+  p.feed(json, strlen(json));
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(p.foundFirmware());
+
+  p.reset();
+
+  ASSERT_TRUE(!p.foundTag());
+  ASSERT_TRUE(!p.foundFirmware());
+  ASSERT_STREQ(p.getTagName(), "");
+  ASSERT_STREQ(p.getFirmwareUrl(), "");
+  ASSERT_EQ(p.getFirmwareSize(), 0u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testPartialAssetNameMatch() {
+  printf("testPartialAssetNameMatch...\n");
+
+  // "firmware.bin.bak" should NOT match "firmware.bin"
+  const char* json = R"({
+      "tag_name": "v1.0",
+      "assets": [
+        {"name": "firmware.bin.bak", "browser_download_url": "https://bak", "size": 100},
+        {"name": "firmware.bin.old", "browser_download_url": "https://old", "size": 200}
+      ]
+    })";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(!p.foundFirmware());
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testFirmwareBinExactMatch() {
+  printf("testFirmwareBinExactMatch...\n");
+
+  // Only exact "firmware.bin" matches, not similar names
+  const char* json = R"({
+      "tag_name": "v1.0",
+      "assets": [
+        {"name": "FIRMWARE.BIN", "browser_download_url": "https://upper", "size": 100},
+        {"name": "firmware.bin", "browser_download_url": "https://exact", "size": 200},
+        {"name": "firmware.bin2", "browser_download_url": "https://suffix", "size": 300}
+      ]
+    })";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getFirmwareUrl(), "https://exact");
+  ASSERT_EQ(p.getFirmwareSize(), 200u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testLargeSize() {
+  printf("testLargeSize...\n");
+
+  // 16MB firmware (maximum flash size)
+  const char* json =
+      R"({"tag_name":"v1.0","assets":[{"name":"firmware.bin","browser_download_url":"https://fw","size":16777216}]})";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_EQ(p.getFirmwareSize(), 16777216u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testSizeZero() {
+  printf("testSizeZero...\n");
+
+  const char* json =
+      R"({"tag_name":"v1.0","assets":[{"name":"firmware.bin","browser_download_url":"https://fw","size":0}]})";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_EQ(p.getFirmwareSize(), 0u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testMinimalValidJson() {
+  printf("testMinimalValidJson...\n");
+
+  const char* json = R"({"tag_name":"v0","assets":[{"name":"firmware.bin","browser_download_url":"u","size":1}]})";
+
+  ReleaseJsonParser p;
+  p.feed(json, strlen(json));
+
+  ASSERT_TRUE(p.foundTag());
+  ASSERT_TRUE(p.foundFirmware());
+  ASSERT_STREQ(p.getTagName(), "v0");
+  ASSERT_STREQ(p.getFirmwareUrl(), "u");
+  ASSERT_EQ(p.getFirmwareSize(), 1u);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testChunkedRealisticEveryBoundary() {
+  printf("testChunkedRealisticEveryBoundary...\n");
+
+  // Two-chunk split at every byte boundary on a compact JSON
+  const char* json =
+      R"({"tag_name":"v2.0","assets":[{"name":"firmware.bin","browser_download_url":"https://example.com/fw","size":9999}]})";
+  size_t len = strlen(json);
+
+  for (size_t split = 0; split <= len; ++split) {
+    ReleaseJsonParser p;
+    if (split > 0) p.feed(json, split);
+    if (split < len) p.feed(json + split, len - split);
+
+    ASSERT_TRUE(p.foundTag());
+    ASSERT_TRUE(p.foundFirmware());
+    ASSERT_STREQ(p.getTagName(), "v2.0");
+    ASSERT_STREQ(p.getFirmwareUrl(), "https://example.com/fw");
+    ASSERT_EQ(p.getFirmwareSize(), 9999u);
+  }
+
+  printf("  passed (all %zu split points)\n", len + 1);
+  PASS();
+}
+
+// ============================================================================
+
+int main() {
+  printf("=== ReleaseJsonParser Tests ===\n\n");
+
+  testRealisticPrettyPrinted();
+  testRealisticMinified();
+  testPrettyAndMinifiedAgree();
+  testFirmwareNotFirstAsset();
+  testFieldOrderUrlBeforeName();
+  testFieldOrderSizeBeforeUrl();
+  testFieldOrderNameFirst();
+  testAssetsBeforeTagName();
+  testChunkedFeedingRealisticSmallChunks();
+  testChunkedFeedingByteByByte();
+  testChunkedFeedingVariousChunkSizes();
+  testMissingTagName();
+  testMissingFirmwareBinAsset();
+  testEmptyAssetsArray();
+  testNoAssetsKey();
+  testTruncatedBeforeTagValue();
+  testTruncatedInsideTagValue();
+  testTruncatedInsideAssetsArray();
+  testTruncatedAfterFirmwareName();
+  testTruncatedRealisticJson();
+  testNestedObjectsInAsset();
+  testNestedObjectsAtTopLevel();
+  testArraysAtTopLevel();
+  testResetAndReuse();
+  testResetClearsState();
+  testPartialAssetNameMatch();
+  testFirmwareBinExactMatch();
+  testLargeSize();
+  testSizeZero();
+  testMinimalValidJson();
+  testChunkedRealisticEveryBoundary();
+
+  printf("\n=== Results: %d passed, %d failed ===\n", testsPassed, testsFailed);
+  return testsFailed > 0 ? 1 : 0;
+}

--- a/test/run_release_json_parser_test.sh
+++ b/test/run_release_json_parser_test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/build/release_json_parser"
+BINARY="$BUILD_DIR/ReleaseJsonParserTest"
+
+mkdir -p "$BUILD_DIR"
+
+SOURCES=(
+  "$ROOT_DIR/test/release_json_parser/ReleaseJsonParserTest.cpp"
+  "$ROOT_DIR/lib/JsonParser/ReleaseJsonParser.cpp"
+  "$ROOT_DIR/lib/JsonParser/StreamingJsonParser.cpp"
+)
+
+CXXFLAGS=(
+  -std=c++20
+  -O2
+  -Wall
+  -Wextra
+  -pedantic
+  -I"$ROOT_DIR"
+  -I"$ROOT_DIR/lib"
+  -I"$ROOT_DIR/lib/JsonParser"
+)
+
+c++ "${CXXFLAGS[@]}" "${SOURCES[@]}" -o "$BINARY"
+
+"$BINARY" "$@"

--- a/test/run_streaming_json_parser_test.sh
+++ b/test/run_streaming_json_parser_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/build/streaming_json_parser"
+BINARY="$BUILD_DIR/StreamingJsonParserTest"
+
+mkdir -p "$BUILD_DIR"
+
+SOURCES=(
+  "$ROOT_DIR/test/streaming_json_parser/StreamingJsonParserTest.cpp"
+  "$ROOT_DIR/lib/JsonParser/StreamingJsonParser.cpp"
+)
+
+CXXFLAGS=(
+  -std=c++20
+  -O2
+  -Wall
+  -Wextra
+  -pedantic
+  -I"$ROOT_DIR"
+  -I"$ROOT_DIR/lib"
+  -I"$ROOT_DIR/lib/JsonParser"
+)
+
+c++ "${CXXFLAGS[@]}" "${SOURCES[@]}" -o "$BINARY"
+
+"$BINARY" "$@"

--- a/test/streaming_json_parser/StreamingJsonParserTest.cpp
+++ b/test/streaming_json_parser/StreamingJsonParserTest.cpp
@@ -1,0 +1,737 @@
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "lib/JsonParser/StreamingJsonParser.h"
+
+static int testsPassed = 0;
+static int testsFailed = 0;
+
+#define ASSERT_EQ(a, b)                                                           \
+  do {                                                                            \
+    auto _a = (a);                                                                \
+    auto _b = (b);                                                                \
+    if (_a != _b) {                                                               \
+      fprintf(stderr, "  FAIL: %s:%d: %s != expected\n", __FILE__, __LINE__, #a); \
+      testsFailed++;                                                              \
+      return;                                                                     \
+    }                                                                             \
+  } while (0)
+
+#define ASSERT_TRUE(cond)                                                \
+  do {                                                                   \
+    if (!(cond)) {                                                       \
+      fprintf(stderr, "  FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+      testsFailed++;                                                     \
+      return;                                                            \
+    }                                                                    \
+  } while (0)
+
+#define PASS() testsPassed++
+
+// Event types for recording callback sequences
+enum class EventType {
+  KEY,
+  STRING,
+  NUMBER,
+  BOOL_TRUE,
+  BOOL_FALSE,
+  NULL_VAL,
+  OBJECT_START,
+  OBJECT_END,
+  ARRAY_START,
+  ARRAY_END,
+};
+
+struct Event {
+  EventType type;
+  std::string value;
+};
+
+struct TestContext {
+  std::vector<Event> events;
+};
+
+static void onKey(void* ctx, const char* key, size_t len) {
+  static_cast<TestContext*>(ctx)->events.push_back({EventType::KEY, std::string(key, len)});
+}
+static void onString(void* ctx, const char* value, size_t len) {
+  static_cast<TestContext*>(ctx)->events.push_back({EventType::STRING, std::string(value, len)});
+}
+static void onNumber(void* ctx, const char* value, size_t len) {
+  static_cast<TestContext*>(ctx)->events.push_back({EventType::NUMBER, std::string(value, len)});
+}
+static void onBool(void* ctx, bool value) {
+  static_cast<TestContext*>(ctx)->events.push_back({value ? EventType::BOOL_TRUE : EventType::BOOL_FALSE, {}});
+}
+static void onNull(void* ctx) { static_cast<TestContext*>(ctx)->events.push_back({EventType::NULL_VAL, {}}); }
+static void onObjectStart(void* ctx) {
+  static_cast<TestContext*>(ctx)->events.push_back({EventType::OBJECT_START, {}});
+}
+static void onObjectEnd(void* ctx) { static_cast<TestContext*>(ctx)->events.push_back({EventType::OBJECT_END, {}}); }
+static void onArrayStart(void* ctx) { static_cast<TestContext*>(ctx)->events.push_back({EventType::ARRAY_START, {}}); }
+static void onArrayEnd(void* ctx) { static_cast<TestContext*>(ctx)->events.push_back({EventType::ARRAY_END, {}}); }
+
+static JsonCallbacks makeCallbacks(TestContext* ctx) {
+  return {ctx, onKey, onString, onNumber, onBool, onNull, onObjectStart, onObjectEnd, onArrayStart, onArrayEnd};
+}
+
+// Feed entire input at once
+static std::vector<Event> parse(const char* json) {
+  TestContext ctx;
+  StreamingJsonParser parser(makeCallbacks(&ctx));
+  parser.feed(json, strlen(json));
+  return ctx.events;
+}
+
+// Feed input one byte at a time
+static std::vector<Event> parseBytewise(const char* json) {
+  TestContext ctx;
+  StreamingJsonParser parser(makeCallbacks(&ctx));
+  size_t len = strlen(json);
+  for (size_t i = 0; i < len; ++i) {
+    parser.feed(json + i, 1);
+  }
+  return ctx.events;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+void testSimpleObject() {
+  printf("testSimpleObject...\n");
+
+  auto events = parse(R"({"key": "value", "num": 42})");
+
+  ASSERT_EQ(events.size(), 6u);
+  ASSERT_EQ(events[0].type, EventType::OBJECT_START);
+  ASSERT_EQ(events[1].type, EventType::KEY);
+  ASSERT_EQ(events[1].value, "key");
+  ASSERT_EQ(events[2].type, EventType::STRING);
+  ASSERT_EQ(events[2].value, "value");
+  ASSERT_EQ(events[3].type, EventType::KEY);
+  ASSERT_EQ(events[3].value, "num");
+  ASSERT_EQ(events[4].type, EventType::NUMBER);
+  ASSERT_EQ(events[4].value, "42");
+  ASSERT_EQ(events[5].type, EventType::OBJECT_END);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testNestedObjects() {
+  printf("testNestedObjects...\n");
+
+  auto events = parse(R"({"a": {"b": "c"}})");
+
+  ASSERT_EQ(events.size(), 7u);
+  ASSERT_EQ(events[0].type, EventType::OBJECT_START);
+  ASSERT_EQ(events[1].type, EventType::KEY);
+  ASSERT_EQ(events[1].value, "a");
+  ASSERT_EQ(events[2].type, EventType::OBJECT_START);
+  ASSERT_EQ(events[3].type, EventType::KEY);
+  ASSERT_EQ(events[3].value, "b");
+  ASSERT_EQ(events[4].type, EventType::STRING);
+  ASSERT_EQ(events[4].value, "c");
+  ASSERT_EQ(events[5].type, EventType::OBJECT_END);
+  ASSERT_EQ(events[6].type, EventType::OBJECT_END);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testArrayOfValues() {
+  printf("testArrayOfValues...\n");
+
+  auto events = parse(R"({"items": [1, "two", true, false, null]})");
+
+  ASSERT_EQ(events.size(), 10u);
+  ASSERT_EQ(events[0].type, EventType::OBJECT_START);
+  ASSERT_EQ(events[1].type, EventType::KEY);
+  ASSERT_EQ(events[1].value, "items");
+  ASSERT_EQ(events[2].type, EventType::ARRAY_START);
+  ASSERT_EQ(events[3].type, EventType::NUMBER);
+  ASSERT_EQ(events[3].value, "1");
+  ASSERT_EQ(events[4].type, EventType::STRING);
+  ASSERT_EQ(events[4].value, "two");
+  ASSERT_EQ(events[5].type, EventType::BOOL_TRUE);
+  ASSERT_EQ(events[6].type, EventType::BOOL_FALSE);
+  ASSERT_EQ(events[7].type, EventType::NULL_VAL);
+  ASSERT_EQ(events[8].type, EventType::ARRAY_END);
+  ASSERT_EQ(events[9].type, EventType::OBJECT_END);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testArrayOfObjects() {
+  printf("testArrayOfObjects...\n");
+
+  auto events = parse(R"([{"a": 1}, {"b": 2}])");
+
+  ASSERT_EQ(events.size(), 10u);
+  ASSERT_EQ(events[0].type, EventType::ARRAY_START);
+  ASSERT_EQ(events[1].type, EventType::OBJECT_START);
+  ASSERT_EQ(events[2].type, EventType::KEY);
+  ASSERT_EQ(events[2].value, "a");
+  ASSERT_EQ(events[3].type, EventType::NUMBER);
+  ASSERT_EQ(events[3].value, "1");
+  ASSERT_EQ(events[4].type, EventType::OBJECT_END);
+  ASSERT_EQ(events[5].type, EventType::OBJECT_START);
+  ASSERT_EQ(events[6].type, EventType::KEY);
+  ASSERT_EQ(events[6].value, "b");
+  ASSERT_EQ(events[7].type, EventType::NUMBER);
+  ASSERT_EQ(events[7].value, "2");
+  ASSERT_EQ(events[8].type, EventType::OBJECT_END);
+  ASSERT_EQ(events[9].type, EventType::ARRAY_END);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testStringEscapes() {
+  printf("testStringEscapes...\n");
+
+  auto events = parse(R"({"esc": "a\"b\\c\/d\ne\tf"})");
+
+  ASSERT_EQ(events.size(), 4u);
+  ASSERT_EQ(events[2].type, EventType::STRING);
+  ASSERT_EQ(events[2].value, std::string("a\"b\\c/d\ne\tf"));
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testUnicodeEscapePassthrough() {
+  printf("testUnicodeEscapePassthrough...\n");
+
+  auto events = parse(R"({"u": "\u0041\u0042"})");
+
+  ASSERT_EQ(events[2].type, EventType::STRING);
+  // \uXXXX passed through as literal \u followed by the hex digits
+  ASSERT_EQ(events[2].value, "\\u0041\\u0042");
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testNumbers() {
+  printf("testNumbers...\n");
+
+  auto events = parse(R"({"int": 42, "neg": -7, "flt": 3.14, "exp": 1e10, "nexp": -2.5E-3})");
+
+  ASSERT_EQ(events[2].type, EventType::NUMBER);
+  ASSERT_EQ(events[2].value, "42");
+  ASSERT_EQ(events[4].type, EventType::NUMBER);
+  ASSERT_EQ(events[4].value, "-7");
+  ASSERT_EQ(events[6].type, EventType::NUMBER);
+  ASSERT_EQ(events[6].value, "3.14");
+  ASSERT_EQ(events[8].type, EventType::NUMBER);
+  ASSERT_EQ(events[8].value, "1e10");
+  ASSERT_EQ(events[10].type, EventType::NUMBER);
+  ASSERT_EQ(events[10].value, "-2.5E-3");
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testBooleansAndNull() {
+  printf("testBooleansAndNull...\n");
+
+  auto events = parse(R"({"t": true, "f": false, "n": null})");
+
+  ASSERT_EQ(events[2].type, EventType::BOOL_TRUE);
+  ASSERT_EQ(events[4].type, EventType::BOOL_FALSE);
+  ASSERT_EQ(events[6].type, EventType::NULL_VAL);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testChunkedFeeding() {
+  printf("testChunkedFeeding...\n");
+
+  const char* json = R"({"key": "value", "num": 42, "arr": [1, 2]})";
+  auto reference = parse(json);
+
+  // Feed byte-by-byte and verify identical event sequence
+  auto bytewise = parseBytewise(json);
+
+  ASSERT_EQ(bytewise.size(), reference.size());
+  for (size_t i = 0; i < reference.size(); ++i) {
+    ASSERT_EQ(bytewise[i].type, reference[i].type);
+    ASSERT_EQ(bytewise[i].value, reference[i].value);
+  }
+
+  // Feed in chunks of varying size
+  for (size_t chunkSize = 2; chunkSize <= 7; ++chunkSize) {
+    TestContext ctx;
+    StreamingJsonParser parser(makeCallbacks(&ctx));
+    size_t len = strlen(json);
+    for (size_t offset = 0; offset < len; offset += chunkSize) {
+      size_t remaining = len - offset;
+      size_t feedLen = remaining < chunkSize ? remaining : chunkSize;
+      parser.feed(json + offset, feedLen);
+    }
+
+    ASSERT_EQ(ctx.events.size(), reference.size());
+    for (size_t i = 0; i < reference.size(); ++i) {
+      ASSERT_EQ(ctx.events[i].type, reference[i].type);
+      ASSERT_EQ(ctx.events[i].value, reference[i].value);
+    }
+  }
+
+  printf("  passed (byte-by-byte + chunk sizes 2-7)\n");
+  PASS();
+}
+
+void testEveryByteBoundary() {
+  printf("testEveryByteBoundary...\n");
+
+  const char* json = R"({"tag_name":"v1.2.3","assets":[{"name":"firmware.bin","size":12345}]})";
+  auto reference = parse(json);
+  size_t len = strlen(json);
+
+  for (size_t split = 0; split <= len; ++split) {
+    TestContext ctx;
+    StreamingJsonParser parser(makeCallbacks(&ctx));
+    if (split > 0) parser.feed(json, split);
+    if (split < len) parser.feed(json + split, len - split);
+
+    ASSERT_EQ(ctx.events.size(), reference.size());
+    for (size_t i = 0; i < reference.size(); ++i) {
+      if (ctx.events[i].type != reference[i].type || ctx.events[i].value != reference[i].value) {
+        fprintf(stderr, "  FAIL at split=%zu, event %zu\n", split, i);
+        testsFailed++;
+        return;
+      }
+    }
+  }
+
+  printf("  passed (all %zu split points)\n", len + 1);
+  PASS();
+}
+
+void testLargeTokenTruncation() {
+  printf("testLargeTokenTruncation...\n");
+
+  // Build a string value that exceeds TOKEN_BUF_SIZE
+  std::string longVal(StreamingJsonParser::TOKEN_BUF_SIZE + 100, 'x');
+  std::string json = R"({"short": "ok", "long": ")" + longVal + R"("})";
+
+  auto events = parse(json.c_str());
+
+  // "short" key + "ok" value should still fire
+  ASSERT_TRUE(events.size() >= 3);
+  ASSERT_EQ(events[1].type, EventType::KEY);
+  ASSERT_EQ(events[1].value, "short");
+  ASSERT_EQ(events[2].type, EventType::STRING);
+  ASSERT_EQ(events[2].value, "ok");
+
+  // The "long" key fires, but the oversized value is silently dropped
+  bool foundLongKey = false;
+  bool foundLongValue = false;
+  for (auto& e : events) {
+    if (e.type == EventType::KEY && e.value == "long") foundLongKey = true;
+    if (e.type == EventType::STRING && e.value.size() > 500) foundLongValue = true;
+  }
+  ASSERT_TRUE(foundLongKey);
+  ASSERT_TRUE(!foundLongValue);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testEmptyObject() {
+  printf("testEmptyObject...\n");
+
+  auto events = parse("{}");
+  ASSERT_EQ(events.size(), 2u);
+  ASSERT_EQ(events[0].type, EventType::OBJECT_START);
+  ASSERT_EQ(events[1].type, EventType::OBJECT_END);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testEmptyArray() {
+  printf("testEmptyArray...\n");
+
+  auto events = parse("[]");
+  ASSERT_EQ(events.size(), 2u);
+  ASSERT_EQ(events[0].type, EventType::ARRAY_START);
+  ASSERT_EQ(events[1].type, EventType::ARRAY_END);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testNestedArrays() {
+  printf("testNestedArrays...\n");
+
+  auto events = parse("[[1, 2], [3]]");
+  ASSERT_EQ(events.size(), 9u);
+  ASSERT_EQ(events[0].type, EventType::ARRAY_START);
+  ASSERT_EQ(events[1].type, EventType::ARRAY_START);
+  ASSERT_EQ(events[2].type, EventType::NUMBER);
+  ASSERT_EQ(events[2].value, "1");
+  ASSERT_EQ(events[3].type, EventType::NUMBER);
+  ASSERT_EQ(events[3].value, "2");
+  ASSERT_EQ(events[4].type, EventType::ARRAY_END);
+  ASSERT_EQ(events[5].type, EventType::ARRAY_START);
+  ASSERT_EQ(events[6].type, EventType::NUMBER);
+  ASSERT_EQ(events[6].value, "3");
+  ASSERT_EQ(events[7].type, EventType::ARRAY_END);
+  ASSERT_EQ(events[8].type, EventType::ARRAY_END);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testTopLevelArray() {
+  printf("testTopLevelArray...\n");
+
+  auto events = parse(R"(["hello", 42, true, null])");
+  ASSERT_EQ(events.size(), 6u);
+  ASSERT_EQ(events[0].type, EventType::ARRAY_START);
+  ASSERT_EQ(events[1].type, EventType::STRING);
+  ASSERT_EQ(events[1].value, "hello");
+  ASSERT_EQ(events[2].type, EventType::NUMBER);
+  ASSERT_EQ(events[2].value, "42");
+  ASSERT_EQ(events[3].type, EventType::BOOL_TRUE);
+  ASSERT_EQ(events[4].type, EventType::NULL_VAL);
+  ASSERT_EQ(events[5].type, EventType::ARRAY_END);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testWhitespaceVariants() {
+  printf("testWhitespaceVariants...\n");
+
+  // Minified
+  auto minified = parse(R"({"a":1,"b":"x"})");
+
+  // Pretty-printed
+  const char* pretty = "{\n  \"a\": 1,\n  \"b\": \"x\"\n}";
+  auto prettyEvents = parse(pretty);
+
+  ASSERT_EQ(minified.size(), prettyEvents.size());
+  for (size_t i = 0; i < minified.size(); ++i) {
+    ASSERT_EQ(minified[i].type, prettyEvents[i].type);
+    ASSERT_EQ(minified[i].value, prettyEvents[i].value);
+  }
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testResetBetweenDocuments() {
+  printf("testResetBetweenDocuments...\n");
+
+  TestContext ctx;
+  StreamingJsonParser parser(makeCallbacks(&ctx));
+
+  const char* json1 = R"({"a": 1})";
+  parser.feed(json1, strlen(json1));
+  ASSERT_EQ(ctx.events.size(), 4u);
+
+  ctx.events.clear();
+  parser.reset();
+
+  const char* json2 = R"({"b": 2})";
+  parser.feed(json2, strlen(json2));
+  ASSERT_EQ(ctx.events.size(), 4u);
+  ASSERT_EQ(ctx.events[1].value, "b");
+  ASSERT_EQ(ctx.events[2].value, "2");
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testNumberAtEndOfInput() {
+  printf("testNumberAtEndOfInput...\n");
+
+  // Number terminated by end of input (no trailing whitespace or structural char).
+  // The parser must emit the number when feed() ends (after a closing brace).
+  auto events = parse(R"({"n": 99})");
+  bool found = false;
+  for (auto& e : events) {
+    if (e.type == EventType::NUMBER && e.value == "99") found = true;
+  }
+  ASSERT_TRUE(found);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testArrayOfStrings() {
+  printf("testArrayOfStrings...\n");
+
+  auto events = parse(R"(["a", "b", "c"])");
+
+  ASSERT_EQ(events.size(), 5u);
+  ASSERT_EQ(events[0].type, EventType::ARRAY_START);
+  ASSERT_EQ(events[1].type, EventType::STRING);
+  ASSERT_EQ(events[1].value, "a");
+  ASSERT_EQ(events[2].type, EventType::STRING);
+  ASSERT_EQ(events[2].value, "b");
+  ASSERT_EQ(events[3].type, EventType::STRING);
+  ASSERT_EQ(events[3].value, "c");
+  ASSERT_EQ(events[4].type, EventType::ARRAY_END);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testTruncatedInputNoCrash() {
+  printf("testTruncatedInputNoCrash...\n");
+
+  // Simulates a connection drop mid-JSON. Parser must not crash.
+  const char* truncated[] = {
+      R"({"key": "val)", R"({"key": )",  R"({"key)",     R"([1, 2, )",
+      R"({"a": tru)",    R"({"a": fal)", R"({"a": nul)", R"({"a": "hello\)",
+  };
+
+  for (auto* json : truncated) {
+    TestContext ctx;
+    StreamingJsonParser parser(makeCallbacks(&ctx));
+    parser.feed(json, strlen(json));
+    // Just verify no crash; partial results are acceptable
+  }
+
+  printf("  passed (no crashes on %d truncated inputs)\n", 8);
+  PASS();
+}
+
+void testAllEscapeSequences() {
+  printf("testAllEscapeSequences...\n");
+
+  auto events = parse(R"({"e": "\b\f\n\r\t\"\\\/"})");
+  ASSERT_EQ(events[2].type, EventType::STRING);
+  ASSERT_EQ(events[2].value, std::string("\b\f\n\r\t\"\\/"));
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testObjectInArray() {
+  printf("testObjectInArray...\n");
+
+  // After an object closes inside an array, the next string after comma
+  // should be correctly identified as a key (inside the next object) or
+  // a string value (if directly in the array).
+  auto events = parse(R"([{"k":"v"}, "bare"])");
+
+  ASSERT_EQ(events.size(), 7u);
+  ASSERT_EQ(events[0].type, EventType::ARRAY_START);
+  ASSERT_EQ(events[1].type, EventType::OBJECT_START);
+  ASSERT_EQ(events[2].type, EventType::KEY);
+  ASSERT_EQ(events[2].value, "k");
+  ASSERT_EQ(events[3].type, EventType::STRING);
+  ASSERT_EQ(events[3].value, "v");
+  ASSERT_EQ(events[4].type, EventType::OBJECT_END);
+  ASSERT_EQ(events[5].type, EventType::STRING);
+  ASSERT_EQ(events[5].value, "bare");
+  ASSERT_EQ(events[6].type, EventType::ARRAY_END);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testDeeplyNested() {
+  printf("testDeeplyNested...\n");
+
+  // 20 levels of nesting (well within MAX_NESTING=32)
+  std::string json;
+  for (int i = 0; i < 20; ++i) json += R"({"d":)";
+  json += "0";
+  for (int i = 0; i < 20; ++i) json += "}";
+
+  auto events = parse(json.c_str());
+
+  // 20 OBJECT_START + 20 KEY + 1 NUMBER + 20 OBJECT_END = 61
+  ASSERT_EQ(events.size(), 61u);
+  ASSERT_EQ(events[0].type, EventType::OBJECT_START);
+  ASSERT_EQ(events[40].type, EventType::NUMBER);
+  ASSERT_EQ(events[40].value, "0");
+  ASSERT_EQ(events[60].type, EventType::OBJECT_END);
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testNestingOverflow() {
+  printf("testNestingOverflow...\n");
+
+  // Exceed MAX_NESTING -- parser should set error flag, not crash
+  std::string json;
+  for (size_t i = 0; i < StreamingJsonParser::MAX_NESTING + 5; ++i) json += "[";
+
+  TestContext ctx;
+  StreamingJsonParser parser(makeCallbacks(&ctx));
+  parser.feed(json.c_str(), json.size());
+
+  ASSERT_TRUE(parser.hasError());
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testNumberZero() {
+  printf("testNumberZero...\n");
+
+  auto events = parse(R"({"z": 0})");
+  ASSERT_EQ(events[2].type, EventType::NUMBER);
+  ASSERT_EQ(events[2].value, "0");
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testMultipleValuesInObject() {
+  printf("testMultipleValuesInObject...\n");
+
+  auto events = parse(R"({"a": "x", "b": "y", "c": "z"})");
+
+  ASSERT_EQ(events.size(), 8u);
+  ASSERT_EQ(events[1].value, "a");
+  ASSERT_EQ(events[2].value, "x");
+  ASSERT_EQ(events[3].value, "b");
+  ASSERT_EQ(events[4].value, "y");
+  ASSERT_EQ(events[5].value, "c");
+  ASSERT_EQ(events[6].value, "z");
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testChunkedSplitInsideString() {
+  printf("testChunkedSplitInsideString...\n");
+
+  const char* json = R"({"key": "hello world"})";
+  auto reference = parse(json);
+
+  // Split right in the middle of "hello world"
+  size_t splitAt = 14;  // inside the string value
+  TestContext ctx;
+  StreamingJsonParser parser(makeCallbacks(&ctx));
+  parser.feed(json, splitAt);
+  parser.feed(json + splitAt, strlen(json) - splitAt);
+
+  ASSERT_EQ(ctx.events.size(), reference.size());
+  for (size_t i = 0; i < reference.size(); ++i) {
+    ASSERT_EQ(ctx.events[i].type, reference[i].type);
+    ASSERT_EQ(ctx.events[i].value, reference[i].value);
+  }
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testChunkedSplitInsideEscape() {
+  printf("testChunkedSplitInsideEscape...\n");
+
+  const char* json = R"({"k": "a\"b"})";
+  auto reference = parse(json);
+
+  // Find the backslash position and split right after it
+  const char* bs = strchr(json + 7, '\\');
+  ASSERT_TRUE(bs != nullptr);
+  size_t splitAt = static_cast<size_t>(bs - json) + 1;  // after the backslash
+
+  TestContext ctx;
+  StreamingJsonParser parser(makeCallbacks(&ctx));
+  parser.feed(json, splitAt);
+  parser.feed(json + splitAt, strlen(json) - splitAt);
+
+  ASSERT_EQ(ctx.events.size(), reference.size());
+  for (size_t i = 0; i < reference.size(); ++i) {
+    ASSERT_EQ(ctx.events[i].type, reference[i].type);
+    ASSERT_EQ(ctx.events[i].value, reference[i].value);
+  }
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testChunkedSplitInsideLiteral() {
+  printf("testChunkedSplitInsideLiteral...\n");
+
+  const char* json = R"({"a": true, "b": false, "c": null})";
+  auto reference = parse(json);
+
+  // Split inside "true" (at "tr|ue")
+  size_t splitAt = 7;
+  TestContext ctx;
+  StreamingJsonParser parser(makeCallbacks(&ctx));
+  parser.feed(json, splitAt);
+  parser.feed(json + splitAt, strlen(json) - splitAt);
+
+  ASSERT_EQ(ctx.events.size(), reference.size());
+  for (size_t i = 0; i < reference.size(); ++i) {
+    ASSERT_EQ(ctx.events[i].type, reference[i].type);
+    ASSERT_EQ(ctx.events[i].value, reference[i].value);
+  }
+
+  printf("  passed\n");
+  PASS();
+}
+
+void testNullCallbacksNoCrash() {
+  printf("testNullCallbacksNoCrash...\n");
+
+  JsonCallbacks nullCbs = {};
+  nullCbs.ctx = nullptr;
+  StreamingJsonParser parser(nullCbs);
+
+  const char* json = R"({"key": "value", "num": 42, "b": true, "n": null, "a": [1]})";
+  parser.feed(json, strlen(json));
+  ASSERT_TRUE(!parser.hasError());
+
+  printf("  passed\n");
+  PASS();
+}
+
+// ============================================================================
+
+int main() {
+  printf("=== StreamingJsonParser Tests ===\n\n");
+
+  testSimpleObject();
+  testNestedObjects();
+  testArrayOfValues();
+  testArrayOfObjects();
+  testStringEscapes();
+  testUnicodeEscapePassthrough();
+  testNumbers();
+  testBooleansAndNull();
+  testChunkedFeeding();
+  testEveryByteBoundary();
+  testLargeTokenTruncation();
+  testEmptyObject();
+  testEmptyArray();
+  testNestedArrays();
+  testTopLevelArray();
+  testWhitespaceVariants();
+  testResetBetweenDocuments();
+  testNumberAtEndOfInput();
+  testArrayOfStrings();
+  testTruncatedInputNoCrash();
+  testAllEscapeSequences();
+  testObjectInArray();
+  testDeeplyNested();
+  testNestingOverflow();
+  testNumberZero();
+  testMultipleValuesInObject();
+  testChunkedSplitInsideString();
+  testChunkedSplitInsideEscape();
+  testChunkedSplitInsideLiteral();
+  testNullCallbacksNoCrash();
+
+  printf("\n=== Results: %d passed, %d failed ===\n", testsPassed, testsFailed);
+  return testsFailed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Ports two high-value upstream commits to DX34, plus a written PR plan covering rationale, DX34 adaptations, smoke tests, and a separate button-detection investigation tracked in the same doc.

- **`25157e4f`** — `fix: Read GH release JSON as stream in OTA updater` (upstream `aa7a31b3` / #1810): new `lib/JsonParser/{StreamingJsonParser,ReleaseJsonParser}` (SAX-style, host-tested); `OtaUpdater::checkForUpdate()` rewired to feed HTTP chunks into the streaming parser. DX34 specifics preserved: release URL, `CrossPoint-Mod-DX34-ESP32-` UA, `findSemverStart()`, 403/429 → `RATE_LIMITED`, `extern "C" esp_crt_bundle_attach` workaround, `installUpdate(std::function<void()>)` callback.
- **`82e69c54`** — `feat: self-heal from transient WiFi loss, add dBm indicator during WebServerActivity` (upstream `adcd7961` / #1780): WiFi state machine with `consecutiveDisconnects` + `firstDisconnectAt`, abandon only after `WIFI_ABANDON_MS = 5 min`; 4-bar dBm indicator with hysteresis. DX34 adaptations: `renderWifiIndicator` rewritten without UITheme metrics, `onGoBack` instead of `onGoHome`, kept STA-only `setAutoReconnect` and heap diag log.
- **`f445e8c0`** — `docs: PR plan` covering this port and the button-detection investigation.

### Skipped / parked from the upstream batch
- **`ba4a361d` (#1805)** skipped — X3-only (`skip_efuse_blk_check.c` + `bootloader_common_check_efuse_blk_validity` linker wrap); API refactor opposite direction from DX34's `std::function` migration.
- **`5717374e` (#1786)** parked — SD-card firmware update desirable but +928 lines / 13 files mixed with X3 bootloader compat; deserves its own PR.

Full rationale, risk surface, and decision tree in `docs/PR-PLAN-ota-wifi-buttons.md`.

## Test plan

- [ ] `pio run` clean (no new warnings)
- [ ] OTA check on device — confirm tag + URL parsed, no crash, free heap not regressed
- [ ] Provoke 403/429 on releases endpoint — returns `RATE_LIMITED`
- [ ] WiFi blip recovery — power-cycle router for ≤30 s during file transfer; banner appears, clears, IP refreshed
- [ ] WiFi sustained loss — kill router for ≥6 min; activity exits to network selection
- [ ] dBm indicator — bars track signal at varying distances, no flicker at thresholds; visual check both AP and STA
- [ ] Host unit tests — `bash test/run_streaming_json_parser_test.sh && bash test/run_release_json_parser_test.sh`

## Open questions for reviewer

1. Confirm DX34 release asset is exactly `firmware.bin` (parser matches that string).
2. Confirm `WIFI_ABANDON_MS = 5 min` is the desired UX vs e.g. 2 min.
3. Button-debug probes: temporary `BUTTON_DEBUG_TRACE` build flag, or separate `debug/` branch with probes always-on?
