### PR TITLE
style: fix clang-format-21 drift across 8 files

### DIFF
--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -151,9 +151,8 @@ void OtaUpdateActivity::render(Activity::RenderLock&&) {
     renderer.fillRect(24, 354, static_cast<int>(updaterProgress * static_cast<float>(pageWidth - 44)), 42);
     renderer.drawCenteredText(UI_10_FONT_ID, 420,
                               (std::to_string(static_cast<int>(updaterProgress * 100)) + "%").c_str());
-    renderer.drawCenteredText(
-        UI_10_FONT_ID, 440,
-        (std::to_string(progressBytesDone) + " / " + std::to_string(progressBytesTotal)).c_str());
+    renderer.drawCenteredText(UI_10_FONT_ID, 440,
+                              (std::to_string(progressBytesDone) + " / " + std::to_string(progressBytesTotal)).c_str());
     renderer.displayBuffer();
     return;
   }

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -80,9 +80,9 @@ struct CheckExitGuard {
   const CheckOutcome& out;
   ~CheckExitGuard() {
     const int httpc = (out.tag == CheckOutcome::Tag::HttpClientError) ? out.u.httpcCode : 0;
-    const int httpStatus =
-        (out.tag == CheckOutcome::Tag::HttpStatusError || out.tag == CheckOutcome::Tag::RateLimited) ? out.u.httpStatus
-                                                                                                     : 0;
+    const int httpStatus = (out.tag == CheckOutcome::Tag::HttpStatusError || out.tag == CheckOutcome::Tag::RateLimited)
+                               ? out.u.httpStatus
+                               : 0;
     WifiDiagReport::noteOtaCheckResult(static_cast<uint8_t>(out.tag), httpc, httpStatus);
   }
 };
@@ -123,9 +123,8 @@ CheckOutcome OtaUpdater::checkForUpdate() {
   WifiDiagReport::noteOtaPreflight(out.preflight.dns == NetPreflight::Dns::Ok,
                                    out.preflight.tcp == NetPreflight::Tcp::Ok, out.preflight.resolvedIpV4,
                                    out.preflight.freeHeapBytes);
-  LOG_INF("OTA", "Pre-flight: dns=%s tcp=%s heap=%u",
-          out.preflight.dns == NetPreflight::Dns::Ok ? "OK" : "FAIL",
-          out.preflight.tcp == NetPreflight::Tcp::Ok    ? "OK"
+  LOG_INF("OTA", "Pre-flight: dns=%s tcp=%s heap=%u", out.preflight.dns == NetPreflight::Dns::Ok ? "OK" : "FAIL",
+          out.preflight.tcp == NetPreflight::Tcp::Ok       ? "OK"
           : out.preflight.tcp == NetPreflight::Tcp::Failed ? "FAIL"
                                                            : "SKIP",
           (unsigned)out.preflight.freeHeapBytes);

--- a/src/network/OtaUpdater.h
+++ b/src/network/OtaUpdater.h
@@ -29,7 +29,7 @@ struct NetPreflight {
 
   Dns dns = Dns::Failed;
   Tcp tcp = Tcp::Skipped;
-  uint32_t resolvedIpV4 = 0;     // 0 if Dns::Failed
+  uint32_t resolvedIpV4 = 0;  // 0 if Dns::Failed
   uint32_t freeHeapBytes = 0;
   // Reserved for the diag::Log unification (RFC #146 follow-up). Today: 0.
   uint16_t lastWifiReason = 0;
@@ -38,14 +38,14 @@ struct NetPreflight {
 // ---- Outcome of checkForUpdate() — Arduino HTTPClient transport ----
 struct CheckOutcome {
   enum class Tag : uint8_t {
-    UpdateAvailable,    // newer release found, ready for installUpdate()
-    AlreadyLatest,      // server reachable; tag matches current or is older
-    NoFirmwareAsset,    // tag present but no firmware.bin attachment
-    HttpClientError,    // HTTPClient negative code (transport-level)
-    HttpStatusError,    // server returned non-2xx (and not 403/429)
-    RateLimited,        // 403 / 429
-    JsonParseError,     // SAX parser found no tag_name
-    InternalError,      // begin() / null stream / etc.
+    UpdateAvailable,  // newer release found, ready for installUpdate()
+    AlreadyLatest,    // server reachable; tag matches current or is older
+    NoFirmwareAsset,  // tag present but no firmware.bin attachment
+    HttpClientError,  // HTTPClient negative code (transport-level)
+    HttpStatusError,  // server returned non-2xx (and not 403/429)
+    RateLimited,      // 403 / 429
+    JsonParseError,   // SAX parser found no tag_name
+    InternalError,    // begin() / null stream / etc.
   };
 
   Tag tag = Tag::InternalError;
@@ -53,9 +53,9 @@ struct CheckOutcome {
 
   // Per-tag payload. Read only the field matching `tag`.
   union U {
-    uint32_t latestSize;     // updateAvailable
-    int      httpcCode;      // httpClientError (negative HTTPC_*)
-    int      httpStatus;     // httpStatusError or rateLimited (4xx/5xx)
+    uint32_t latestSize;  // updateAvailable
+    int httpcCode;        // httpClientError (negative HTTPC_*)
+    int httpStatus;       // httpStatusError or rateLimited (4xx/5xx)
     U() : latestSize(0) {}
   } u;
 
@@ -73,17 +73,17 @@ struct InstallProgress {
 struct InstallOutcome {
   enum class Tag : uint8_t {
     Success,
-    NotNewer,           // installUpdate called without prior UpdateAvailable
-    BeginFailed,        // esp_https_ota_begin (TLS / DNS / redirect)
-    PerformFailed,      // esp_https_ota_perform mid-stream
-    Incomplete,         // exited OK but Content-Length not satisfied
-    FinishFailed,       // hash / signature / partition validate
+    NotNewer,       // installUpdate called without prior UpdateAvailable
+    BeginFailed,    // esp_https_ota_begin (TLS / DNS / redirect)
+    PerformFailed,  // esp_https_ota_perform mid-stream
+    Incomplete,     // exited OK but Content-Length not satisfied
+    FinishFailed,   // hash / signature / partition validate
   };
 
-  Tag         tag = Tag::NotNewer;
-  uint32_t    bytesProcessed = 0;
-  uint32_t    bytesExpected = 0;
-  esp_err_t   espErr = ESP_OK;
+  Tag tag = Tag::NotNewer;
+  uint32_t bytesProcessed = 0;
+  uint32_t bytesExpected = 0;
+  esp_err_t espErr = ESP_OK;
   const char* espErrName = nullptr;  // rodata via esp_err_to_name; null if espErr == ESP_OK
 };
 
@@ -93,16 +93,16 @@ class OtaUpdater {
 
   OtaUpdater() = default;
 
-  CheckOutcome   checkForUpdate();
+  CheckOutcome checkForUpdate();
   InstallOutcome installUpdate(ProgressFn onProgress = {});
 
   // Held between checkForUpdate() and installUpdate(). Caller may also read
   // these from CheckOutcome.latestVersion / .u.updateAvailable.latestSize
   // — exposed here so legacy render paths that already grab the version
   // for the confirmation screen do not need to thread the outcome through.
-  bool               hasPendingUpdate() const { return pending_.has; }
+  bool hasPendingUpdate() const { return pending_.has; }
   const std::string& latestVersion() const { return pending_.version; }
-  uint32_t           latestSize() const { return pending_.size; }
+  uint32_t latestSize() const { return pending_.size; }
 
  private:
   struct Pending {

--- a/src/network/WifiDiagReport.cpp
+++ b/src/network/WifiDiagReport.cpp
@@ -239,27 +239,43 @@ const char* disconnectReasonName(int32_t r) {
 // below the noteOta* setters.
 const char* otaCheckTagName(uint8_t t) {
   switch (t) {
-    case 0: return "UpdateAvailable";
-    case 1: return "AlreadyLatest";
-    case 2: return "NoFirmwareAsset";
-    case 3: return "HttpClientError";
-    case 4: return "HttpStatusError";
-    case 5: return "RateLimited";
-    case 6: return "JsonParseError";
-    case 7: return "InternalError";
-    default: return "?";
+    case 0:
+      return "UpdateAvailable";
+    case 1:
+      return "AlreadyLatest";
+    case 2:
+      return "NoFirmwareAsset";
+    case 3:
+      return "HttpClientError";
+    case 4:
+      return "HttpStatusError";
+    case 5:
+      return "RateLimited";
+    case 6:
+      return "JsonParseError";
+    case 7:
+      return "InternalError";
+    default:
+      return "?";
   }
 }
 
 const char* otaInstallTagName(uint8_t t) {
   switch (t) {
-    case 0: return "Success";
-    case 1: return "NotNewer";
-    case 2: return "BeginFailed";
-    case 3: return "PerformFailed";
-    case 4: return "Incomplete";
-    case 5: return "FinishFailed";
-    default: return "?";
+    case 0:
+      return "Success";
+    case 1:
+      return "NotNewer";
+    case 2:
+      return "BeginFailed";
+    case 3:
+      return "PerformFailed";
+    case 4:
+      return "Incomplete";
+    case 5:
+      return "FinishFailed";
+    default:
+      return "?";
   }
 }
 
@@ -577,12 +593,22 @@ void writeReportOnFailure(FailureKind kind) {
   // Result
   const char* kindName;
   switch (kind) {
-    case FailureKind::Timeout:          kindName = "TIMEOUT (15 s)"; break;
-    case FailureKind::NoSsidAvail:      kindName = "NO_SSID_AVAIL"; break;
-    case FailureKind::OtaCheckFailed:   kindName = "OTA_CHECK_FAILED"; break;
-    case FailureKind::OtaInstallFailed: kindName = "OTA_INSTALL_FAILED"; break;
+    case FailureKind::Timeout:
+      kindName = "TIMEOUT (15 s)";
+      break;
+    case FailureKind::NoSsidAvail:
+      kindName = "NO_SSID_AVAIL";
+      break;
+    case FailureKind::OtaCheckFailed:
+      kindName = "OTA_CHECK_FAILED";
+      break;
+    case FailureKind::OtaInstallFailed:
+      kindName = "OTA_INSTALL_FAILED";
+      break;
     case FailureKind::StatusFailed:
-    default:                            kindName = "CONNECT_FAILED"; break;
+    default:
+      kindName = "CONNECT_FAILED";
+      break;
   }
   appendf(f, "Result:          %s\n", kindName);
   if (!isOtaKind) {

--- a/src/persist/PersistManager.h
+++ b/src/persist/PersistManager.h
@@ -50,9 +50,7 @@ class PersistManagerImpl {
   void setAsyncRunnerForTest(IAsyncRunner* runner) { asyncRunner_ = runner; }
 
   // Diagnostics passthrough. Returns 0 if no runner has been bound yet.
-  size_t asyncDroppedCount() const {
-    return asyncRunner_ ? asyncRunner_->droppedCount() : 0;
-  }
+  size_t asyncDroppedCount() const { return asyncRunner_ ? asyncRunner_->droppedCount() : 0; }
 
   // Call from main loop. Ticks every store; returns count of flushes performed.
   size_t tick(uint32_t nowMs) {

--- a/src/sleep/Wallpaper.cpp
+++ b/src/sleep/Wallpaper.cpp
@@ -43,10 +43,10 @@ void ensureConfigured() {
   s_configured = true;
 
   v2::WallpaperPlaylistV2::Deps d;
-  d.fs                = &defaultFs();
-  d.fileIO            = &defaultFileIO();
+  d.fs = &defaultFs();
+  d.fileIO = &defaultFileIO();
   d.lastShownFilename = &APP_STATE.lastShownSleepFilename;
-  d.lastRenderedPath  = &APP_STATE.lastSleepWallpaperPath;
+  d.lastRenderedPath = &APP_STATE.lastSleepWallpaperPath;
   // advance() runs inside SleepActivity::onEnter, milliseconds before the
   // CPU enters deep sleep. The PersistManager debounce window never fires
   // before sleep, so we force a synchronous flush so rotation state
@@ -56,12 +56,12 @@ void ensureConfigured() {
     crosspoint::persist::PersistManager().flushAll();
     return ok;
   };
-  d.randomFn      = [](long mod) -> long { return ::random(mod); };
-  d.isFavorite    = [](const std::string& path) { return FavoriteImage::isFavoritePath(path); };
+  d.randomFn = [](long mod) -> long { return ::random(mod); };
+  d.isFavorite = [](const std::string& path) { return FavoriteImage::isFavoritePath(path); };
   d.onPathRenamed = [](const std::string& from, const std::string& to) {
     FavoriteImage::replacePathReferences(from, to);
   };
-  d.onTrimMoved           = [](uint16_t /*moved*/) {};
+  d.onTrimMoved = [](uint16_t /*moved*/) {};
   d.onFavoritesCapBlocked = []() {};
   // Heap probe (RFC #156 C2): inject the device's contiguous-block query
   // through the playlist so the same code path runs under host tests with
@@ -209,18 +209,18 @@ void Configure(const Config& c) {
   s_configured = true;
 
   v2::WallpaperPlaylistV2::Deps d;
-  d.fs                    = c.fs;
-  d.fileIO                = c.fileIO;
-  d.orderFilePath         = c.orderFilePath;
-  d.lastShownFilename     = c.lastShownFilename;
-  d.lastRenderedPath      = c.lastRenderedPath;
-  d.saveAppState          = c.saveAppState;
-  d.randomFn              = c.randomFn;
-  d.isFavorite            = c.isFavorite;
-  d.onPathRenamed         = c.onPathRenamed;
-  d.onTrimMoved           = c.onTrimMoved;
+  d.fs = c.fs;
+  d.fileIO = c.fileIO;
+  d.orderFilePath = c.orderFilePath;
+  d.lastShownFilename = c.lastShownFilename;
+  d.lastRenderedPath = c.lastRenderedPath;
+  d.saveAppState = c.saveAppState;
+  d.randomFn = c.randomFn;
+  d.isFavorite = c.isFavorite;
+  d.onPathRenamed = c.onPathRenamed;
+  d.onTrimMoved = c.onTrimMoved;
   d.onFavoritesCapBlocked = c.onFavoritesCapBlocked;
-  d.largestFreeBlockFn    = c.largestFreeBlockFn;
+  d.largestFreeBlockFn = c.largestFreeBlockFn;
 
   v2::WallpaperPlaylistV2::instance().setDeps(d);
 }

--- a/src/sleep/Wallpaper.h
+++ b/src/sleep/Wallpaper.h
@@ -95,12 +95,12 @@ void reconcileIfDirty();
 // init wires production adapters automatically. Tests call resetForTest()
 // then Configure() with fakes.
 struct Config {
-  ISleepFs*         fs            = nullptr;
-  persist::IFileIO* fileIO        = nullptr;
-  std::string       orderFilePath = "/.crosspoint/sleep_order.txt";
+  ISleepFs* fs = nullptr;
+  persist::IFileIO* fileIO = nullptr;
+  std::string orderFilePath = "/.crosspoint/sleep_order.txt";
 
   std::string* lastShownFilename = nullptr;
-  std::string* lastRenderedPath  = nullptr;
+  std::string* lastRenderedPath = nullptr;
 
   std::function<bool()> saveAppState;
   std::function<long(long)> randomFn;

--- a/test/test_wallpaper_playlist_v2/test_main.cpp
+++ b/test/test_wallpaper_playlist_v2/test_main.cpp
@@ -310,7 +310,7 @@ void test_fragmented_heap_blocks_initial_reshuffle_buffer_stays_empty() {
   fx.wire(wp);
 
   const auto first = wp.advance();
-  TEST_ASSERT_TRUE(first.empty());            // bailed — no buffer to walk
+  TEST_ASSERT_TRUE(first.empty());  // bailed — no buffer to walk
   TEST_ASSERT_TRUE(wp.bufferForTest().empty());
 }
 
@@ -326,7 +326,7 @@ void test_healthy_heap_allows_reshuffle_and_advance_returns_name() {
   fx.wire(wp);
 
   const auto first = wp.advance();
-  TEST_ASSERT_FALSE(first.empty());           // reshuffle succeeded
+  TEST_ASSERT_FALSE(first.empty());  // reshuffle succeeded
   TEST_ASSERT_FALSE(wp.bufferForTest().empty());
 }
 


### PR DESCRIPTION
## Summary

- clang-format CI has been failing on every PR (including main itself) due to format drift in 8 files. Likely cause: those files pre-date the clang-format-21 upgrade reflected in CI (`PATH=/usr/lib/llvm-21/bin:$PATH ./bin/clang-format-fix` in `.github/workflows/ci.yml`).
- Ran `bin/clang-format-fix` locally with `clang-format-21.1.5`. Re-running it after this commit produces no diff.
- Pure whitespace/wrapping changes only — no semantic edits. Most are switch-case statements split per the `AllowShortCaseLabelsOnASingleLine: false` rule, plus some line-wrap fixes.
- Unblocks PR #157 (wallpaper-upload heap-defrag fix) which inherits the same red clang-format status.

## Files touched

- `src/activities/settings/OtaUpdateActivity.cpp`
- `src/network/OtaUpdater.cpp`
- `src/network/OtaUpdater.h`
- `src/network/WifiDiagReport.cpp`
- `src/persist/PersistManager.h`
- `src/sleep/Wallpaper.cpp`
- `src/sleep/Wallpaper.h`
- `test/test_wallpaper_playlist_v2/test_main.cpp`

## Note on cppcheck

cppcheck CI is also red on this branch's baseline. That looks like a separate pre-existing issue (couldn't reproduce locally — the PlatformIO toolchain host is not reachable from my environment). Will investigate as a follow-up once this lands and clang-format CI is green.

## Test plan

- [ ] CI clang-format check passes on this PR.
- [ ] After merge, re-run CI on PR #157 — clang-format should now go green there too.

https://claude.ai/code/session_01V5bczvySUB4bqcubrPMf7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5bczvySUB4bqcubrPMf7p)_