### PR TITLE
fix(ota): set 15s timeout on checkForUpdate, surface error code on failure

### DIFF
--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -156,6 +156,33 @@ void OtaUpdateActivity::render(Activity::RenderLock&&) {
     renderer.drawCenteredText(UI_10_FONT_ID, 300, tr(STR_UPDATE_FAILED), true, EpdFontFamily::REGULAR);
     if (lastError == OtaUpdater::RATE_LIMITED) {
       renderer.drawCenteredText(UI_10_FONT_ID, 340, "Try again in a few minutes");
+    } else {
+      // Surface the failure branch on screen so users without a serial console
+      // can report exactly which step failed. Codes match OtaUpdater::OtaUpdaterError.
+      const char* hint = "";
+      switch (lastError) {
+        case OtaUpdater::HTTP_ERROR:
+          hint = "Code 2: network/TLS to GitHub";
+          break;
+        case OtaUpdater::JSON_PARSE_ERROR:
+          hint = "Code 3: release JSON parse";
+          break;
+        case OtaUpdater::UPDATE_OLDER_ERROR:
+          hint = "Code 4: latest is older";
+          break;
+        case OtaUpdater::INTERNAL_UPDATE_ERROR:
+          hint = "Code 5: install/partition";
+          break;
+        case OtaUpdater::OOM_ERROR:
+          hint = "Code 6: out of memory";
+          break;
+        default:
+          hint = "";
+          break;
+      }
+      if (hint[0] != '\0') {
+        renderer.drawCenteredText(UI_10_FONT_ID, 340, hint);
+      }
     }
     renderer.displayBuffer();
     return;

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -4,6 +4,8 @@
 #include <I18n.h>
 #include <WiFi.h>
 
+#include <cstdio>
+
 #include "MappedInputManager.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/themes/BaseTheme.h"
@@ -158,30 +160,33 @@ void OtaUpdateActivity::render(Activity::RenderLock&&) {
       renderer.drawCenteredText(UI_10_FONT_ID, 340, "Try again in a few minutes");
     } else {
       // Surface the failure branch on screen so users without a serial console
-      // can report exactly which step failed. Codes match OtaUpdater::OtaUpdaterError.
-      const char* hint = "";
+      // can report exactly which step failed. The numeric code is rendered
+      // from the enum value at runtime so it can't drift if OtaUpdaterError
+      // is reordered.
+      const char* desc = "";
       switch (lastError) {
         case OtaUpdater::HTTP_ERROR:
-          hint = "Code 2: network/TLS to GitHub";
+          desc = "network/TLS to GitHub";
           break;
         case OtaUpdater::JSON_PARSE_ERROR:
-          hint = "Code 3: release JSON parse";
+          desc = "release JSON parse";
           break;
         case OtaUpdater::UPDATE_OLDER_ERROR:
-          hint = "Code 4: latest is older";
+          desc = "latest is older";
           break;
         case OtaUpdater::INTERNAL_UPDATE_ERROR:
-          hint = "Code 5: install/partition";
+          desc = "install/partition";
           break;
         case OtaUpdater::OOM_ERROR:
-          hint = "Code 6: out of memory";
+          desc = "out of memory";
           break;
         default:
-          hint = "";
           break;
       }
-      if (hint[0] != '\0') {
-        renderer.drawCenteredText(UI_10_FONT_ID, 340, hint);
+      if (desc[0] != '\0') {
+        char hintBuf[64];
+        std::snprintf(hintBuf, sizeof(hintBuf), "Code %d: %s", static_cast<int>(lastError), desc);
+        renderer.drawCenteredText(UI_10_FONT_ID, 340, hintBuf);
       }
     }
     renderer.displayBuffer();

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -57,6 +57,12 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
 
   esp_http_client_config_t client_config = {
       .url = latestReleaseUrl,
+      // ESP-IDF default is 5 s, which is too tight for the full DNS + TLS +
+      // GitHub-API roundtrip on a marginal WiFi: a single slow DNS lookup or
+      // TLS retransmit pushed the whole request into ESP_ERR_TIMEOUT, surfacing
+      // as "Update failed (Code 2)" before the retry loop's backoff helped.
+      // 15 s matches installUpdate() and gives the retry loop a fair shot.
+      .timeout_ms = 15000,
       .event_handler = event_handler,
       .buffer_size = 8192,
       .buffer_size_tx = 8192,


### PR DESCRIPTION
## Summary

User report: OTA from Settings → Update fails with "Update failed" during the **"Checking for update"** step (not during install). No serial console available, so the on-screen text was the only diagnostic — and it carried no detail about which branch fired.

## Investigation

Traced both layers and ruled out:

1. **GitHub release infrastructure** — v2.2.2 release exists with a correctly-named `firmware.bin` asset (size 6,123,888 B, fits the 6.55 MB OTA partition with ~420 KB headroom).
2. **Streaming JSON parser regression** (introduced in #135) — fed the *real* live v2.2.2 release JSON to `ReleaseJsonParser` in a host-side test; it correctly extracts `tag_name`, `firmware.bin` URL, and size.

That points the failure at the HTTP/TLS layer of `OtaUpdater::checkForUpdate()`. Reading the code: `installUpdate()` sets `timeout_ms = 15000`, but `checkForUpdate()`'s `esp_http_client_config_t` left `timeout_ms` unset, so it inherits ESP-IDF's **5-second** default. On flaky WiFi a single slow DNS resolution or TLS retransmit blows past 5s, `esp_http_client_perform` returns `ESP_ERR_TIMEOUT`, and the activity drops into FAILED — exactly the symptom reported.

## Changes

1. **`OtaUpdater.cpp`** — set `timeout_ms = 15000` on the check-for-update HTTP client config, mirroring `installUpdate()`. Combined with the existing 3-attempt retry-with-backoff in `OtaUpdateActivity::onWifiSelectionComplete`, this gives the request a fair shot on marginal WiFi.

2. **`OtaUpdateActivity.cpp`** — when `state == FAILED` (and the error isn't `RATE_LIMITED`, which already has its own message), render a short hint under "Update failed" describing which `OtaUpdaterError` branch fired:
   - Code 2: network/TLS to GitHub
   - Code 3: release JSON parse
   - Code 4: latest is older
   - Code 5: install/partition
   - Code 6: out of memory

   So the next failed OTA — even on a user's device without a serial console — produces an actionable bug report.

## Test plan

- [x] Host-side: re-ran the parser against the live v2.2.2 release JSON in `lib/JsonParser` to confirm `foundTag` + `foundFirmware` + correct `getFirmwareUrl/getFirmwareSize`. (Rules out the parser as the cause.)
- [ ] On-device verification on a marginal WiFi: previously-failing OTA check now succeeds, or fails with the specific error code visible on the FAILED screen.

## Notes for the reporting user

Today's broken OTA can't pull this fix in (chicken-and-egg). To unblock, you'll need a one-time manual flash of this build via PlatformIO / esptool. After that, future OTA attempts will either succeed (if the timeout was the issue) or show a code on screen so we can pinpoint the exact failure branch.

https://claude.ai/code/session_014UzqqXhUSt2PJb8LPo6gPT

---
_Generated by [Claude Code](https://claude.ai/code/session_014UzqqXhUSt2PJb8LPo6gPT)_