### PR TITLE
fix: snappy nav (#138) — match upstream input + drop home recents placeholder

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -173,20 +173,13 @@ void HomeActivity::onEnter() {
   selectorIndex = 1;  // Default focus on first recent book
   scrollOffset = 0;
 
-  // Paint-then-load: defer the recent-books SD scan to the first loop tick so
-  // the popup ("Loading home…") is replaced by a real frame in <100 ms instead
-  // of waiting for the per-book Storage.exists() probes. The SD layer can be
-  // unresponsive for several seconds right after a file-transfer session
-  // (15+ uploads dirties the SdFat cluster cache and contends the storage
-  // mutex with the AsyncWriter drain), which previously left the user staring
-  // at the popup over the file-transfer screen for the entire scan window.
-  //
-  // First-ever entry (cold boot): no cached list, draw placeholder + block
-  // input until the scan completes. Re-entry: keep the cached list visible
-  // and refresh silently in the background so users don't see a brief
-  // "Loading recents…" flash every time they exit a book.
+  // Cold boot: scan synchronously so the first home frame is fully populated
+  // (no "Loading recents…" placeholder). The "Loading home…" transition popup
+  // already covers this window. Re-entry: cached list is drawn immediately
+  // and a silent rescan runs on the first loop tick to pick up any changes.
   if (recentBooks.empty()) {
-    recentsLoading = true;
+    auto metrics = BaseMetrics::values;
+    loadRecentBooks(metrics.homeRecentBooksCount);
   } else {
     recentsStale = true;
   }
@@ -209,17 +202,6 @@ void HomeActivity::onEnter() {
 void HomeActivity::onExit() { Activity::onExit(); }
 
 void HomeActivity::loop() {
-  // Paint-then-load: first tick after onEnter — placeholder frame is already
-  // painting (or just painted), now run the actual SD scan. Skip input
-  // handling entirely until the load completes so the user cannot act on a
-  // stale empty list.
-  if (recentsLoading) {
-    auto metrics = BaseMetrics::values;
-    loadRecentBooks(metrics.homeRecentBooksCount);
-    recentsLoading = false;
-    requestUpdate();
-    return;
-  }
   if (recentsStale) {
     // Background refresh on re-entry: cached list already painted, rescan
     // SD to pick up changes (deleted books, updated percentages), then
@@ -421,34 +403,19 @@ void HomeActivity::render(Activity::RenderLock&&) {
   const int recentAreaBottomGap = 8;
   const int recentAreaY = warningBottomY;
   const int recentAreaHeight = std::max(0, menuY - recentAreaBottomGap - recentAreaY);
-  if (recentsLoading) {
-    // Paint-then-load placeholder: SD scan runs on next loop tick. Centered
-    // status text in the recents region keeps the rest of the home frame
-    // (header, session counter, menu) usable so the popup goes away quickly
-    // even when /sleep is dirty from a just-finished file transfer.
-    const char* msg = tr(STR_LOADING_RECENTS);
-    const int msgW = renderer.getTextWidth(UI_10_FONT_ID, msg);
-    const int msgH = renderer.getLineHeight(UI_10_FONT_ID);
-    const int msgX = (pageWidth - msgW) / 2;
-    const int msgY = recentAreaY + std::max(0, (recentAreaHeight - msgH) / 2);
-    renderer.drawText(UI_10_FONT_ID, msgX, msgY, msg);
-  } else {
-    switch (SETTINGS.homeLayout) {
-      case CrossPointSettings::HOME_LAYOUT_SINGLE_COVER: {
-        GUI.drawRecentBookSingleCover(renderer, Rect{0, recentAreaY, pageWidth, recentAreaHeight}, recentBooks,
-                                      selectorIndex - 1, scrollOffset);
-        break;
-      }
-      default: {
-        auto vis = GUI.drawRecentBookCover(renderer, Rect{0, recentAreaY, pageWidth, recentAreaHeight}, recentBooks,
-                                           selectorIndex - 1, scrollOffset);
-        firstVisibleBookIdx = vis.firstVisible;
-        lastVisibleBookIdx = vis.lastVisible;
-        // Sync scrollOffset with renderer's adjusted position
-        // (renderer may have adjusted it to keep the selected book visible)
-        scrollOffset = vis.firstVisible;
-        break;
-      }
+  switch (SETTINGS.homeLayout) {
+    case CrossPointSettings::HOME_LAYOUT_SINGLE_COVER: {
+      GUI.drawRecentBookSingleCover(renderer, Rect{0, recentAreaY, pageWidth, recentAreaHeight}, recentBooks,
+                                    selectorIndex - 1, scrollOffset);
+      break;
+    }
+    default: {
+      auto vis = GUI.drawRecentBookCover(renderer, Rect{0, recentAreaY, pageWidth, recentAreaHeight}, recentBooks,
+                                         selectorIndex - 1, scrollOffset);
+      firstVisibleBookIdx = vis.firstVisible;
+      lastVisibleBookIdx = vis.lastVisible;
+      scrollOffset = vis.firstVisible;
+      break;
     }
   }
 
@@ -488,10 +455,7 @@ void HomeActivity::render(Activity::RenderLock&&) {
 
   renderer.displayBuffer();
 
-  // Defer the post-HALF_REFRESH RED-RAM baseline render until the recents
-  // load has finished — otherwise we'd burn an extra refresh on the
-  // placeholder frame that the next loop tick would immediately overwrite.
-  if (!firstRenderDone && !recentsLoading) {
+  if (!firstRenderDone) {
     firstRenderDone = true;
     requestUpdate();
   }

--- a/src/activities/home/HomeActivity.h
+++ b/src/activities/home/HomeActivity.h
@@ -16,15 +16,11 @@ class HomeActivity final : public ActivityWithSubactivity {
   int scrollOffset = 0;         // First visible book index in recents list
   int firstVisibleBookIdx = 0;  // Updated by renderer each frame
   int lastVisibleBookIdx = 0;   // Updated by renderer each frame
-  // Paint-then-load: true on the very first home entry (cold boot) when no
-  // cached list is available. While set, render() draws a "Loading recents…"
-  // placeholder in the recents area and loop() bails out before any input
-  // handling so the user can't act on a stale empty list.
-  bool recentsLoading = false;
   // Re-entry refresh: true when home is re-entered with a cached list still
-  // in memory. The cached list is rendered immediately (no placeholder), and
-  // the SD scan runs on the first loop tick to refresh in place. Avoids the
-  // brief "Loading recents…" flash on every back-from-reader/library.
+  // in memory. The cached list is rendered immediately, and the SD scan runs
+  // on the first loop tick to refresh in place. On cold boot the scan runs
+  // synchronously inside onEnter() (covered by the "Loading home…" transition
+  // popup) so the recents list is fully populated by the first frame.
   bool recentsStale = false;
   bool firstRenderDone = false;
   bool hasOpdsUrl = false;


### PR DESCRIPTION
## Summary
Fixes #138. Two changes:

1. **Input** (submodule `open-x4-sdk` @ `fix/input-debounce-snappy`): match upstream / inx single-sample reads.
   - `DEBOUNCE_DELAY` 15 → 5 ms
   - `ADC_OVERSAMPLE` 8 → 1
   - Reverts both deltas from #136. Page-turn taps no longer need extra force; menu/Settings entry feels as snappy as `crosspoint-reader/community-sdk` and `open-x4-epaper/community-sdk`.

2. **Home** (`HomeActivity`): drop "Loading recents…" placeholder.
   - Cold boot: `loadRecentBooks()` runs synchronously inside `onEnter()` so the first home frame is fully populated. The existing "Loading home…" transition popup covers this window.
   - Re-entry: cached static list (#137) is drawn immediately, silent background rescan continues on the first loop tick.
   - Removes `recentsLoading` flag and its paint-then-load / render / first-refresh branches.

## Verification
- [x] Flashed on DX34, page-turns register on light taps, no missed presses on rapid Up/Down/Confirm.
- [x] Cold boot home: recents list appears with the frame, no placeholder.
- [x] Back-from-reader to home: cached list shown immediately.
- [x] Remove book via Back: list refreshes without placeholder.

Closes #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)