### PR TITLE
fix(upload): evict font cache before rejecting upload on fragmented heap

### DIFF
--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -1797,8 +1797,8 @@ void CrossPointWebServer::handleUploadFont(FontUploadState& state) {
                   static_cast<unsigned>(before), static_cast<unsigned>(largest), static_cast<unsigned>(kNeeded));
         } else {
           state.error = "out of memory (try again from desktop browser)";
-          LOG_ERR("WEB", "[FONT-UPLOAD] buffer alloc skipped: largest=%u free=%u min=%u", static_cast<unsigned>(largest),
-                  ESP.getFreeHeap(), ESP.getMinFreeHeap());
+          LOG_ERR("WEB", "[FONT-UPLOAD] buffer alloc skipped: largest=%u free=%u min=%u",
+                  static_cast<unsigned>(largest), ESP.getFreeHeap(), ESP.getMinFreeHeap());
           return;
         }
       }

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -5,7 +5,9 @@
 #include <EpdBinFontLoader.h>
 #include <EpdBinFormat.h>
 #include <Epub.h>
+#include <FontCacheManager.h>
 #include <FsHelpers.h>
+#include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <Logging.h>
 #include <Txt.h>
@@ -43,6 +45,10 @@
 #include "html/js/pako_minJs.generated.h"
 #include "network/ws/WsUploadSession.h"
 #include "util/StringUtils.h"
+
+// Global renderer defined in main.cpp. We only need it for the upload-path
+// heap-relief helper below; see tryReleaseHeapForUpload().
+extern GfxRenderer renderer;
 
 namespace {
 // Folders/files to hide from the web interface file browser
@@ -93,6 +99,25 @@ std::string bookCachePath(const std::string& filePath) {
     return BookFingerprint::cacheDirName("txt", filePath, Paths::kDataDir);
   }
   return {};
+}
+
+// Drop the font-decompressor's hot-group + page-slot buffers and re-probe
+// the largest contiguous free block. This is the only cache-drop primitive
+// reachable from the upload callback that is safe from any task — same
+// rationale documented on the heap alloc-failure hook in main.cpp: FCM is a
+// single-instance subsystem behind a global renderer, no locks needed, and
+// free() coalesces adjacent blocks in-place so `largest` reflects the merged
+// region on return. Returns true iff post-drop largest >= `needed`.
+//
+// Heavier primitives (page cache, CSS parser, Epub::clearCache, removeDir)
+// either need the active reader's render lock or do SD I/O — both off-limits
+// here.
+bool tryReleaseHeapForUpload(size_t needed) {
+  auto* fcm = renderer.getFontCacheManager();
+  if (!fcm) return false;
+  fcm->clearCache();
+  const size_t largest = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+  return largest >= needed;
 }
 
 // Clear book cache for a file (all book types, not just epub)
@@ -1151,13 +1176,23 @@ void CrossPointWebServer::handleUpload(UploadState& state) const {
     // (-fno-exceptions), so a bad_alloc inside resize would call terminate()
     // and abort the firmware. Phone-on-STA after fetching the 64 KB JS bundle
     // hits this path: heap can fragment below the buffer size mid-upload.
+    // Before bailing, drop reclaimable caches and re-probe — most often the
+    // fragmentation is glyph hot-group + page slots from rendering the UI.
     if (state.buffer.size() != UploadState::UPLOAD_BUFFER_SIZE) {
-      const size_t largest = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
-      if (largest < UploadState::UPLOAD_BUFFER_SIZE + 1024) {
-        state.error = "out of memory (try again from desktop browser)";
-        LOG_ERR("WEB", "[UPLOAD] buffer alloc skipped: largest=%u free=%u min=%u", static_cast<unsigned>(largest),
-                ESP.getFreeHeap(), ESP.getMinFreeHeap());
-        return;
+      constexpr size_t kNeeded = UploadState::UPLOAD_BUFFER_SIZE + 1024;
+      size_t largest = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+      if (largest < kNeeded) {
+        const size_t before = largest;
+        if (tryReleaseHeapForUpload(kNeeded)) {
+          largest = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+          LOG_INF("WEB", "[UPLOAD] heap recovered via cache evict: %u -> %u (need %u)", static_cast<unsigned>(before),
+                  static_cast<unsigned>(largest), static_cast<unsigned>(kNeeded));
+        } else {
+          state.error = "out of memory (try again from desktop browser)";
+          LOG_ERR("WEB", "[UPLOAD] buffer alloc skipped: largest=%u free=%u min=%u", static_cast<unsigned>(largest),
+                  ESP.getFreeHeap(), ESP.getMinFreeHeap());
+          return;
+        }
       }
       state.buffer.resize(UploadState::UPLOAD_BUFFER_SIZE);
     }
@@ -1748,15 +1783,24 @@ void CrossPointWebServer::handleUploadFont(FontUploadState& state) {
     state.finalPath = "";
     // Pre-flight heap check (exceptions disabled — bad_alloc would abort).
     // Phone-on-STA after fetching the 64 KB JS bundle hits this path; heap
-    // can fragment below the 4 KB buffer size. Bail gracefully so
-    // handleUploadFontPost returns a 400 JSON error instead of crashing.
+    // can fragment below the 4 KB buffer size. Before bailing, drop
+    // reclaimable caches and re-probe so a fragmented-but-recoverable heap
+    // doesn't force the user back to a desktop browser.
     if (state.buffer.size() != FontUploadState::UPLOAD_BUFFER_SIZE) {
-      const size_t largest = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
-      if (largest < FontUploadState::UPLOAD_BUFFER_SIZE + 1024) {
-        state.error = "out of memory (try again from desktop browser)";
-        LOG_ERR("WEB", "[FONT-UPLOAD] buffer alloc skipped: largest=%u free=%u min=%u", static_cast<unsigned>(largest),
-                ESP.getFreeHeap(), ESP.getMinFreeHeap());
-        return;
+      constexpr size_t kNeeded = FontUploadState::UPLOAD_BUFFER_SIZE + 1024;
+      size_t largest = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+      if (largest < kNeeded) {
+        const size_t before = largest;
+        if (tryReleaseHeapForUpload(kNeeded)) {
+          largest = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+          LOG_INF("WEB", "[FONT-UPLOAD] heap recovered via cache evict: %u -> %u (need %u)",
+                  static_cast<unsigned>(before), static_cast<unsigned>(largest), static_cast<unsigned>(kNeeded));
+        } else {
+          state.error = "out of memory (try again from desktop browser)";
+          LOG_ERR("WEB", "[FONT-UPLOAD] buffer alloc skipped: largest=%u free=%u min=%u", static_cast<unsigned>(largest),
+                  ESP.getFreeHeap(), ESP.getMinFreeHeap());
+          return;
+        }
       }
       state.buffer.resize(FontUploadState::UPLOAD_BUFFER_SIZE);
     }


### PR DESCRIPTION
## Summary

- The pre-flight heap gate in `handleUpload` / `handleUploadFont` (`UPLOAD_FILE_START`) was bailing with `OUT OF MEMORY (TRY AGAIN FROM DESKTOP BROWSER)` whenever the largest contiguous free block was below `UPLOAD_BUFFER_SIZE + 1024`. On phone-on-STA the heap fragments after the ~64 KB JS-bundle fetch (font glyph hot-group + page-slot buffers, render state), even though aggregate free is comfortable.
- Before bailing, the gate now drops the font-decompressor's hot-group + page-slot buffers via `renderer.getFontCacheManager()->clearCache()` and re-probes `heap_caps_get_largest_free_block`. If the re-probe meets the threshold we proceed with the buffer resize; otherwise we keep the existing error path.
- Picked FCM because it is the only cache-drop primitive reachable from the upload callback that is safe from any task context — `main.cpp::onHeapAllocFailed` already documents this and uses the same call site. Heavier primitives (`EpubReaderActivity::releaseMaxResources`, `Epub::clearCache`, `removeDir` on cache dirs) either need the active reader's render lock or do SD I/O, both off-limits in the pre-flight gate.
- Added `LOG_INF` on successful recovery so the eviction path is visible in serial logs; existing `LOG_ERR` is preserved on the final-failure path.
- Both upload entry points share a single file-local helper `tryReleaseHeapForUpload(needed)` to avoid duplication.
- Build not run locally — PlatformIO isn't installed in the worktree environment. Only `src/network/CrossPointWebServer.cpp` changed; new includes are `<FontCacheManager.h>` and `<GfxRenderer.h>`, both already pulled in transitively elsewhere in the firmware.

## Test plan

- [ ] Flash this build, connect phone to home Wi-Fi (STA mode), open the device's web UI from the phone browser so it fetches the ~64 KB JS bundle.
- [ ] Browse a couple of pages so font caches warm up (glyph hot-group + page slots populated).
- [ ] Upload a sleep wallpaper via the PWA. Confirm it succeeds on first try where it used to return `HTTP 400 · OUT OF MEMORY`.
- [ ] Check serial log for `[UPLOAD] heap recovered via cache evict: <before> -> <after> (need <needed>)` — confirms the eviction-recovery path actually fired.
- [ ] Repeat with `/fonts` upload from the phone (covers the `handleUploadFont` path) — look for `[FONT-UPLOAD] heap recovered via cache evict`.
- [ ] Negative case: artificially starve heap further (e.g. open a long EPUB then immediately attempt upload before scrolling) and confirm the existing `[UPLOAD] buffer alloc skipped` `LOG_ERR` still fires and the client gets the 400 response — i.e. the fallback path didn't regress.

https://claude.ai/code/session_01V5bczvySUB4bqcubrPMf7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5bczvySUB4bqcubrPMf7p)_