### PR TITLE
fix(home): cache recents across re-entries to skip placeholder

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -68,6 +68,8 @@ std::vector<HomeMenuItem> buildHomeMenuItems(bool hasOpdsUrl) {
 
 }  // namespace
 
+std::vector<RecentBook> HomeActivity::recentBooks;
+
 int HomeActivity::getMenuItemCount() const {
   return getRecentSlotCount() + 1 + static_cast<int>(buildHomeMenuItems(hasOpdsUrl).size());
 }
@@ -178,8 +180,16 @@ void HomeActivity::onEnter() {
   // (15+ uploads dirties the SdFat cluster cache and contends the storage
   // mutex with the AsyncWriter drain), which previously left the user staring
   // at the popup over the file-transfer screen for the entire scan window.
-  recentBooks.clear();
-  recentsLoading = true;
+  //
+  // First-ever entry (cold boot): no cached list, draw placeholder + block
+  // input until the scan completes. Re-entry: keep the cached list visible
+  // and refresh silently in the background so users don't see a brief
+  // "Loading recents…" flash every time they exit a book.
+  if (recentBooks.empty()) {
+    recentsLoading = true;
+  } else {
+    recentsStale = true;
+  }
 
   // Half refresh on first render to clear ghosting from previous activity
   renderer.requestHalfRefresh();
@@ -209,6 +219,15 @@ void HomeActivity::loop() {
     recentsLoading = false;
     requestUpdate();
     return;
+  }
+  if (recentsStale) {
+    // Background refresh on re-entry: cached list already painted, rescan
+    // SD to pick up changes (deleted books, updated percentages), then
+    // request a redraw and fall through to normal input handling.
+    auto metrics = BaseMetrics::values;
+    recentsStale = false;
+    loadRecentBooks(metrics.homeRecentBooksCount);
+    requestUpdate();
   }
 
   // Let sub-activity (e.g. confirm dialog) handle input when active

--- a/src/activities/home/HomeActivity.h
+++ b/src/activities/home/HomeActivity.h
@@ -16,16 +16,24 @@ class HomeActivity final : public ActivityWithSubactivity {
   int scrollOffset = 0;         // First visible book index in recents list
   int firstVisibleBookIdx = 0;  // Updated by renderer each frame
   int lastVisibleBookIdx = 0;   // Updated by renderer each frame
-  // Paint-then-load: true between onEnter() and the first loop() tick that
-  // runs the SD scan. While set, render() draws a "Loading recents…"
+  // Paint-then-load: true on the very first home entry (cold boot) when no
+  // cached list is available. While set, render() draws a "Loading recents…"
   // placeholder in the recents area and loop() bails out before any input
   // handling so the user can't act on a stale empty list.
   bool recentsLoading = false;
+  // Re-entry refresh: true when home is re-entered with a cached list still
+  // in memory. The cached list is rendered immediately (no placeholder), and
+  // the SD scan runs on the first loop tick to refresh in place. Avoids the
+  // brief "Loading recents…" flash on every back-from-reader/library.
+  bool recentsStale = false;
   bool firstRenderDone = false;
   bool hasOpdsUrl = false;
   bool sleepFavoritesFull = false;
   size_t protectedSleepFavoriteCount = 0;
-  std::vector<RecentBook> recentBooks;
+  // Static so the list survives HomeActivity destruction/recreation (each
+  // home entry constructs a fresh instance). Lets re-entries render the
+  // last-known recents immediately while the background rescan runs.
+  static std::vector<RecentBook> recentBooks;
   const std::function<void(const std::string& path)> onSelectBook;
   const std::function<void()> onMyLibraryOpen;
   const std::function<void()> onRecentsOpen;


### PR DESCRIPTION
## Summary
- Make `recentBooks` static so it survives `HomeActivity` destruction (new instance constructed every home entry)
- On re-entry with non-empty cache: render cached list immediately, refresh via `recentsStale` flag in background — no placeholder flash
- Cold boot / empty cache: existing `recentsLoading` placeholder path unchanged
- Stale list briefly visible until rescan completes; reader-open path validates deleted paths

Companion to #132/#134 — preserves the post-file-transfer fix while removing the placeholder flicker on every back-from-reader.

## Test plan
- [ ] Cold boot: placeholder shows once, then list (unchanged)
- [ ] Open book → exit: home shows recents immediately, no placeholder flash
- [ ] Delete book on web, return to home: brief stale entry, then refreshed list
- [ ] After 15+ wallpaper uploads → exit: no UI hang (placeholder also skipped if cache exists; if user wants placeholder there, can revisit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)