### PR TITLE
fix(ota): evict font cache before TLS handshake to prevent OOM

### DIFF
--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -1,8 +1,11 @@
 #include "OtaUpdateActivity.h"
 
+#include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <I18n.h>
 #include <WiFi.h>
+
+#include "esp_heap_caps.h"
 
 #include <cstdio>
 
@@ -37,6 +40,20 @@ void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
     state = CHECKING_FOR_UPDATE;
   }
   requestUpdateAndWait();
+
+  // TLS handshake needs ~10 KB contiguous for mbedTLS session buffers.
+  // On the C3's tight heap (~27 KB free) the font cache often fragments
+  // memory enough to cause a -1 (HTTPC_ERROR_CONNECTION_REFUSED) during
+  // the handshake. Drop reclaimable caches before attempting.
+  const size_t heapBefore = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+  if (auto* fcm = renderer.getFontCacheManager()) {
+    fcm->clearCache();
+    const size_t heapAfter = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+    if (heapAfter > heapBefore) {
+      LOG_INF("OTA", "Heap recovered via cache evict: %u -> %u", static_cast<unsigned>(heapBefore),
+              static_cast<unsigned>(heapAfter));
+    }
+  }
 
   CheckOutcome res;
   for (int attempt = 0; attempt <= OTA_CHECK_MAX_RETRIES; attempt++) {


### PR DESCRIPTION
## Summary

- Device diagnostic report (v2.2.2) showed OTA check failing: DNS OK, TCP OK, but HTTP client code -1. Root cause: font cache fragments the C3's ~27 KB heap so mbedTLS can't allocate session buffers for the TLS handshake.
- Evicts font decompressor hot-group + page-slot buffers via `FontCacheManager::clearCache()` before the OTA check loop. Same safe primitive used by the upload path (#157) and the global alloc-failure hook in `main.cpp`.
- Logs heap recovery when eviction frees contiguous space.

## Test plan

- [ ] Flash on ESP32-C3, browse a few pages (warm font caches), then trigger OTA check from Settings.
- [ ] Serial log should show `[OTA] Heap recovered via cache evict: <before> -> <after>` if caches were populated.
- [ ] OTA check should succeed where it previously failed with `HttpClientError / HTTPC -1`.
- [ ] If no font caches are populated (fresh boot, no reading), OTA check still works (no-op eviction path).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)