### PR TITLE
fix(sleep): prevent same wallpaper showing back-to-back after reshuffle

### DIFF
--- a/src/sleep/WallpaperPlaylistV2.cpp
+++ b/src/sleep/WallpaperPlaylistV2.cpp
@@ -417,7 +417,20 @@ bool WallpaperPlaylistV2::reshuffle() {
       std::swap(names[i], names[j]);
     }
   }
-  writeBuffer(names, 0);
+  // Anti-repeat: after Fisher-Yates the just-shown name has a 1/N chance of
+  // landing at index 0. With small libraries (4-6 favorites) that produces
+  // visible back-to-back repeats almost every lap. Rotate the just-shown name
+  // to position 0 and start the cursor past it so the next advance() skips
+  // it. Mirrors V1 migrateToSmall (WallpaperPlaylist.cpp).
+  size_t startCursor = 0;
+  if (deps_.lastShownFilename && !deps_.lastShownFilename->empty() && names.size() > 1) {
+    auto it = std::find(names.begin(), names.end(), *deps_.lastShownFilename);
+    if (it != names.end()) {
+      std::rotate(names.begin(), it, it + 1);
+      startCursor = names[0].size() + 1;
+    }
+  }
+  writeBuffer(names, startCursor);
   loaded_ = true;
   return true;
 }

--- a/test/test_wallpaper_playlist_v2/test_main.cpp
+++ b/test/test_wallpaper_playlist_v2/test_main.cpp
@@ -275,8 +275,7 @@ void test_reshuffle_does_not_repeat_just_shown_wallpaper() {
     fx.fakeRandomSeed = static_cast<long>(trial * 31 + 7);
     const auto firstAfterReshuffle = wp.advance();
     TEST_ASSERT_FALSE(firstAfterReshuffle.empty());
-    TEST_ASSERT_TRUE_MESSAGE(firstAfterReshuffle != lastInLap,
-                             "Just-shown wallpaper appeared again after reshuffle");
+    TEST_ASSERT_TRUE_MESSAGE(firstAfterReshuffle != lastInLap, "Just-shown wallpaper appeared again after reshuffle");
     lastInLap = firstAfterReshuffle;
     // Walk to end of this lap to set up the next reshuffle.
     for (int i = 0; i < 2; ++i) {

--- a/test/test_wallpaper_playlist_v2/test_main.cpp
+++ b/test/test_wallpaper_playlist_v2/test_main.cpp
@@ -253,6 +253,39 @@ void test_advance_skips_files_deleted_since_reconcile() {
   }
 }
 
+void test_reshuffle_does_not_repeat_just_shown_wallpaper() {
+  // 4 files. With seed 0 the FY shuffle ends "f3, f0, f1, f2" — index 0 is
+  // f3, which would also be the last file shown by lap 1 under that same
+  // PRNG sequence. Pre-fix: f3 shows again immediately after reshuffle.
+  Fixture fx;
+  for (int i = 0; i < 4; ++i) fx.fs.seed(std::string("f") + char('0' + i) + ".bmp", 100 + i);
+  auto& wp = crosspoint::sleep::v2::WallpaperPlaylistV2::instance();
+  wp.resetForTest();
+  fx.wire(wp);
+  wp.markFolderDirty();
+  wp.reconcile();
+
+  std::string lastInLap;
+  for (int i = 0; i < 4; ++i) lastInLap = wp.advance();
+  TEST_ASSERT_FALSE(lastInLap.empty());
+
+  // Drive several reshuffle cycles under different PRNG seeds. The first
+  // wallpaper of each new lap must never equal the last of the previous lap.
+  for (int trial = 0; trial < 16; ++trial) {
+    fx.fakeRandomSeed = static_cast<long>(trial * 31 + 7);
+    const auto firstAfterReshuffle = wp.advance();
+    TEST_ASSERT_FALSE(firstAfterReshuffle.empty());
+    TEST_ASSERT_TRUE_MESSAGE(firstAfterReshuffle != lastInLap,
+                             "Just-shown wallpaper appeared again after reshuffle");
+    lastInLap = firstAfterReshuffle;
+    // Walk to end of this lap to set up the next reshuffle.
+    for (int i = 0; i < 2; ++i) {
+      const auto n = wp.advance();
+      if (!n.empty()) lastInLap = n;
+    }
+  }
+}
+
 }  // namespace
 
 int main(int, char**) {
@@ -264,5 +297,6 @@ int main(int, char**) {
   RUN_TEST(test_favorites_full_blocks_new_uploads);
   RUN_TEST(test_reshuffle_clears_buffer_when_sleep_empty);
   RUN_TEST(test_advance_skips_files_deleted_since_reconcile);
+  RUN_TEST(test_reshuffle_does_not_repeat_just_shown_wallpaper);
   return UNITY_END();
 }


### PR DESCRIPTION
## Summary

User-reported regression: after a sleep wallpaper is shown, the next sleep cycle could show the same wallpaper again — visible nearly every lap with small libraries (favorites-only setups of 4-6 files).

## Root cause

`WallpaperPlaylistV2::reshuffle()` (src/sleep/WallpaperPlaylistV2.cpp) Fisher-Yates'd the full `/sleep` listing and wrote `cursor=0` with **no awareness of `lastShownFilename`**. The just-displayed wallpaper had a 1/N chance of landing at index 0 and being displayed again immediately on the next sleep cycle.

V1 (`WallpaperPlaylist::migrateToSmall`) deliberately handled this case — V2 lost it during the unification.

## Fix

After Fisher-Yates, find `lastShownFilename` in the shuffled list, rotate it to position 0, and start the cursor past it so the next `advance()` skips it. The skipped wallpaper rejoins the random pool on the following reshuffle, so it isn't permanently excluded.

## Notes on the second symptom

The user also reported "recent photos added not going on top of array." Tracing reconcile() against the existing test (`test_new_files_inserted_at_cursor_in_mtime_order`) confirms the splice-at-cursor insertion is correct — new files do display next. The perceived "not on top" was almost certainly the same back-to-back-repeat bug surfacing an old wallpaper right after the new one was shown once, making it look like the queue had reverted. The reshuffle fix addresses both perceptions.

## Test plan

- [x] New host test `test_reshuffle_does_not_repeat_just_shown_wallpaper` walks 16 reshuffle cycles under varied PRNG seeds and asserts the first wallpaper of each new lap differs from the last of the previous lap. Fails on `main`, passes with the fix.
- [x] Existing tests unchanged (`test_advance_with_4_files_walks_all_then_reshuffles`, `test_new_files_inserted_at_cursor_in_mtime_order`, etc.) — fix doesn't change in-lap order or insertion semantics.
- [ ] Manual check on device with a small favorites set (4-6 wallpapers): walk through ≥3 laps and confirm no back-to-back repeats.

https://claude.ai/code/session_014UzqqXhUSt2PJb8LPo6gPT

---
_Generated by [Claude Code](https://claude.ai/code/session_014UzqqXhUSt2PJb8LPo6gPT)_