### PR TITLE
refactor(web): simplify HttpUploadSink — template writer, hoist capacity guard

### DIFF
--- a/src/network/HttpUploadSink.h
+++ b/src/network/HttpUploadSink.h
@@ -23,6 +23,11 @@ namespace crosspoint::net {
 // flush return false so the caller can abort the upload.
 class HttpUploadSink {
  public:
+  // The writer is invoked as `size_t write(const uint8_t* data, size_t len)`
+  // returning the bytes actually written. It is taken as a template parameter
+  // (below), not via this std::function, so the SD-write body inlines into the
+  // per-chunk hot loop with no type-erasure or per-call allocation. `Writer`
+  // documents the expected signature and is the callable type the tests pass.
   using Writer = std::function<size_t(const uint8_t* data, size_t len)>;
 
   explicit HttpUploadSink(size_t capacity) : capacity_(capacity) {}
@@ -30,23 +35,25 @@ class HttpUploadSink {
   // Size the batching buffer (lazily, on UPLOAD_FILE_START). The caller is
   // responsible for any heap pre-flight before calling — under -fno-exceptions
   // a failed resize would abort, so callers gate this with a largest-free-block
-  // probe. Returns true once the buffer is at full capacity. Resets position.
-  bool ensureCapacity() {
+  // probe. Resets position; use hasCapacity() to confirm sizing succeeded.
+  void ensureCapacity() {
     if (buffer_.size() != capacity_) buffer_.resize(capacity_);
     bufferPos_ = 0;
-    return buffer_.size() == capacity_;
   }
 
   bool hasCapacity() const { return buffer_.size() == capacity_; }
 
   // Copy len bytes into the buffer, flushing through `write` whenever the
   // buffer fills. Returns false on a short write (caller should abort).
-  bool append(const uint8_t* data, size_t len, const Writer& write) {
+  template <typename W>
+  bool append(const uint8_t* data, size_t len, const W& write) {
+    // Capacity is an invariant for the whole WRITE phase (ensureCapacity ran
+    // at UPLOAD_FILE_START), so check once here rather than per iteration. Also
+    // rejects misuse: append before ensureCapacity fails instead of an OOB copy.
+    if (buffer_.size() != capacity_) return false;
     while (len > 0) {
       const size_t space = capacity_ - bufferPos_;
       const size_t toCopy = (len < space) ? len : space;
-      // buffer_ is guaranteed sized by ensureCapacity(); guard defensively.
-      if (buffer_.size() != capacity_) return false;
       std::memcpy(buffer_.data() + bufferPos_, data, toCopy);
       bufferPos_ += toCopy;
       data += toCopy;
@@ -60,7 +67,8 @@ class HttpUploadSink {
 
   // Flush whatever remains buffered. No-op (success) when empty. On a short
   // write the position is still cleared so a follow-up flush won't re-emit.
-  bool flush(const Writer& write) {
+  template <typename W>
+  bool flush(const W& write) {
     if (bufferPos_ == 0) return true;
     const size_t written = write(buffer_.data(), bufferPos_);
     const bool ok = (written == bufferPos_);

--- a/test/test_http_upload_sink/test_main.cpp
+++ b/test/test_http_upload_sink/test_main.cpp
@@ -50,7 +50,7 @@ void tearDown() {}
 void test_ensure_capacity() {
   HttpUploadSink sink(16);
   TEST_ASSERT_FALSE(sink.hasCapacity());
-  TEST_ASSERT_TRUE(sink.ensureCapacity());
+  sink.ensureCapacity();
   TEST_ASSERT_TRUE(sink.hasCapacity());
   TEST_ASSERT_EQUAL_UINT32(16, sink.capacity());
   TEST_ASSERT_EQUAL_UINT32(0, sink.pending());
@@ -174,7 +174,8 @@ void test_reset_then_reuse() {
   TEST_ASSERT_FALSE(sink.hasCapacity());
   TEST_ASSERT_EQUAL_UINT32(0, sink.pending());
 
-  TEST_ASSERT_TRUE(sink.ensureCapacity());
+  sink.ensureCapacity();
+  TEST_ASSERT_TRUE(sink.hasCapacity());
   FakeFile f2;
   auto data2 = seq(3, 100);
   TEST_ASSERT_TRUE(sink.append(data2.data(), data2.size(), f2.writer()));


### PR DESCRIPTION
## Summary

Quality cleanups (`/simplify`) on the freshly-extracted `HttpUploadSink` from the prior commit. No behavior change — purely reuse/simplification/efficiency improvements found by parallel review agents.

## Changes

- **Template writer instead of `std::function`** on `append()`/`flush()`. The writer is invoked once per upload chunk (the hot path). `std::function` added a per-handler-call construct/destruct plus a type-erased indirect call that defeated inlining of the SD-write body. The template lets the writer inline with zero allocation. The `Writer` typedef is kept to document the expected signature and for the host tests.
- **Hoisted the buffer-sized invariant check out of `append()`'s copy loop.** Capacity holds for the entire `UPLOAD_FILE_WRITE` phase, so it's checked once on entry rather than every loop iteration (still rejects append-before-`ensureCapacity` misuse).
- **Dropped `ensureCapacity()`'s dead `bool` return.** Every caller ignored it and queries `hasCapacity()` instead; now `void`, with tests asserting via `hasCapacity()`.

## Verification

Compiled and exercised host-side under `-fno-exceptions -Wall -Wextra` (matching firmware flags): both the bare-lambda hot path and the `std::function` test path compile clean and behave identically (partial fill, exact-boundary flush, oversized chunk + tail, append-before-capacity rejection).

## Deliberately skipped

- Folding the per-handler heap pre-flight (`roomToGrow` → `ensureCapacity`) into a sink method — would couple the deliberately platform-free, host-testable header to the memory module and break the host tests.
- Consolidating the two `sdWriter` lambdas — they intentionally differ: the book-upload path carries write-timing diagnostics (logged), the font path does not.
- Removing test-only `pending()`/`capacity()` accessors and the defensive `bufferPos_` reset in `ensureCapacity()` — both are harmless and support white-box testing.

https://claude.ai/code/session_01PkCbK9arkFYXpkcCr9ASHY

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkCbK9arkFYXpkcCr9ASHY)_