### PR TITLE
fix: the png converter allocates row buffers based o... in...

### DIFF
--- a/lib/PngToBmpConverter/PngToBmpConverter.cpp
+++ b/lib/PngToBmpConverter/PngToBmpConverter.cpp
@@ -350,7 +350,7 @@ static void convertScanlineToGray(const PngDecodeContext& ctx, uint8_t* grayRow)
   switch (ctx.colorType) {
     case PNG_COLOR_GRAYSCALE:
       if (ctx.bitDepth == 8) {
-        memcpy(grayRow, src, w);
+        memcpy(grayRow, src, ctx.rawRowBytes);
       } else if (ctx.bitDepth == 16) {
         for (uint32_t x = 0; x < w; x++) grayRow[x] = src[x * 2];
       } else {


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `lib/PngToBmpConverter/PngToBmpConverter.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `lib/PngToBmpConverter/PngToBmpConverter.cpp:353` |
| **CWE** | CWE-120 |

**Description**: The PNG converter allocates row buffers based on rawRowBytes (derived from PNG header fields: width × channels × bytesPerSample) and then performs memcpy(grayRow, src, w) at line 353 using the raw image width 'w' as the copy length. If the PNG header specifies a large width but rawRowBytes is computed as a smaller value (due to channel/bit-depth mismatch or integer overflow in V-002), 'w' can exceed the allocated buffer size, causing a heap buffer overflow. An attacker crafts a PNG with manipulated header fields to trigger this condition via any file delivery mechanism.

## Changes
- `lib/PngToBmpConverter/PngToBmpConverter.cpp`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
