### PR TITLE
style: apply clang-format-21 across the tree

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -444,15 +444,15 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss,
   // path rather than RTC_SW_SYS_RST.
   bookMetadataCache.reset(new (std::nothrow) BookMetadataCache(cachePath));
   if (!bookMetadataCache) {
-    LOG_ERR("EBP", "OOM new BookMetadataCache (load) free=%u largest=%u",
-            (unsigned)ESP.getFreeHeap(), (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+    LOG_ERR("EBP", "OOM new BookMetadataCache (load) free=%u largest=%u", (unsigned)ESP.getFreeHeap(),
+            (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
     return false;
   }
   // Always create CssParser - needed for inline style parsing even without CSS files
   cssParser.reset(new (std::nothrow) CssParser(cachePath));
   if (!cssParser) {
-    LOG_ERR("EBP", "OOM new CssParser (load) free=%u largest=%u",
-            (unsigned)ESP.getFreeHeap(), (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+    LOG_ERR("EBP", "OOM new CssParser (load) free=%u largest=%u", (unsigned)ESP.getFreeHeap(),
+            (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
     return false;
   }
   reporter.report(0);
@@ -621,8 +621,8 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss,
   // Reload the cache from disk so it's in the correct state
   bookMetadataCache.reset(new (std::nothrow) BookMetadataCache(cachePath));
   if (!bookMetadataCache) {
-    LOG_ERR("EBP", "OOM new BookMetadataCache (reload) free=%u largest=%u",
-            (unsigned)ESP.getFreeHeap(), (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+    LOG_ERR("EBP", "OOM new BookMetadataCache (reload) free=%u largest=%u", (unsigned)ESP.getFreeHeap(),
+            (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
     return false;
   }
   {
@@ -658,8 +658,8 @@ bool Epub::ensureCssCache(const std::function<void(int)>& progressCallback) {
   if (!cssParser) {
     cssParser.reset(new (std::nothrow) CssParser(cachePath));
     if (!cssParser) {
-      LOG_ERR("EBP", "OOM new CssParser (ensureCssCache) free=%u largest=%u",
-              (unsigned)ESP.getFreeHeap(), (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+      LOG_ERR("EBP", "OOM new CssParser (ensureCssCache) free=%u largest=%u", (unsigned)ESP.getFreeHeap(),
+              (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
       return false;
     }
   }

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -213,8 +213,8 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
   if (oom_) return;
 
   std::vector<size_t> lineBreakIndices =
-      computeLineBreaks(renderer, fontId, pageWidth, spaceWidth, words.size(), wordWidths, wordContinues, canBreakBefore,
-                        wordNeedsHyphenAtBreak, arena_);
+      computeLineBreaks(renderer, fontId, pageWidth, spaceWidth, words.size(), wordWidths, wordContinues,
+                        canBreakBefore, wordNeedsHyphenAtBreak, arena_);
   const size_t lineCount = includeLastLine ? lineBreakIndices.size() : lineBreakIndices.size() - 1;
 
   for (size_t i = 0; i < lineCount; ++i) {
@@ -312,8 +312,7 @@ void ParsedText::splitOversizedTokens(const GfxRenderer& renderer, const int fon
         const size_t needBytes = nextCap * sizeof(std::string);
         if (!crosspoint::heap::canAllocateContiguous(needBytes)) {
           LOG_ERR("PT", "OOM splitOversized size=%u cap=%u need=%u largest=%u", (unsigned)words.size(),
-                  (unsigned)words.capacity(), (unsigned)needBytes,
-                  (unsigned)crosspoint::heap::largestFreeBlockBytes());
+                  (unsigned)words.capacity(), (unsigned)needBytes, (unsigned)crosspoint::heap::largestFreeBlockBytes());
           oom_ = true;
           return;
         }
@@ -405,8 +404,7 @@ void ParsedText::expandHyphenationBreaks(const GfxRenderer& renderer, const int 
         const size_t needBytes = nextCap * sizeof(std::string);
         if (!crosspoint::heap::canAllocateContiguous(needBytes)) {
           LOG_ERR("PT", "OOM expandHyphen size=%u cap=%u need=%u largest=%u", (unsigned)words.size(),
-                  (unsigned)words.capacity(), (unsigned)needBytes,
-                  (unsigned)crosspoint::heap::largestFreeBlockBytes());
+                  (unsigned)words.capacity(), (unsigned)needBytes, (unsigned)crosspoint::heap::largestFreeBlockBytes());
           oom_ = true;
           return;
         }
@@ -749,8 +747,8 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
     processLine(nullptr);
     return;
   }
-  processLine(std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles),
-                                          blockStyle));
+  processLine(
+      std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles), blockStyle));
 }
 
 // — RFC #164 step 4: arena-backed accumulation buffer —
@@ -913,8 +911,9 @@ bool ParsedText::layoutArenaWords(const GfxRenderer& renderer, const int fontId,
   }
   const std::vector<bool> wordNeedsHyphenAtBreak(n, false);
 
-  std::vector<size_t> lineBreakIndices = computeLineBreaks(renderer, fontId, pageWidth, spaceWidth, n, wordWidths,
-                                                           continuesVec, canBreakBefore, wordNeedsHyphenAtBreak, arena_);
+  std::vector<size_t> lineBreakIndices =
+      computeLineBreaks(renderer, fontId, pageWidth, spaceWidth, n, wordWidths, continuesVec, canBreakBefore,
+                        wordNeedsHyphenAtBreak, arena_);
   const size_t lineCount = includeLastLine ? lineBreakIndices.size() : lineBreakIndices.size() - 1;
 
   for (size_t i = 0; i < lineCount; ++i) {

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -42,7 +42,7 @@ class ParsedText {
   size_t arenaCount_ = 0;
   size_t arenaCap_ = 0;
   bool useArenaWords_ = false;
-  bool arenaRegionActive_ = false;  // true once wordsMark_ is captured and the word region is held
+  bool arenaRegionActive_ = false;                   // true once wordsMark_ is captured and the word region is held
   crosspoint::layout::LayoutArena::Mark wordsMark_;  // checkpoint to rewind the whole word region
   BlockStyle blockStyle;
   bool extraParagraphSpacing;
@@ -84,7 +84,7 @@ class ParsedText {
   std::vector<uint16_t> calculateWordWidths(const GfxRenderer& renderer, int fontId);
 
   // — arena word-store helpers (RFC #164 step 4) —
-  bool ensureArenaWords();  // lazily reserve arenaWords_ from arena_; false if it won't fit
+  bool ensureArenaWords();            // lazily reserve arenaWords_ from arena_; false if it won't fit
   void migrateArenaWordsToVectors();  // copy arenaWords_ -> the std::vectors, drop the arena path
   // Drop the first `consumed` arena words after a partial flush and recompact
   // the interned bytes (re-intern the survivors), mirroring the std::vector

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -3,14 +3,13 @@
 #include <Arduino.h>
 #include <HalStorage.h>
 #include <Logging.h>
+#include <MemoryPolicy.h>
 #include <Serialization.h>
 #include <esp_heap_caps.h>
 #include <esp_task_wdt.h>
 
 #include <algorithm>
 #include <deque>
-
-#include <MemoryPolicy.h>
 
 #include "Page.h"
 #include "parsers/ChapterHtmlSlimParser.h"
@@ -152,7 +151,7 @@ void Section::writeSectionFileHeader(const int fontId, const float lineCompressi
   serialization::writePod(file, textRenderMode);
   serialization::writePod(file, readerBoldSwap);
   serialization::writePod(file, degradeLevel);  // RFC #164 step 7: which DegradeLevel produced this layout
-  serialization::writePod(file, pageCount);  // Placeholder for page count (will be initially 0 when written)
+  serialization::writePod(file, pageCount);     // Placeholder for page count (will be initially 0 when written)
   serialization::writePod(file, static_cast<uint32_t>(0));  // Placeholder for LUT offset
 }
 
@@ -469,18 +468,10 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
   // happened before the parser was constructed, holding both peaks
   // simultaneously and crowding out other allocations.
   CssParser* cssParser = (readerStyleMode != 0) ? epub->getCssParser() : nullptr;
-  ChapterParseConfig parseConfig{fontId,
-                                 lineCompression,
-                                 extraParagraphSpacingLevel,
-                                 paragraphAlignment,
-                                 viewportWidth,
-                                 viewportHeight,
-                                 hyphenationEnabled,
-                                 wordSpacingPercent,
-                                 firstLineIndentMode,
-                                 readerStyleMode != 0,
-                                 contentBase,
-                                 imageBasePath};
+  ChapterParseConfig parseConfig{
+      fontId,         lineCompression,    extraParagraphSpacingLevel, paragraphAlignment,  viewportWidth,
+      viewportHeight, hyphenationEnabled, wordSpacingPercent,         firstLineIndentMode, readerStyleMode != 0,
+      contentBase,    imageBasePath};
   // RFC #164 step 6: hand the parser the reader activity's section-lifetime
   // arena (the repurposed 24 KB anchor) when provided, so the bounded word
   // buffer is available even on a fragmented heap.
@@ -488,8 +479,7 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
   // RFC #164 step 7: resolve the level into the per-section degradation plan the
   // parser reads (images branch + hyphenation). prewarmStyleMask is unused at
   // layout time (it gates render-side glyph warmth); kStyleAll is a no-op here.
-  parseConfig.degradePlan =
-      crosspoint::layout::DegradePlan::from(layoutLevel, crosspoint::layout::kStyleAll);
+  parseConfig.degradePlan = crosspoint::layout::DegradePlan::from(layoutLevel, crosspoint::layout::kStyleAll);
   ChapterHtmlSlimParser visitor(
       epub, tmpHtmlPath, renderer, parseConfig,
       [this, &lut](std::unique_ptr<Page> page) { lut.emplace_back(this->onPageComplete(std::move(page))); },

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -1,12 +1,11 @@
 #include "TextBlock.h"
 
 #include <GfxRenderer.h>
+#include <HeapGuard.h>
 #include <Logging.h>
 #include <Serialization.h>
 
 #include <new>
-
-#include <HeapGuard.h>
 
 #ifdef ESP_PLATFORM
 #include <esp_heap_caps.h>
@@ -220,8 +219,8 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(FsFile& file) {
     }
 #endif
     if (!crosspoint::heap::canAllocateContiguous(wordsBytes)) {
-      LOG_ERR("TXB", "Deserialization skipped: %u words (~%u B contiguous) largest=%u", wc,
-              (unsigned)wordsBytes, (unsigned)crosspoint::heap::largestFreeBlockBytes());
+      LOG_ERR("TXB", "Deserialization skipped: %u words (~%u B contiguous) largest=%u", wc, (unsigned)wordsBytes,
+              (unsigned)crosspoint::heap::largestFreeBlockBytes());
       return nullptr;
     }
   }

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -912,8 +912,8 @@ bool CssParser::loadFromCache() {
   {
     const size_t needBytes = static_cast<size_t>(ruleCount) * sizeof(HashedOffset);
     if (!crosspoint::heap::canAllocateContiguous(needBytes)) {
-      LOG_ERR("CSS", "OOM hashedIndex_ reserve: need=%u largest=%u",
-              (unsigned)needBytes, (unsigned)crosspoint::heap::largestFreeBlockBytes());
+      LOG_ERR("CSS", "OOM hashedIndex_ reserve: need=%u largest=%u", (unsigned)needBytes,
+              (unsigned)crosspoint::heap::largestFreeBlockBytes());
       cacheFile_.close();
       cacheFileOpen_ = false;
       return false;

--- a/lib/Epub/Epub/layout/DegradeLevel.h
+++ b/lib/Epub/Epub/layout/DegradeLevel.h
@@ -41,9 +41,9 @@ enum class DegradeLevel : uint8_t {
 // Fully-resolved, per-section plan derived once from a level + the styles the
 // page actually uses. Pure data; the engine reads the booleans/mask directly.
 struct DegradePlan {
-  bool images = true;          // render image blocks
-  bool hyphenate = true;       // hyphenate / split oversized tokens at breaks
-  bool optimalBreak = true;    // Knuth-Plass DP line breaking (false = greedy)
+  bool images = true;                    // render image blocks
+  bool hyphenate = true;                 // hyphenate / split oversized tokens at breaks
+  bool optimalBreak = true;              // Knuth-Plass DP line breaking (false = greedy)
   uint8_t prewarmStyleMask = kStyleAll;  // which styles to warm in the glyph cache
 
   // Derive the plan for `level`, intersecting the prewarm mask with the styles

--- a/lib/Epub/Epub/layout/LayoutArena.h
+++ b/lib/Epub/Epub/layout/LayoutArena.h
@@ -96,7 +96,7 @@ class LayoutArena {
   Str intern(const char* bytes, size_t len) noexcept {
     Str h;
     if (block_ == nullptr || len > 0xFFFFu) return h;
-    const size_t need = len + 1;  // + NUL
+    const size_t need = len + 1;                               // + NUL
     if (need > textTop_ || textTop_ - need < bump_) return h;  // collides with alloc region
     textTop_ -= need;
     if (len > 0 && bytes != nullptr) std::memcpy(block_ + textTop_, bytes, len);

--- a/lib/Epub/Epub/page/PageBuilder.h
+++ b/lib/Epub/Epub/page/PageBuilder.h
@@ -106,7 +106,8 @@ class PageBuilder {
   // the block boundary onto the current page (mirrors makePages' tail).
   void drainFootnotes() {
     if (!footnotes_.empty() && currentPage_) {
-      footnotes_.drainRemaining([this](const char* number, const char* href) { currentPage_->addFootnote(number, href); });
+      footnotes_.drainRemaining(
+          [this](const char* number, const char* href) { currentPage_->addFootnote(number, href); });
     }
   }
 
@@ -140,8 +141,8 @@ class PageBuilder {
   bool hasOpenPage() const { return static_cast<bool>(currentPage_); }
 
  private:
-  [[nodiscard]] PageStatus ensurePage();        // lazy new(nothrow) Page, resets cursor
-  void completePage();                          // dense-fit + emit + count++ (no alloc)
+  [[nodiscard]] PageStatus ensurePage();  // lazy new(nothrow) Page, resets cursor
+  void completePage();                    // dense-fit + emit + count++ (no alloc)
   [[nodiscard]] PageStatus bindPendingAnchors();
 
   PageConfig cfg_;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -8,13 +8,13 @@
 #include <vector>
 
 #include "../FootnoteEntry.h"
-#include "../layout/LayoutEngine.h"
-#include "../page/PageBuilder.h"
-#include "FootnotePlacer.h"
 #include "../blocks/ImageBlock.h"
 #include "../blocks/TextBlock.h"
 #include "../css/CssParser.h"
 #include "../css/CssStyle.h"
+#include "../layout/LayoutEngine.h"
+#include "../page/PageBuilder.h"
+#include "FootnotePlacer.h"
 #include "StyleResolver.h"
 
 class Page;
@@ -74,9 +74,9 @@ class ChapterHtmlSlimParser {
   // the bounded buffer is available even on a fragmented heap. sectionArena_
   // points at whichever is active for the current parse.
   static constexpr size_t kLayoutScratchArenaBytes = 16 * 1024;
-  crosspoint::layout::LayoutArena layoutArena_;                 // owned self-create fallback
-  crosspoint::layout::LayoutArena* externalArena_ = nullptr;    // activity-owned arena (nullable), from config
-  crosspoint::layout::LayoutArena* sectionArena_ = nullptr;     // active arena for this parse (set in parseAndBuildPages)
+  crosspoint::layout::LayoutArena layoutArena_;               // owned self-create fallback
+  crosspoint::layout::LayoutArena* externalArena_ = nullptr;  // activity-owned arena (nullable), from config
+  crosspoint::layout::LayoutArena* sectionArena_ = nullptr;   // active arena for this parse (set in parseAndBuildPages)
   std::unique_ptr<crosspoint::layout::LayoutEngine> currentTextBlock = nullptr;
   // RFC #171-followup: page assembly (in-flight page, vertical cursor,
   // completed-page count, pending anchors, complete-when-full + dense-fit) lives

--- a/lib/Epub/Epub/parsers/StyleResolver.h
+++ b/lib/Epub/Epub/parsers/StyleResolver.h
@@ -60,7 +60,7 @@ class StyleResolver {
   bool popInlineAtDepth(int depth);
 
   // --- depth flags (was boldUntilDepth / italicUntilDepth / underlineUntilDepth) ---
-  void setBoldFrom(int depth);       // flag = min(flag, depth)
+  void setBoldFrom(int depth);  // flag = min(flag, depth)
   void setItalicFrom(int depth);
   void setUnderlineFrom(int depth);
   void clearDepthFlagsAt(int depth);  // clears each flag whose value == depth

--- a/lib/HeapGuard/HeapGuard.h
+++ b/lib/HeapGuard/HeapGuard.h
@@ -53,16 +53,13 @@ inline void setLargestFreeBlockOverride(size_t bytes) { largestFreeBlockOverride
 inline void clearLargestFreeBlockOverride() { largestFreeBlockOverride_() = SIZE_MAX; }
 inline size_t largestFreeBlockBytes() { return largestFreeBlockOverride_(); }
 #else
-inline size_t largestFreeBlockBytes() {
-  return heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
-}
+inline size_t largestFreeBlockBytes() { return heap_caps_get_largest_free_block(MALLOC_CAP_8BIT); }
 #endif
 
 // Returns true if the heap reports a contiguous free block large enough
 // for `needBytes + headroomBytes`. Headroom defaults to 4 KB to absorb
 // transient growth between the probe and the subsequent allocation.
-inline bool canAllocateContiguous(size_t needBytes,
-                                  size_t headroomBytes = kDefaultHeadroomBytes) {
+inline bool canAllocateContiguous(size_t needBytes, size_t headroomBytes = kDefaultHeadroomBytes) {
   const size_t requested = needBytes + headroomBytes;
   // Overflow check: if requested wrapped, treat as unsatisfiable.
   if (requested < needBytes) return false;

--- a/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
@@ -348,10 +348,10 @@ bool JpegToBmpConverter::jpegFileToBmpStreamInternal(FsFile& jpegFile, Print& bm
   // constructor allocates ~width*2 bytes per row buffer, which can fail
   // independently under fragmentation).
   const bool ditherer1BitOom = oneBit && (!atkinson1BitDitherer || !atkinson1BitDitherer->valid());
-  const bool dithererAtkOom = !oneBit && !USE_8BIT_OUTPUT && USE_ATKINSON &&
-                              (!atkinsonDitherer || !atkinsonDitherer->valid());
-  const bool dithererFsOom = !oneBit && !USE_8BIT_OUTPUT && USE_FLOYD_STEINBERG &&
-                             (!fsDitherer || !fsDitherer->valid());
+  const bool dithererAtkOom =
+      !oneBit && !USE_8BIT_OUTPUT && USE_ATKINSON && (!atkinsonDitherer || !atkinsonDitherer->valid());
+  const bool dithererFsOom =
+      !oneBit && !USE_8BIT_OUTPUT && USE_FLOYD_STEINBERG && (!fsDitherer || !fsDitherer->valid());
   if (ditherer1BitOom || dithererAtkOom || dithererFsOom) {
     LOG_ERR("JPG", "OOM ditherer outWidth=%u", (unsigned)outWidth);
     return false;  // RAII Cleanup frees what was allocated

--- a/lib/MemoryPolicy/MemoryPolicy.h
+++ b/lib/MemoryPolicy/MemoryPolicy.h
@@ -57,7 +57,7 @@ enum class Op : uint8_t {
   // before std::move collapses them; surviving.reserve() threw bad_alloc with
   // the residual largest block at ~47 KB. 64 KB clears the trim peak. Below it,
   // callers bypass the playlist and stream-pick a file by directory index.
-  ScanSleepPlaylist,      // playlist trim peak              (largest >= 64 KB)
+  ScanSleepPlaylist,  // playlist trim peak              (largest >= 64 KB)
 };
 
 namespace detail {
@@ -67,7 +67,8 @@ struct Gate {
 };
 inline Gate gateFor(Op op) {
   switch (op) {
-    case Op::SpawnRenderTask:       return {false, 12 * 1024};
+    case Op::SpawnRenderTask:
+      return {false, 12 * 1024};
     // 48 KB clears the section-load working peak (CSS index + expat read
     // buffer + page LUT + ParsedText word/style vectors) with margin and is
     // what the pre-flight defrag pass targets. PR #95/#100 tried higher
@@ -76,23 +77,29 @@ inline Gate gateFor(Op op) {
     // indefinitely, turning a would-pass layout into a permanent
     // recovery-screen dead-end; the gate stays at the section-peak value and
     // the rebuild *floor* below absorbs the fragmented-device case.
-    case Op::BuildSectionLayout:    return {false, 48 * 1024};
+    case Op::BuildSectionLayout:
+      return {false, 48 * 1024};
     // Hard floor for attempting a section rebuild: below this even a
     // post-defrag malloc is essentially guaranteed to fail. Reverted to PR
     // #96's 20 KB after #95/#100's higher floors bounced every modest book on
     // this device — the retry-once + auto-revert path plus the OOM recovery
     // screen handle a real mid-layout failure cleanly, so the floor optimizes
     // for "try and let the failure path catch it" over "block proactively".
-    case Op::RebuildSectionFloor:   return {false, 20 * 1024};
-    case Op::PrefetchNeighborPages: return {false, 30 * 1024};
+    case Op::RebuildSectionFloor:
+      return {false, 20 * 1024};
+    case Op::PrefetchNeighborPages:
+      return {false, 30 * 1024};
     // Forward-only single-page prefetch (RFC reading-speed Stage 1a): one
     // deserialized Page's working set is ~half the prev+next pair, so a lower
     // floor keeps the *next* page warm under moderate fragmentation (the common
     // forward-reading case) where the 30 KB neighbour gate would close and force
     // a synchronous on-turn SD load (the intermittent ~1 s stalls).
-    case Op::PrefetchNextPage:      return {false, 18 * 1024};
-    case Op::RenderRichSleepScreen: return {true,  30 * 1024};
-    case Op::ScanSleepPlaylist:     return {false, 64 * 1024};
+    case Op::PrefetchNextPage:
+      return {false, 18 * 1024};
+    case Op::RenderRichSleepScreen:
+      return {true, 30 * 1024};
+    case Op::ScanSleepPlaylist:
+      return {false, 64 * 1024};
   }
   return {false, SIZE_MAX};  // unreachable; conservative (gate stays closed)
 }

--- a/lib/PngToBmpConverter/PngToBmpConverter.cpp
+++ b/lib/PngToBmpConverter/PngToBmpConverter.cpp
@@ -668,10 +668,10 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(FsFile& pngFile, Print& bmpOu
   // The ditherer constructor allocates internal error-row buffers — check
   // both the outer object pointer AND the inner valid() flag.
   const bool ditherer1BitOom = oneBit && (!atkinson1BitDitherer || !atkinson1BitDitherer->valid());
-  const bool dithererAtkOom = !oneBit && !USE_8BIT_OUTPUT && USE_ATKINSON &&
-                              (!atkinsonDitherer || !atkinsonDitherer->valid());
-  const bool dithererFsOom = !oneBit && !USE_8BIT_OUTPUT && USE_FLOYD_STEINBERG &&
-                             (!fsDitherer || !fsDitherer->valid());
+  const bool dithererAtkOom =
+      !oneBit && !USE_8BIT_OUTPUT && USE_ATKINSON && (!atkinsonDitherer || !atkinsonDitherer->valid());
+  const bool dithererFsOom =
+      !oneBit && !USE_8BIT_OUTPUT && USE_FLOYD_STEINBERG && (!fsDitherer || !fsDitherer->valid());
   if (ditherer1BitOom || dithererAtkOom || dithererFsOom) {
     LOG_ERR("PNG", "OOM ditherer outWidth=%u", (unsigned)outWidth);
     delete atkinsonDitherer;

--- a/lib/Xtc/Xtc/XtcParser.cpp
+++ b/lib/Xtc/Xtc/XtcParser.cpp
@@ -319,8 +319,7 @@ XtcError XtcParser::readChapters() {
   {
     const size_t needBytes = chapterCount * sizeof(ChapterInfo);
     if (!crosspoint::heap::canAllocateContiguous(needBytes)) {
-      LOG_ERR("XTC", "OOM m_chapters reserve: count=%u need=%u largest=%u",
-              (unsigned)chapterCount, (unsigned)needBytes,
+      LOG_ERR("XTC", "OOM m_chapters reserve: count=%u need=%u largest=%u", (unsigned)chapterCount, (unsigned)needBytes,
               (unsigned)crosspoint::heap::largestFreeBlockBytes());
       return XtcError::READ_ERROR;
     }

--- a/src/HeapReport.cpp
+++ b/src/HeapReport.cpp
@@ -28,18 +28,30 @@ void appendf(std::string& s, const char* fmt, ...) {
 
 const char* resetReasonName(esp_reset_reason_t r) {
   switch (r) {
-    case ESP_RST_UNKNOWN: return "UNKNOWN";
-    case ESP_RST_POWERON: return "POWERON";
-    case ESP_RST_EXT: return "EXT";
-    case ESP_RST_SW: return "SW";
-    case ESP_RST_PANIC: return "PANIC";
-    case ESP_RST_INT_WDT: return "INT_WDT";
-    case ESP_RST_TASK_WDT: return "TASK_WDT";
-    case ESP_RST_WDT: return "WDT";
-    case ESP_RST_DEEPSLEEP: return "DEEPSLEEP";
-    case ESP_RST_BROWNOUT: return "BROWNOUT";
-    case ESP_RST_SDIO: return "SDIO";
-    default: return "?";
+    case ESP_RST_UNKNOWN:
+      return "UNKNOWN";
+    case ESP_RST_POWERON:
+      return "POWERON";
+    case ESP_RST_EXT:
+      return "EXT";
+    case ESP_RST_SW:
+      return "SW";
+    case ESP_RST_PANIC:
+      return "PANIC";
+    case ESP_RST_INT_WDT:
+      return "INT_WDT";
+    case ESP_RST_TASK_WDT:
+      return "TASK_WDT";
+    case ESP_RST_WDT:
+      return "WDT";
+    case ESP_RST_DEEPSLEEP:
+      return "DEEPSLEEP";
+    case ESP_RST_BROWNOUT:
+      return "BROWNOUT";
+    case ESP_RST_SDIO:
+      return "SDIO";
+    default:
+      return "?";
   }
 }
 
@@ -56,10 +68,9 @@ HeapSnapshot captureHeapSnapshot() {
 }
 
 void appendHeapSnapshot(std::string& out, const HeapSnapshot& snap) {
-  appendf(out, "free=%u largest=%u min=%u intl=%u intlLargest=%u",
-          static_cast<unsigned>(snap.freeBytes), static_cast<unsigned>(snap.largestFreeBlockBytes),
-          static_cast<unsigned>(snap.minFreeEverBytes), static_cast<unsigned>(snap.internalFreeBytes),
-          static_cast<unsigned>(snap.internalLargestBytes));
+  appendf(out, "free=%u largest=%u min=%u intl=%u intlLargest=%u", static_cast<unsigned>(snap.freeBytes),
+          static_cast<unsigned>(snap.largestFreeBlockBytes), static_cast<unsigned>(snap.minFreeEverBytes),
+          static_cast<unsigned>(snap.internalFreeBytes), static_cast<unsigned>(snap.internalLargestBytes));
 }
 
 bool writeHeapReport(const char* reason) {

--- a/src/HeapReport.h
+++ b/src/HeapReport.h
@@ -19,11 +19,11 @@
 // The report file is overwritten on each write — most-recent-restart wins.
 
 struct HeapSnapshot {
-  uint32_t freeBytes;            // total free across all 8-bit-capable regions
+  uint32_t freeBytes;              // total free across all 8-bit-capable regions
   uint32_t largestFreeBlockBytes;  // largest contiguous free chunk (8-bit)
-  uint32_t minFreeEverBytes;     // smallest free total seen since boot
-  uint32_t internalFreeBytes;    // free in INTERNAL caps (no SPIRAM split on C3,
-                                 // but kept for forward portability)
+  uint32_t minFreeEverBytes;       // smallest free total seen since boot
+  uint32_t internalFreeBytes;      // free in INTERNAL caps (no SPIRAM split on C3,
+                                   // but kept for forward portability)
   uint32_t internalLargestBytes;
 };
 

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -12,10 +12,9 @@
 
 #include <algorithm>
 
-#include "MemoryPolicy.h"
-
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
+#include "MemoryPolicy.h"
 #include "Paths.h"
 #include "activities/reader/ReaderLayoutSafety.h"
 #include "components/themes/BaseTheme.h"
@@ -28,7 +27,6 @@
 #include "util/StringUtils.h"
 
 namespace {
-
 
 // Sleep rendering runs inside SleepActivity::onEnter, called AFTER
 // enterDeepSleep's persistAppState flushAll and milliseconds before the CPU

--- a/src/activities/network/QRShareActivity.cpp
+++ b/src/activities/network/QRShareActivity.cpp
@@ -5,10 +5,9 @@
 #include <Logging.h>
 #include <WiFi.h>
 #include <esp_task_wdt.h>
-
-#include "SilentRestart.h"
 #include <qrcode.h>
 
+#include "SilentRestart.h"
 #include "WifiSelectionActivity.h"
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -31,11 +31,11 @@
 #include "MemoryPolicy.h"
 #include "QuotesViewerActivity.h"
 #include "ReaderCommon.h"
-#include "SilentRestart.h"
 #include "ReaderLayoutSafety.h"
 #include "ReadingThemeStore.h"
 #include "ReadingThemesActivity.h"
 #include "RecentBooksStore.h"
+#include "SilentRestart.h"
 #include "activities/network/QRShareActivity.h"
 #include "activities/util/ConfirmDialogActivity.h"
 #include "components/themes/BaseTheme.h"
@@ -144,9 +144,8 @@ void EpubReaderActivity::onEnter() {
   // existing pre-flight / silent-restart paths still catch fragmentation.
   layoutHeapAnchor_ = crosspoint::layout::LayoutArena::create(kLayoutHeapAnchorBytes);
   if (layoutHeapAnchor_.ok()) {
-    LOG_DBG("HEAP", "EPUB onEnter:anchor-acquired %u bytes free=%u largest=%u",
-            (unsigned)kLayoutHeapAnchorBytes, (unsigned)ESP.getFreeHeap(),
-            (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+    LOG_DBG("HEAP", "EPUB onEnter:anchor-acquired %u bytes free=%u largest=%u", (unsigned)kLayoutHeapAnchorBytes,
+            (unsigned)ESP.getFreeHeap(), (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
   } else {
     LOG_DIAG("ERS", "EPUB onEnter: layout heap anchor alloc failed (largest=%u) — continuing without",
              (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
@@ -864,8 +863,7 @@ crosspoint::reader::ReaderInput EpubReaderActivity::snapshotInput() {
   // Power, PageBack, PageForward). MappedInputManager::Button declares them in
   // exactly that order; this static_assert is the drift tripwire.
   static constexpr MB kMap[crosspoint::reader::kReaderButtonCount] = {
-      MB::Back, MB::Confirm, MB::Left,  MB::Right,      MB::Up,
-      MB::Down, MB::Power,   MB::PageBack, MB::PageForward};
+      MB::Back, MB::Confirm, MB::Left, MB::Right, MB::Up, MB::Down, MB::Power, MB::PageBack, MB::PageForward};
   static_assert(static_cast<int>(crosspoint::reader::ReaderButton::Back) == 0 &&
                     static_cast<int>(crosspoint::reader::ReaderButton::PageForward) == 8,
                 "ReaderButton order must mirror MappedInputManager::Button");
@@ -928,8 +926,7 @@ void EpubReaderActivity::applyEffect(const crosspoint::reader::ReaderInputDispat
       {
         RenderLock lock(*this);
         nextPageNumber = 0;
-        currentSpineIndex =
-            (effect.action == A::SkipChapterNext) ? currentSpineIndex + 1 : currentSpineIndex - 1;
+        currentSpineIndex = (effect.action == A::SkipChapterNext) ? currentSpineIndex + 1 : currentSpineIndex - 1;
         // No progress write on chapter skip — saves are lifecycle-only now. The
         // new position lives in currentSpineIndex/nextPageNumber (consumed by the
         // reload below); the post-load render's observe() refreshes the tracker
@@ -1287,13 +1284,12 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
     // GO_HOME menu item removed — Back button handles this
     case EpubReaderMenuActivity::MenuAction::THEMES_MENU: {
       exitActivity();
-      enterNewActivity(new (std::nothrow) ReadingThemesActivity(renderer, mappedInput,
-                                                 epub ? epub->getCachePath() : std::string(),
-                                                 [this](const bool changed) {
-                                                   pendingSubactivityExit = true;
-                                                   inputDispatcher_.clearPendingTap();
-                                                   pendingThemeReload = changed;
-                                                 }));
+      enterNewActivity(new (std::nothrow) ReadingThemesActivity(
+          renderer, mappedInput, epub ? epub->getCachePath() : std::string(), [this](const bool changed) {
+            pendingSubactivityExit = true;
+            inputDispatcher_.clearPendingTap();
+            pendingThemeReload = changed;
+          }));
       break;
     }
     // REVERT_THEME menu item removed — use Reading Themes to manage themes
@@ -1979,7 +1975,7 @@ void EpubReaderActivity::render(Activity::RenderLock&& lock) {
     currentPageFootnotes = p->footnotes;
     const auto start = millis();
     const bool renderOk = renderContents(*p, orientedMarginTop, orientedMarginRight, orientedMarginBottom,
-                                          orientedMarginLeft, statusBarLayout);
+                                         orientedMarginLeft, statusBarLayout);
     LOG_DBG("ERS", "Rendered page in %dms", millis() - start);
     if (!renderOk) {
       // Render-time glyph allocations failed on a fragmented heap: the frame
@@ -2552,12 +2548,11 @@ bool EpubReaderActivity::renderContents(const Page& page, const int orientedMarg
     // headroom (>=40 KB largest) this resolves to Full -> 0x0F, byte-identical to
     // before; under pressure it warms regular glyphs only, shrinking the
     // simultaneous glyph-cache peak that crowds the render-OOM path.
-    const uint8_t prewarmMask =
-        crosspoint::layout::DegradePlan::from(
-            crosspoint::layout::renderLevelFor(crosspoint::heap::largestFreeBlockBytes(),
-                                               crosspoint::mem::kRenderTrimPrewarmBelowBytes),
-            crosspoint::layout::kStyleAll)
-            .prewarmStyleMask;
+    const uint8_t prewarmMask = crosspoint::layout::DegradePlan::from(
+                                    crosspoint::layout::renderLevelFor(crosspoint::heap::largestFreeBlockBytes(),
+                                                                       crosspoint::mem::kRenderTrimPrewarmBelowBytes),
+                                    crosspoint::layout::kStyleAll)
+                                    .prewarmStyleMask;
     scope.endScanAndPrewarm(prewarmMask);
     auto* fd = fcm->getDecompressor();
     if (fd) fd->resetBitmapAllocFailures();

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -80,7 +80,7 @@ class EpubReaderActivity final : public ActivityWithSubactivity {
   bool pendingSubactivityExit = false;  // Defer subactivity exit to avoid use-after-free
   bool pendingGoHome = false;           // Defer go home to avoid race condition with display task
   bool pendingGoLibrary = false;        // Defer go library after destructive actions
-  bool pendingThemeReload = false;  // Defer settings reload after ReadingThemesActivity exits
+  bool pendingThemeReload = false;      // Defer settings reload after ReadingThemesActivity exits
   // Snapshot of the per-book Bold Swap preference at the moment the reader
   // menu was opened. Compared on menu exit; if the user toggled the in-menu
   // Bold Swap item, the current page is re-laid out to apply the change.

--- a/src/activities/reader/PagedProgressSink.h
+++ b/src/activities/reader/PagedProgressSink.h
@@ -31,8 +31,7 @@ class PagedProgressSink : public IProgressSink {
   // `cachePath` is the per-book cache dir (no trailing slash). `logTag` is the
   // 3-letter subsystem tag for log lines ("TRS" / "XTR"), preserving the
   // legacy per-reader logging.
-  PagedProgressSink(std::string cachePath, const char* logTag)
-      : cachePath_(std::move(cachePath)), logTag_(logTag) {}
+  PagedProgressSink(std::string cachePath, const char* logTag) : cachePath_(std::move(cachePath)), logTag_(logTag) {}
 
   // IProgressSink — writes ReaderPosition.page as 4-byte LE, synchronously.
   bool write(const ReaderPosition& p) override;

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -51,8 +51,8 @@ std::unique_ptr<Epub> ReaderActivity::loadEpub(const std::string& path) {
 
   auto epub = std::unique_ptr<Epub>(new (std::nothrow) Epub(path, Paths::kDataDir));
   if (!epub) {
-    LOG_ERR("READER", "OOM new Epub free=%u largest=%u",
-            (unsigned)ESP.getFreeHeap(), (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+    LOG_ERR("READER", "OOM new Epub free=%u largest=%u", (unsigned)ESP.getFreeHeap(),
+            (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
     return nullptr;
   }
 

--- a/src/activities/reader/ReaderInputDispatcher.h
+++ b/src/activities/reader/ReaderInputDispatcher.h
@@ -29,12 +29,12 @@ namespace reader {
 // One frame of input, snapshotted from MappedInputManager by the adapter.
 struct ReaderInput {
   bool pressed[kReaderButtonCount] = {};   // wasPressed(b)
-  bool released[kReaderButtonCount] = {};   // wasReleased(b)
-  bool down[kReaderButtonCount] = {};       // isPressed(b) (level)
-  bool anyPressed = false;                   // wasAnyPressed()
-  bool anyReleased = false;                  // wasAnyReleased()
-  unsigned long heldTimeMs = 0;              // getHeldTime() (GLOBAL, not per-button)
-  unsigned long nowMs = 0;                   // millis()
+  bool released[kReaderButtonCount] = {};  // wasReleased(b)
+  bool down[kReaderButtonCount] = {};      // isPressed(b) (level)
+  bool anyPressed = false;                 // wasAnyPressed()
+  bool anyReleased = false;                // wasAnyReleased()
+  unsigned long heldTimeMs = 0;            // getHeldTime() (GLOBAL, not per-button)
+  unsigned long nowMs = 0;                 // millis()
 
   bool p(ReaderButton b) const { return pressed[static_cast<int>(b)]; }
   bool r(ReaderButton b) const { return released[static_cast<int>(b)]; }
@@ -51,9 +51,9 @@ struct ReaderInputSettings {
 struct ReaderState {
   enum class Mode : uint8_t { Normal, Recovery, Highlight };
   Mode mode = Mode::Normal;
-  bool inFootnote = false;    // footnoteDepth > 0  -> Back restores
-  bool atEndOfBook = false;   // currentSpineIndex > 0 && >= spineItemsCount
-  bool hasSection = false;    // section != nullptr
+  bool inFootnote = false;   // footnoteDepth > 0  -> Back restores
+  bool atEndOfBook = false;  // currentSpineIndex > 0 && >= spineItemsCount
+  bool hasSection = false;   // section != nullptr
 };
 
 // Per-reader gesture opt-in (epub: all on; txt/xtc: leaner). OpenMenu and
@@ -138,8 +138,7 @@ class ReaderInputDispatcher {
     }
 
     // 4. Confirm long-press -> highlight (requests input suppression), once.
-    if (cfg_.longPressConfirm && !confirmLongPressHandled_ && confirmDown &&
-        in.heldTimeMs >= kGoHomeMs) {
+    if (cfg_.longPressConfirm && !confirmLongPressHandled_ && confirmDown && in.heldTimeMs >= kGoHomeMs) {
       confirmLongPressHandled_ = true;
       return {ReaderAction::LongPressConfirm, true};
     }

--- a/src/activities/reader/ReaderSession.h
+++ b/src/activities/reader/ReaderSession.h
@@ -31,11 +31,11 @@ namespace reader {
 // tests record calls into vectors.
 struct IReaderEnvPort {
   virtual ~IReaderEnvPort() = default;
-  virtual bool shouldFullRefreshOnEnter(const std::string& path) = 0;   // stateful; call once per enter
+  virtual bool shouldFullRefreshOnEnter(const std::string& path) = 0;  // stateful; call once per enter
   virtual bool boldSwap(const std::string& path) const = 0;
   virtual void registerOpened(const std::string& path, const std::string& title, const std::string& author,
                               const std::string& thumb) = 0;
-  virtual std::string moveBookToRecents(const std::string& path) = 0;   // "" if not relocated
+  virtual std::string moveBookToRecents(const std::string& path) = 0;  // "" if not relocated
 };
 
 // Display seam. Prod wraps GfxRenderer + ReaderCommon::applyReaderOrientation +
@@ -52,27 +52,27 @@ struct IReaderDisplayPort {
 // (position returns {0, currentPage, 1}); the optional onEnter inserts are where
 // Epub does its heap-anchor / CSS / bookmark work.
 struct ReaderHooks {
-  std::function<std::string()>    path;            // REQUIRED
-  std::function<ReaderPosition()> position;        // REQUIRED
-  std::function<void()>           beforeRefresh;   // optional onEnter inserts
-  std::function<void()>           afterOrientation;
-  std::function<void()>           afterRegister;
+  std::function<std::string()> path;         // REQUIRED
+  std::function<ReaderPosition()> position;  // REQUIRED
+  std::function<void()> beforeRefresh;       // optional onEnter inserts
+  std::function<void()> afterOrientation;
+  std::function<void()> afterRegister;
   std::function<void(std::string& title, std::string& author, std::string& thumb)> recentMeta;  // optional
 };
 
 class ReaderSession {
  public:
   struct Ports {
-    IProgressSink&      sink;
-    IReaderEnvPort&     env;
+    IProgressSink& sink;
+    IReaderEnvPort& env;
     IReaderDisplayPort& display;
   };
 
   // applyOrientationOnEnter: Epub/Txt re-apply SETTINGS.orientation to the
   // renderer on enter; the pre-rendered XTC reader does not (false) — its bitmaps
   // are fixed and it never applied orientation on open.
-  ReaderSession(Ports ports, ReaderHooks hooks,
-                uint32_t debounceMs = ReaderProgressTracker::kDefaultDebounceMs, bool applyOrientationOnEnter = true)
+  ReaderSession(Ports ports, ReaderHooks hooks, uint32_t debounceMs = ReaderProgressTracker::kDefaultDebounceMs,
+                bool applyOrientationOnEnter = true)
       : env_(ports.env),
         display_(ports.display),
         hooks_(std::move(hooks)),
@@ -101,11 +101,11 @@ class ReaderSession {
   ReaderProgressTracker& progress() { return progress_; }
 
  private:
-  IReaderEnvPort&       env_;
-  IReaderDisplayPort&   display_;
-  ReaderHooks           hooks_;
+  IReaderEnvPort& env_;
+  IReaderDisplayPort& display_;
+  ReaderHooks hooks_;
   ReaderProgressTracker progress_;
-  bool                  applyOrientationOnEnter_;
+  bool applyOrientationOnEnter_;
 };
 
 }  // namespace reader

--- a/src/activities/reader/ReadingThemesActivity.cpp
+++ b/src/activities/reader/ReadingThemesActivity.cpp
@@ -245,11 +245,11 @@ void ReadingThemesActivity::loop() {
   if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
     if (selectedRowIndex == 0) {
       exitActivity();
-      enterNewActivity(new (std::nothrow) ReaderSettingsActivity(renderer, mappedInput, bookCachePath,
-                                                                 [this](const bool changed) {
-        pendingSubactivityExit = true;
-        pendingSettingsChanged = changed;
-      }));
+      enterNewActivity(new (std::nothrow)
+                           ReaderSettingsActivity(renderer, mappedInput, bookCachePath, [this](const bool changed) {
+                             pendingSubactivityExit = true;
+                             pendingSettingsChanged = changed;
+                           }));
       return;
     }
     if (selectedRowIndex == 1) {

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -1,16 +1,16 @@
 #include "TxtReaderActivity.h"
 
 #include <EpdFontFamily.h>
+#include <Epub/layout/DegradeLevel.h>
 #include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
+#include <HeapGuard.h>
 #include <I18n.h>
 #include <Logging.h>
+#include <MemoryPolicy.h>
 #include <Serialization.h>
 #include <Utf8.h>
-#include <Epub/layout/DegradeLevel.h>
-#include <HeapGuard.h>
-#include <MemoryPolicy.h>
 #include <esp_task_wdt.h>
 
 #include <algorithm>
@@ -1006,12 +1006,11 @@ void TxtReaderActivity::renderPage() {
     renderLines();  // scan pass
     // RFC #164 step 7: trim glyph prewarm to regular-only under heap pressure
     // (Full -> 0x0F on a healthy heap, so unchanged for the common case).
-    const uint8_t prewarmMask =
-        crosspoint::layout::DegradePlan::from(
-            crosspoint::layout::renderLevelFor(crosspoint::heap::largestFreeBlockBytes(),
-                                               crosspoint::mem::kRenderTrimPrewarmBelowBytes),
-            crosspoint::layout::kStyleAll)
-            .prewarmStyleMask;
+    const uint8_t prewarmMask = crosspoint::layout::DegradePlan::from(
+                                    crosspoint::layout::renderLevelFor(crosspoint::heap::largestFreeBlockBytes(),
+                                                                       crosspoint::mem::kRenderTrimPrewarmBelowBytes),
+                                    crosspoint::layout::kStyleAll)
+                                    .prewarmStyleMask;
     scope.endScanAndPrewarm(prewarmMask);
     renderLines();  // actual render (BW)
   } else {
@@ -1177,8 +1176,8 @@ bool TxtReaderActivity::loadPageIndexCache() {
   {
     const size_t needBytes = static_cast<size_t>(numPages) * sizeof(uint32_t);
     if (!crosspoint::heap::canAllocateContiguous(needBytes)) {
-      LOG_ERR("TRS", "OOM pageOffsets reserve: need=%u largest=%u",
-              (unsigned)needBytes, (unsigned)crosspoint::heap::largestFreeBlockBytes());
+      LOG_ERR("TRS", "OOM pageOffsets reserve: need=%u largest=%u", (unsigned)needBytes,
+              (unsigned)crosspoint::heap::largestFreeBlockBytes());
       f.close();
       return false;
     }

--- a/src/activities/reader/TxtReaderActivity.h
+++ b/src/activities/reader/TxtReaderActivity.h
@@ -15,10 +15,10 @@
 
 #include "CrossPointSettings.h"
 #include "PagedProgressSink.h"
-#include "ReaderStatusBar.h"
 #include "ReaderInputDispatcher.h"
 #include "ReaderSession.h"
 #include "ReaderSessionPorts.h"
+#include "ReaderStatusBar.h"
 #include "activities/ActivityWithSubactivity.h"
 
 struct RecentBook;
@@ -56,14 +56,13 @@ class TxtReaderActivity final : public ActivityWithSubactivity {
   crosspoint::reader::ProdEnvPort envPort_;
   crosspoint::reader::ReaderSession session_{
       {progressSink_, envPort_, displayPort_},
-      crosspoint::reader::ReaderHooks{
-          [this] { return txt ? txt->getPath() : std::string(); },
-          [this] { return crosspoint::reader::ReaderPosition{0, currentPage, 1}; },
-          nullptr, nullptr, nullptr,
-          [this](std::string& title, std::string&, std::string&) {
-            const std::string p = txt ? txt->getPath() : std::string();
-            title = p.substr(p.rfind('/') + 1);
-          }}};
+      crosspoint::reader::ReaderHooks{[this] { return txt ? txt->getPath() : std::string(); },
+                                      [this] { return crosspoint::reader::ReaderPosition{0, currentPage, 1}; }, nullptr,
+                                      nullptr, nullptr,
+                                      [this](std::string& title, std::string&, std::string&) {
+                                        const std::string p = txt ? txt->getPath() : std::string();
+                                        title = p.substr(p.rfind('/') + 1);
+                                      }}};
   int recentSwitcherSelection = 0;
   std::vector<RecentBook> recentSwitcherBooks;
 

--- a/src/activities/reader/XtcReaderActivity.h
+++ b/src/activities/reader/XtcReaderActivity.h
@@ -48,8 +48,8 @@ class XtcReaderActivity final : public ActivityWithSubactivity {
       {progressSink_, envPort_, displayPort_},
       crosspoint::reader::ReaderHooks{
           [this] { return xtc ? xtc->getPath() : std::string(); },
-          [this] { return crosspoint::reader::ReaderPosition{0, static_cast<int32_t>(currentPage), 1}; },
-          nullptr, nullptr,
+          [this] { return crosspoint::reader::ReaderPosition{0, static_cast<int32_t>(currentPage), 1}; }, nullptr,
+          nullptr,
           [this] {
             if (xtc) xtc->generateThumbBmp(400);  // afterRegister: cover thumbnail for home
           },

--- a/src/activities/settings/CleanupStorageActivity.cpp
+++ b/src/activities/settings/CleanupStorageActivity.cpp
@@ -156,8 +156,7 @@ void CleanupStorageActivity::runCleanup() {
   failedCount = result.failed;
   bytesFreed = result.bytesFreed;
 
-  LOG_DIAG("CLEANUP", "done: %d removed, %d failed, %u B freed", removedCount, failedCount,
-           (unsigned)bytesFreed);
+  LOG_DIAG("CLEANUP", "done: %d removed, %d failed, %u B freed", removedCount, failedCount, (unsigned)bytesFreed);
 
   if (failedCount > 0 && removedCount == 0) {
     state = FAILED;
@@ -197,8 +196,7 @@ void CleanupStorageActivity::render(Activity::RenderLock&&) {
   if (state == SUCCESS) {
     renderer.drawCenteredText(UI_10_FONT_ID, pageHeight / 2 - 20, tr(STR_CLEANUP_STORAGE_DONE), true,
                               EpdFontFamily::REGULAR);
-    std::string resultText =
-        std::to_string(removedCount) + " " + std::string(tr(STR_ITEMS_REMOVED));
+    std::string resultText = std::to_string(removedCount) + " " + std::string(tr(STR_ITEMS_REMOVED));
     if (bytesFreed > 0) {
       resultText += ", " + std::to_string(bytesFreed) + " " + std::string(tr(STR_BYTES_FREED));
     }

--- a/src/activities/settings/KOReaderAuthActivity.cpp
+++ b/src/activities/settings/KOReaderAuthActivity.cpp
@@ -6,8 +6,8 @@
 
 #include "KOReaderCredentialStore.h"
 #include "KOReaderSyncClient.h"
-#include "SilentRestart.h"
 #include "MappedInputManager.h"
+#include "SilentRestart.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"

--- a/src/boot/BootSequenceOrchestrator.h
+++ b/src/boot/BootSequenceOrchestrator.h
@@ -30,12 +30,12 @@ namespace boot {
 // Snapshot of every impure input, gathered by the caller from the globals.
 struct BootInputs {
   bool isSilentReboot = false;
-  int silentRebootTarget = -1;          // consumeSilentRebootTarget(): -1 none, 0 home, 1 reader
-  std::string openEpubPath;             // APP_STATE.openEpubPath (read)
-  uint8_t readerActivityLoadCount = 0;  // APP_STATE crash-loop guard (read)
-  bool backHeld = false;                // mappedInputManager.isPressed(Back)
+  int silentRebootTarget = -1;               // consumeSilentRebootTarget(): -1 none, 0 home, 1 reader
+  std::string openEpubPath;                  // APP_STATE.openEpubPath (read)
+  uint8_t readerActivityLoadCount = 0;       // APP_STATE crash-loop guard (read)
+  bool backHeld = false;                     // mappedInputManager.isPressed(Back)
   std::vector<std::string> recentBookPaths;  // RECENT_BOOKS paths, in order, UNFILTERED
-  bool randomBookOnBoot = false;        // SETTINGS.randomBookOnBoot
+  bool randomBookOnBoot = false;             // SETTINGS.randomBookOnBoot
 };
 
 // Count-dependent random, injected. The core calls it with the FILTERED epub
@@ -44,8 +44,8 @@ struct BootInputs {
 using RandomIndexFn = uint32_t (*)(uint32_t count);  // returns [0, count)
 
 struct BootDecision {
-  bool goHome = true;       // true -> RouteId::Home, false -> RouteId::Reader
-  std::string readerPath;   // valid iff !goHome
+  bool goHome = true;      // true -> RouteId::Home, false -> RouteId::Reader
+  std::string readerPath;  // valid iff !goHome
   // When true the caller MUST, before launching the reader, run the durable
   // crash-loop guard side effect: clear openEpubPath; increment
   // readerActivityLoadCount (cap 255); APP_STATE.saveToFileSync(). Returned, not
@@ -55,9 +55,7 @@ struct BootDecision {
 
 namespace detail {
 // Exact legacy predicate (main.cpp:833): p.size() > 5 && rfind(".epub") == size-5.
-inline bool endsWithEpub(const std::string& p) {
-  return p.size() > 5 && p.rfind(".epub") == p.size() - 5;
-}
+inline bool endsWithEpub(const std::string& p) { return p.size() > 5 && p.rfind(".epub") == p.size() - 5; }
 }  // namespace detail
 
 // The whole decision, pure + deterministic given (inputs, rng).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include "Paths.h"
 #include "ReadingThemeStore.h"
 #include "RecentBooksStore.h"
+#include "SilentRestart.h"
 #include "activities/boot_sleep/BootActivity.h"
 #include "activities/boot_sleep/SleepActivity.h"
 #include "activities/browser/OpdsBookBrowserActivity.h"
@@ -50,12 +51,11 @@
 #include "activities/reader/ReaderActivity.h"
 #include "activities/settings/SettingsActivity.h"
 #include "activities/util/FullScreenMessageActivity.h"
+#include "boot/BootSequenceOrchestrator.h"
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"
 #include "fonts/CustomBinFontIds.h"
 #include "fonts/CustomBinFontManager.h"
-#include "SilentRestart.h"
-#include "boot/BootSequenceOrchestrator.h"
 #include "lifecycle/ActivityRouter.h"
 #include "network/WifiDiagReport.h"
 #include "persist/AppStateStore.h"
@@ -838,10 +838,8 @@ void setup() {
     in.randomBookOnBoot = SETTINGS.randomBookOnBoot;
     for (const auto& b : RECENT_BOOKS.getBooks()) in.recentBookPaths.push_back(b.path);
 
-    const crosspoint::boot::BootDecision decision =
-        crosspoint::boot::decideBoot(in, [](uint32_t count) -> uint32_t {
-          return static_cast<uint32_t>(random(static_cast<long>(count)));
-        });
+    const crosspoint::boot::BootDecision decision = crosspoint::boot::decideBoot(
+        in, [](uint32_t count) -> uint32_t { return static_cast<uint32_t>(random(static_cast<long>(count))); });
     readerPath = decision.readerPath;
     goHome = decision.goHome;
 

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -238,8 +238,8 @@ void CrossPointWebServer::begin() {
   LOG_DBG("WEB", "Creating web server on port %d...", port);
   server.reset(new (std::nothrow) WebServer(port));
   if (!server) {
-    LOG_ERR("WEB", "OOM new WebServer port=%d free=%u largest=%u", port,
-            (unsigned)ESP.getFreeHeap(), (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
+    LOG_ERR("WEB", "OOM new WebServer port=%d free=%u largest=%u", port, (unsigned)ESP.getFreeHeap(),
+            (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
     return;  // running stays false; caller sees server unavailable
   }
 
@@ -777,12 +777,24 @@ void CrossPointWebServer::handleFirmwareStatus() const {
     if (esp_ota_get_state_partition(running, &imgState) == ESP_OK) {
       const char* name = "unknown";
       switch (imgState) {
-        case ESP_OTA_IMG_NEW:            name = "new"; break;
-        case ESP_OTA_IMG_PENDING_VERIFY: name = "pending_verify"; break;
-        case ESP_OTA_IMG_VALID:          name = "valid"; break;
-        case ESP_OTA_IMG_INVALID:        name = "invalid"; break;
-        case ESP_OTA_IMG_ABORTED:        name = "aborted"; break;
-        case ESP_OTA_IMG_UNDEFINED:      name = "undefined"; break;
+        case ESP_OTA_IMG_NEW:
+          name = "new";
+          break;
+        case ESP_OTA_IMG_PENDING_VERIFY:
+          name = "pending_verify";
+          break;
+        case ESP_OTA_IMG_VALID:
+          name = "valid";
+          break;
+        case ESP_OTA_IMG_INVALID:
+          name = "invalid";
+          break;
+        case ESP_OTA_IMG_ABORTED:
+          name = "aborted";
+          break;
+        case ESP_OTA_IMG_UNDEFINED:
+          name = "undefined";
+          break;
       }
       doc["ota_state"] = name;
       // VALID = explicitly confirmed; UNDEFINED = app rollback not enabled, so a

--- a/test/test_boot_orchestrator/test_main.cpp
+++ b/test/test_boot_orchestrator/test_main.cpp
@@ -108,7 +108,7 @@ void test_silent_reader_empty_path_goes_home() {
 void test_silent_home_target_goes_home() {
   BootInputs in = normalBoot();
   in.isSilentReboot = true;
-  in.silentRebootTarget = 0;  // home
+  in.silentRebootTarget = 0;          // home
   in.openEpubPath = "/books/a.epub";  // ignored on a home-target silent reboot
   BootDecision d = decideBoot(in, testRng);
   TEST_ASSERT_TRUE(d.goHome);

--- a/test/test_deferred_action_queue/test_main.cpp
+++ b/test/test_deferred_action_queue/test_main.cpp
@@ -107,8 +107,8 @@ void test_repost_self_during_drain_rearms_for_next_pass() {
     }
     return false;
   });
-  TEST_ASSERT_EQUAL_INT(1, firstPassRuns);       // ran once this pass
-  TEST_ASSERT_TRUE(q.pending(TestAction::A));     // re-armed for next pass
+  TEST_ASSERT_EQUAL_INT(1, firstPassRuns);     // ran once this pass
+  TEST_ASSERT_TRUE(q.pending(TestAction::A));  // re-armed for next pass
   int secondPassRuns = 0;
   q.drain([&](TestAction a) {
     if (a == TestAction::A) secondPassRuns++;

--- a/test/test_heap_guard/test_main.cpp
+++ b/test/test_heap_guard/test_main.cpp
@@ -16,9 +16,7 @@ using crosspoint::heap::setLargestFreeBlockOverride;
 void setUp() { clearLargestFreeBlockOverride(); }
 void tearDown() { clearLargestFreeBlockOverride(); }
 
-void test_unset_override_returns_size_max() {
-  TEST_ASSERT_EQUAL_size_t(SIZE_MAX, largestFreeBlockBytes());
-}
+void test_unset_override_returns_size_max() { TEST_ASSERT_EQUAL_size_t(SIZE_MAX, largestFreeBlockBytes()); }
 
 void test_unset_override_allows_any_allocation() {
   TEST_ASSERT_TRUE(canAllocateContiguous(0));

--- a/test/test_http_upload_sink/test_main.cpp
+++ b/test/test_http_upload_sink/test_main.cpp
@@ -21,9 +21,9 @@ namespace {
 
 // Collects everything the sink flushes, and can simulate a short write.
 struct FakeFile {
-  std::vector<uint8_t> bytes;     // all data the sink flushed, in order
-  std::vector<size_t> flushSizes; // size of each flush call
-  bool shortWrite = false;        // when true, writer reports 1 byte short
+  std::vector<uint8_t> bytes;      // all data the sink flushed, in order
+  std::vector<size_t> flushSizes;  // size of each flush call
+  bool shortWrite = false;         // when true, writer reports 1 byte short
 
   HttpUploadSink::Writer writer() {
     return [this](const uint8_t* d, size_t n) -> size_t {
@@ -81,8 +81,8 @@ void test_exact_boundary_autoflush() {
 
   auto data = seq(8);
   TEST_ASSERT_TRUE(sink.append(data.data(), data.size(), f.writer()));
-  TEST_ASSERT_EQUAL_UINT32(0, sink.pending());          // auto-flushed
-  TEST_ASSERT_EQUAL_UINT32(1, f.flushSizes.size());     // exactly one flush
+  TEST_ASSERT_EQUAL_UINT32(0, sink.pending());       // auto-flushed
+  TEST_ASSERT_EQUAL_UINT32(1, f.flushSizes.size());  // exactly one flush
   TEST_ASSERT_EQUAL_UINT32(8, f.flushSizes[0]);
   TEST_ASSERT_EQUAL_UINT32(8, f.bytes.size());
 }
@@ -95,8 +95,8 @@ void test_chunk_larger_than_buffer() {
 
   auto data = seq(20);  // 8 + 8 + 4
   TEST_ASSERT_TRUE(sink.append(data.data(), data.size(), f.writer()));
-  TEST_ASSERT_EQUAL_UINT32(4, sink.pending());          // 4-byte tail buffered
-  TEST_ASSERT_EQUAL_UINT32(2, f.flushSizes.size());     // two full flushes
+  TEST_ASSERT_EQUAL_UINT32(4, sink.pending());       // 4-byte tail buffered
+  TEST_ASSERT_EQUAL_UINT32(2, f.flushSizes.size());  // two full flushes
   TEST_ASSERT_EQUAL_UINT32(16, f.bytes.size());
 
   TEST_ASSERT_TRUE(sink.flush(f.writer()));

--- a/test/test_memory_harness/FakeHeap.h
+++ b/test/test_memory_harness/FakeHeap.h
@@ -83,8 +83,10 @@ class FakeHeap {
       return false;
     }
     largestFreeBlock_ -= bytes;
-    if (bytes > totalFree_) totalFree_ = 0;
-    else totalFree_ -= bytes;
+    if (bytes > totalFree_)
+      totalFree_ = 0;
+    else
+      totalFree_ -= bytes;
     if (minFreeEver_ == 0 || largestFreeBlock_ < minFreeEver_) minFreeEver_ = largestFreeBlock_;
     return true;
   }

--- a/test/test_memory_harness/test_main.cpp
+++ b/test/test_memory_harness/test_main.cpp
@@ -23,11 +23,11 @@ using crosspoint::persist::InMemoryFileIO;
 using crosspoint::sleep::ISleepFs;
 using crosspoint::sleep::SleepBmpEntry;
 using crosspoint::sleep::v2::WallpaperPlaylistV2;
+using crosspoint::test::applyScenario;
 using crosspoint::test::FakeHeap;
 using crosspoint::test::kCrash1Preconditions;
 using crosspoint::test::kCrash2Preconditions;
 using crosspoint::test::kHealthyBoot;
-using crosspoint::test::applyScenario;
 
 namespace {
 
@@ -58,22 +58,21 @@ class FakeSleepFs : public ISleepFs {
     if (best.empty() && !files.empty()) best = files.front();
     return best;
   }
-  std::string nthSleepBmp(size_t n) override {
-    return n < files.size() ? files[n] : std::string();
-  }
+  std::string nthSleepBmp(size_t n) override { return n < files.size() ? files[n] : std::string(); }
   bool exists(const std::string& path) override {
     // Path comes in as "/sleep/<basename>" — match the basename against `files`.
     const auto slash = path.find_last_of('/');
     const std::string base = (slash == std::string::npos) ? path : path.substr(slash + 1);
-    for (const auto& f : files) if (f == base) return true;
+    for (const auto& f : files)
+      if (f == base) return true;
     return false;
   }
   bool mkdir(const std::string&) override { return true; }
   bool rename(const std::string&, const std::string&) override { return true; }
 };
 
-WallpaperPlaylistV2::Deps makeDeps(FakeSleepFs* fs, InMemoryFileIO* io,
-                                   std::string* lastShown, std::string* lastRendered) {
+WallpaperPlaylistV2::Deps makeDeps(FakeSleepFs* fs, InMemoryFileIO* io, std::string* lastShown,
+                                   std::string* lastRendered) {
   WallpaperPlaylistV2::Deps deps;
   deps.fs = fs;
   deps.fileIO = io;

--- a/test/test_memory_policy/test_main.cpp
+++ b/test/test_memory_policy/test_main.cpp
@@ -75,8 +75,8 @@ void test_rich_sleep_reads_total_free_not_largest_block() {
   // Inverse: plenty of total free but fragmented into small blocks.
   setLargestFreeBlockOverride(10 * 1024);
   setTotalFreeOverride(120 * 1024);
-  TEST_ASSERT_TRUE(canAfford(Op::RenderRichSleepScreen));   // 120K total >= 30K
-  TEST_ASSERT_FALSE(canAfford(Op::ScanSleepPlaylist));      // 10K largest < 64K
+  TEST_ASSERT_TRUE(canAfford(Op::RenderRichSleepScreen));  // 120K total >= 30K
+  TEST_ASSERT_FALSE(canAfford(Op::ScanSleepPlaylist));     // 10K largest < 64K
 }
 
 // ── Recovery ladder (pure decision) ────────────────────────────────────────
@@ -160,8 +160,8 @@ void test_room_to_grow_sheds_once_then_succeeds() {
     shedCalls++;
     setLargestFreeBlockOverride(50 * 1024);
   });
-  TEST_ASSERT_TRUE(roomToGrow(20 * 1024));   // flips false -> shed -> true
-  TEST_ASSERT_EQUAL_INT(1, shedCalls);       // shed exactly once
+  TEST_ASSERT_TRUE(roomToGrow(20 * 1024));  // flips false -> shed -> true
+  TEST_ASSERT_EQUAL_INT(1, shedCalls);      // shed exactly once
 }
 
 void test_room_to_grow_fails_when_shed_cannot_free_enough() {

--- a/test/test_reader_input_dispatcher/test_main.cpp
+++ b/test/test_reader_input_dispatcher/test_main.cpp
@@ -78,8 +78,7 @@ void test_double_tap_toggles_render_mode() {
 
   ReaderInput f2 = frame(1200);  // 200ms <= 350 double-tap window
   release(f2, ReaderButton::Confirm);
-  TEST_ASSERT_EQUAL_INT((int)ReaderAction::ToggleTextRenderMode,
-                        act(d.dispatch(f2, relSettings(), normalReading())));
+  TEST_ASSERT_EQUAL_INT((int)ReaderAction::ToggleTextRenderMode, act(d.dispatch(f2, relSettings(), normalReading())));
   TEST_ASSERT_FALSE(d.pendingMenuOpen());
 }
 

--- a/test/test_reader_session/test_main.cpp
+++ b/test/test_reader_session/test_main.cpp
@@ -64,18 +64,15 @@ struct Harness {
   ReaderSession session;
 
   Harness()
-      : session({sink, env, display},
-                ReaderHooks{
-                    [this] { return path; },
-                    [this] { return pos; },
-                    [this] { order.push_back("beforeRefresh"); },
-                    [this] { order.push_back("afterOrientation"); },
-                    [this] { order.push_back("afterRegister"); },
-                    [this](std::string& t, std::string& a, std::string& th) {
-                      t = "Title";
-                      a = "Author";
-                      th = "/t.bmp";
-                    }}) {}
+      : session(
+            {sink, env, display},
+            ReaderHooks{[this] { return path; }, [this] { return pos; }, [this] { order.push_back("beforeRefresh"); },
+                        [this] { order.push_back("afterOrientation"); }, [this] { order.push_back("afterRegister"); },
+                        [this](std::string& t, std::string& a, std::string& th) {
+                          t = "Title";
+                          a = "Author";
+                          th = "/t.bmp";
+                        }}) {}
 };
 
 }  // namespace
@@ -95,8 +92,8 @@ void test_enter_full_refresh_registers_and_seeds() {
   TEST_ASSERT_TRUE(h.display.boldCalls.back());  // bold-swap on from env
   TEST_ASSERT_EQUAL(1, h.env.registerCalls);
   TEST_ASSERT_EQUAL_STRING("Title", h.env.lastTitle.c_str());
-  TEST_ASSERT_EQUAL_STRING("", moved.c_str());            // not relocated
-  TEST_ASSERT_EQUAL(0, h.sink.writes.size());             // seed performs no write
+  TEST_ASSERT_EQUAL_STRING("", moved.c_str());                  // not relocated
+  TEST_ASSERT_EQUAL(0, h.sink.writes.size());                   // seed performs no write
   TEST_ASSERT_EQUAL(5, h.session.progress().lastSaved().page);  // seeded
 }
 
@@ -123,11 +120,11 @@ void test_tick_debounces_then_writes() {
   Harness h;
   h.session.enter({0, 0, 1});
   h.pos = {0, 1, 1};
-  h.session.tick(1000, false);          // observe page 1, anchor debounce
+  h.session.tick(1000, false);  // observe page 1, anchor debounce
   TEST_ASSERT_EQUAL(0, h.sink.writes.size());
-  h.session.tick(1500, false);          // < 800ms since change? change was at 1000, now 1500 -> 500ms
+  h.session.tick(1500, false);  // < 800ms since change? change was at 1000, now 1500 -> 500ms
   TEST_ASSERT_EQUAL(0, h.sink.writes.size());
-  h.session.tick(1900, false);          // 900ms elapsed -> write
+  h.session.tick(1900, false);  // 900ms elapsed -> write
   TEST_ASSERT_EQUAL(1, h.sink.writes.size());
   TEST_ASSERT_EQUAL(1, h.sink.writes.back().page);
 }
@@ -136,7 +133,7 @@ void test_tick_force_writes_immediately() {
   Harness h;
   h.session.enter({0, 0, 1});
   h.pos = {0, 7, 1};
-  h.session.tick(100, true);            // force ignores debounce
+  h.session.tick(100, true);  // force ignores debounce
   TEST_ASSERT_EQUAL(1, h.sink.writes.size());
   TEST_ASSERT_EQUAL(7, h.sink.writes.back().page);
 }
@@ -144,8 +141,8 @@ void test_tick_force_writes_immediately() {
 void test_tick_idempotent_when_unchanged() {
   Harness h;
   h.session.enter({0, 3, 1});
-  h.pos = {0, 3, 1};                    // same as seed
-  h.session.tick(5000, true);          // nothing dirty -> no write
+  h.pos = {0, 3, 1};           // same as seed
+  h.session.tick(5000, true);  // nothing dirty -> no write
   TEST_ASSERT_EQUAL(0, h.sink.writes.size());
 }
 
@@ -176,13 +173,13 @@ void test_resetto_flushes_then_reseeds() {
   Harness h;
   h.session.enter({0, 0, 1});
   h.pos = {0, 2, 1};
-  h.session.tick(1000, false);         // dirty at page 2, not yet flushed
-  h.session.resetTo({0, 50, 1}, 1100); // KOReader sync: flush pending then reseed
+  h.session.tick(1000, false);          // dirty at page 2, not yet flushed
+  h.session.resetTo({0, 50, 1}, 1100);  // KOReader sync: flush pending then reseed
   // pending page-2 write flushed, then reseed to 50, dirty cleared.
   TEST_ASSERT_EQUAL(2, h.sink.writes.back().page);
   TEST_ASSERT_EQUAL(50, h.session.progress().lastSaved().page);
   h.pos = {0, 50, 1};
-  h.session.tick(9999, true);          // reseeded position is not dirty -> no extra write
+  h.session.tick(9999, true);  // reseeded position is not dirty -> no extra write
   TEST_ASSERT_EQUAL(1, h.sink.writes.size());
 }
 

--- a/test/test_reader_sim/StubRenderer.cpp
+++ b/test/test_reader_sim/StubRenderer.cpp
@@ -1,10 +1,9 @@
 // Metrics-only GfxRenderer implementation for the host reader-sim.
 // Answers text-measurement queries from a real built-in EpdFontFamily so
 // ParsedText's line breaking sees realistic widths.
-#include <GfxRenderer.h>  // the shadow (sim_shadows is first on the include path)
-
 #include <EpdFont.h>
 #include <EpdFontFamily.h>
+#include <GfxRenderer.h>         // the shadow (sim_shadows is first on the include path)
 #include <unifont_14_regular.h>  // -I lib/EpdFont/builtinFonts; defines static const EpdFontData
 
 #include <cstdint>
@@ -31,8 +30,7 @@ int GfxRenderer::getTextWidth(int, const char* text, EpdFontFamily::Style style)
   return w;
 }
 
-int GfxRenderer::getTextWidthSpaced(int fontId, const char* text, int letterSpacing,
-                                    EpdFontFamily::Style style) const {
+int GfxRenderer::getTextWidthSpaced(int fontId, const char* text, int letterSpacing, EpdFontFamily::Style style) const {
   int base = getTextWidth(fontId, text, style);
   const size_t n = cpCount(text);
   if (n > 0 && letterSpacing != 0) base += letterSpacing * static_cast<int>(n);
@@ -54,6 +52,4 @@ int GfxRenderer::getLineHeight(int) const {
   return d ? d->advanceY : 16;
 }
 
-bool GfxRenderer::hasGlyph(int, uint32_t cp, EpdFontFamily::Style style) const {
-  return g_family.hasGlyph(cp, style);
-}
+bool GfxRenderer::hasGlyph(int, uint32_t cp, EpdFontFamily::Style style) const { return g_family.hasGlyph(cp, style); }

--- a/test/test_reader_sim/test_main.cpp
+++ b/test/test_reader_sim/test_main.cpp
@@ -8,11 +8,10 @@
 // which is exactly where the on-device OOM crashes originate.
 //
 // Run via: pio test -e test_sim -f test_reader_sim
-#include <unity.h>
-
 #include <GfxRenderer.h>  // shadow: full definition needed for g_renderer instance
 #include <HeapGuard.h>
 #include <ParsedText.h>
+#include <unity.h>
 
 #include <chrono>
 #include <functional>
@@ -41,9 +40,9 @@ uint32_t layoutParagraph(int words, int viewportWidth, int longEvery = 0, bool h
     }
   }
   uint32_t lines = 0;
-  pt.layoutAndExtractLines(g_renderer, /*fontId=*/0, static_cast<uint16_t>(viewportWidth),
-                           [&lines](std::shared_ptr<TextBlock>) { ++lines; },
-                           /*includeLastLine=*/true);
+  pt.layoutAndExtractLines(
+      g_renderer, /*fontId=*/0, static_cast<uint16_t>(viewportWidth), [&lines](std::shared_ptr<TextBlock>) { ++lines; },
+      /*includeLastLine=*/true);
   return lines;
 }
 
@@ -89,9 +88,9 @@ void test_layout_under_fragmentation_no_would_abort() {
   SimHeap::disarm();
   crosspoint::heap::clearLargestFreeBlockOverride();
 
-  TEST_ASSERT_FALSE(threw);                     // no throwing alloc reached
-  TEST_ASSERT_EQUAL_UINT(0, wouldAbort);        // no unguarded alloc would crash
-  (void)lines;  // layout may have bailed early via oom_ — that's the safe path
+  TEST_ASSERT_FALSE(threw);               // no throwing alloc reached
+  TEST_ASSERT_EQUAL_UINT(0, wouldAbort);  // no unguarded alloc would crash
+  (void)lines;                            // layout may have bailed early via oom_ — that's the safe path
 }
 
 // Snappiness + memory-churn baseline. Measures layout wall-clock AND the number
@@ -169,7 +168,10 @@ void test_hyphenation_path_under_fragmentation_no_would_abort() {
 void test_fuzz_layout_random_fragmentation_never_aborts() {
   const size_t bins[] = {1024, 4096, 9216, 12288, 25600, 49152, 90000};
   uint32_t lcg = 0xBEEF1234u;
-  auto next = [&]() { lcg = lcg * 1664525u + 1013904223u; return lcg; };
+  auto next = [&]() {
+    lcg = lcg * 1664525u + 1013904223u;
+    return lcg;
+  };
 
   unsigned totalWouldAbort = 0;
   bool anyThrew = false;

--- a/test/test_reader_sim_parse/StubEpub.cpp
+++ b/test/test_reader_sim_parse/StubEpub.cpp
@@ -1,11 +1,11 @@
 // Define the few REAL symbols the parse slice references without compiling the
 // heavy Epub.cpp: Epub::readItemContentsToStream (stubbed to "no image") and
 // BookFingerprint::cacheDirName (used by Epub's inline ctor).
-#include <Epub.h>
 #include <BookFingerprint.h>
+#include <Epub.h>
 
 bool Epub::readItemContentsToStream(const std::string&, Print&, size_t) const { return false; }
 
 namespace BookFingerprint {
 std::string cacheDirName(const char*, const std::string&, const std::string&) { return std::string("/tmp/sim_cache"); }
-}
+}  // namespace BookFingerprint

--- a/test/test_reader_sim_parse/StubRenderer.cpp
+++ b/test/test_reader_sim_parse/StubRenderer.cpp
@@ -1,9 +1,10 @@
 // Metrics-only GfxRenderer for the parse sim (layout widths + line/ascender
 // heights) from a real built-in font. No pixels.
-#include <GfxRenderer.h>
 #include <EpdFont.h>
 #include <EpdFontFamily.h>
+#include <GfxRenderer.h>
 #include <unifont_14_regular.h>
+
 #include <cstdint>
 
 namespace {
@@ -11,13 +12,16 @@ const EpdFont g_regular(&unifont_14_regular);
 const EpdFontFamily g_family(&g_regular);
 size_t cpCount(const char* s) {
   size_t n = 0;
-  for (; *s; ++s) if ((static_cast<unsigned char>(*s) & 0xC0) != 0x80) ++n;
+  for (; *s; ++s)
+    if ((static_cast<unsigned char>(*s) & 0xC0) != 0x80) ++n;
   return n;
 }
 }  // namespace
 
 int GfxRenderer::getTextWidth(int, const char* text, EpdFontFamily::Style style) const {
-  int w = 0, h = 0; g_family.getTextDimensions(text, &w, &h, style); return w;
+  int w = 0, h = 0;
+  g_family.getTextDimensions(text, &w, &h, style);
+  return w;
 }
 int GfxRenderer::getTextWidthSpaced(int fontId, const char* text, int ls, EpdFontFamily::Style style) const {
   int base = getTextWidth(fontId, text, style);
@@ -26,20 +30,22 @@ int GfxRenderer::getTextWidthSpaced(int fontId, const char* text, int ls, EpdFon
   return base;
 }
 int GfxRenderer::getSpaceWidth(int, EpdFontFamily::Style style) const {
-  int w = 0, h = 0; g_family.getTextDimensions(" ", &w, &h, style); return w;
+  int w = 0, h = 0;
+  g_family.getTextDimensions(" ", &w, &h, style);
+  return w;
 }
 int GfxRenderer::getTextAdvanceX(int fontId, const char* text, EpdFontFamily::Style style) const {
   return getTextWidth(fontId, text, style);
 }
 int GfxRenderer::getLineHeight(int) const {
-  const EpdFontData* d = g_family.getData(EpdFontFamily::REGULAR); return d ? d->advanceY : 16;
+  const EpdFontData* d = g_family.getData(EpdFontFamily::REGULAR);
+  return d ? d->advanceY : 16;
 }
 int GfxRenderer::getFontAscenderSize(int) const {
-  const EpdFontData* d = g_family.getData(EpdFontFamily::REGULAR); return d ? d->ascender : 12;
+  const EpdFontData* d = g_family.getData(EpdFontFamily::REGULAR);
+  return d ? d->ascender : 12;
 }
-bool GfxRenderer::hasGlyph(int, uint32_t cp, EpdFontFamily::Style style) const {
-  return g_family.hasGlyph(cp, style);
-}
+bool GfxRenderer::hasGlyph(int, uint32_t cp, EpdFontFamily::Style style) const { return g_family.hasGlyph(cp, style); }
 
 // --- render-path no-ops (linked via TextBlock/ImageBlock vtables, never called) ---
 int GfxRenderer::getScreenWidth() const { return 600; }

--- a/test/test_reader_sim_parse/shadows/Arduino.h
+++ b/test/test_reader_sim_parse/shadows/Arduino.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <WString.h>
 #include <esp_heap_caps.h>
-#include <cstdint>
+
 #include <cstddef>
+#include <cstdint>

--- a/test/test_reader_sim_parse/shadows/esp_heap_caps.h
+++ b/test/test_reader_sim_parse/shadows/esp_heap_caps.h
@@ -5,9 +5,9 @@
 #include <cstddef>
 #include <cstdint>
 
-#define MALLOC_CAP_8BIT     (1 << 2)
+#define MALLOC_CAP_8BIT (1 << 2)
 #define MALLOC_CAP_INTERNAL (1 << 11)
-#define MALLOC_CAP_DEFAULT  0
+#define MALLOC_CAP_DEFAULT 0
 
 inline size_t heap_caps_get_largest_free_block(uint32_t) { return 4u * 1024 * 1024; }
 inline size_t heap_caps_get_free_size(uint32_t) { return 8u * 1024 * 1024; }

--- a/test/test_reader_sim_parse/test_main.cpp
+++ b/test/test_reader_sim_parse/test_main.cpp
@@ -7,8 +7,6 @@
 // parses it into Pages (delivered via callback).
 //
 // Run via: pio test -e test_sim_parse -f test_reader_sim_parse
-#include <unity.h>
-
 #include <Epub.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
@@ -20,6 +18,7 @@
 #include <parsers/ChapterHtmlSlimParser.h>
 #include <parsers/FootnotePlacer.h>
 #include <parsers/StyleResolver.h>
+#include <unity.h>
 
 #include <chrono>
 #include <cstdio>
@@ -77,8 +76,9 @@ uint32_t parseChapter() {
   cfg.hyphenationEnabled = false;
   cfg.wordSpacingPercent = 1;
   cfg.usePublisherStyles = true;
-  ChapterHtmlSlimParser parser(epub, filepath, g_renderer, cfg, [&pages](std::unique_ptr<Page>) { ++pages; },
-                               [](const std::string&, uint16_t) {}, /*progressFn=*/nullptr, /*cssParser=*/nullptr);
+  ChapterHtmlSlimParser parser(
+      epub, filepath, g_renderer, cfg, [&pages](std::unique_ptr<Page>) { ++pages; },
+      [](const std::string&, uint16_t) {}, /*progressFn=*/nullptr, /*cssParser=*/nullptr);
   parser.parseAndBuildPages();
   return pages;
 }
@@ -220,7 +220,7 @@ void test_style_underline_via_anchor() {
 // setting overrides it (CSS cascade). This fixes the former OR-merge quirk.
 void test_style_inline_normal_unbolds_under_depth_flag() {
   StyleResolver r;
-  r.setBoldFrom(0);  // ancestor <b>/header at depth 0 sets boldUntilDepth = 0
+  r.setBoldFrom(0);                                   // ancestor <b>/header at depth 0 sets boldUntilDepth = 0
   r.pushInline(2, {.hasBold = true, .bold = false});  // inner span font-weight:normal
   TEST_ASSERT_FALSE(r.effectiveStyle(3) & EpdFontFamily::BOLD);  // explicit normal wins
 }
@@ -229,9 +229,9 @@ void test_style_inline_normal_unbolds_under_depth_flag() {
 // font-weight:normal over a CSS-base bold does turn bold off.
 void test_style_inline_normal_overrides_css_base_bold() {
   StyleResolver r;
-  r.setCssBase(cssBold());                                       // base bold, no depth flag
+  r.setCssBase(cssBold());  // base bold, no depth flag
   TEST_ASSERT_TRUE(r.effectiveStyle(1) & EpdFontFamily::BOLD);
-  r.pushInline(1, {.hasBold = true, .bold = false});            // <span font-weight:normal>
+  r.pushInline(1, {.hasBold = true, .bold = false});             // <span font-weight:normal>
   TEST_ASSERT_FALSE(r.effectiveStyle(2) & EpdFontFamily::BOLD);  // overridden off
 }
 
@@ -356,8 +356,8 @@ void test_footnote_on_new_block_resets_count_keeps_pending() {
   p.registerFootnote(2, fnEntry("1", "h"));
   p.onNewBlock();
   TEST_ASSERT_EQUAL_INT(0, p.extractedWordCount());
-  TEST_ASSERT_FALSE(p.empty());                 // pending preserved
-  p.placeForLine(2, log.fn());                  // cumulative 2 -> 2<=2 drains
+  TEST_ASSERT_FALSE(p.empty());  // pending preserved
+  p.placeForLine(2, log.fn());   // cumulative 2 -> 2<=2 drains
   TEST_ASSERT_EQUAL_UINT(1, log.numbers.size());
 }
 
@@ -637,8 +637,7 @@ void test_arena_reused_across_blocks_bounded() {
     cur.reset(new ParsedText(/*extraSpacing=*/false, /*hyphenation=*/false, BlockStyle(), /*wordSpacing=*/1,
                              /*indentMode=*/0, /*usePublisher=*/true, &arena));  // construct-before-destroy
     for (int i = 0; i < 40; ++i) cur->addWord("word", EpdFontFamily::REGULAR, false, false);
-    cur->layoutAndExtractLines(
-        g_renderer, 0, 600, [](std::shared_ptr<TextBlock>) {}, /*includeLastLine=*/true);
+    cur->layoutAndExtractLines(g_renderer, 0, 600, [](std::shared_ptr<TextBlock>) {}, /*includeLastLine=*/true);
     if (b == 0) peakAfterFirst = arena.highWater();
   }
   cur.reset();
@@ -652,8 +651,8 @@ void test_arena_reused_across_blocks_bounded() {
 // the first addWord and lays out byte-identically.
 void test_arena_too_small_migrates() {
   const std::vector<WordSpec> w = repeatWords("word", 80);
-  const std::vector<CapturedLine> noArena = captureParagraph(w, false, styleWith(CssTextAlign::Justify), 1, 0, true, 600,
-                                                             nullptr);
+  const std::vector<CapturedLine> noArena =
+      captureParagraph(w, false, styleWith(CssTextAlign::Justify), 1, 0, true, 600, nullptr);
   crosspoint::layout::LayoutArena tiny = crosspoint::layout::LayoutArena::create(2 * 1024);  // < handle array
   TEST_ASSERT_TRUE(tiny.ok());
   const std::vector<CapturedLine> withTiny =
@@ -667,8 +666,8 @@ void test_arena_too_small_migrates() {
 void test_arena_byte_overflow_migrates() {
   // Long words so the packed byte region fills before the 1024-handle cap.
   const std::vector<WordSpec> w = repeatWords("supercalifragilistic", 200);
-  const std::vector<CapturedLine> noArena = captureParagraph(w, false, styleWith(CssTextAlign::Justify), 1, 0, true, 600,
-                                                             nullptr);
+  const std::vector<CapturedLine> noArena =
+      captureParagraph(w, false, styleWith(CssTextAlign::Justify), 1, 0, true, 600, nullptr);
   // 13 KB: handle array (~12 KB) fits, leaving ~1 KB for bytes -> interning
   // overflows after a few dozen words -> migrate.
   crosspoint::layout::LayoutArena arena = crosspoint::layout::LayoutArena::create(13 * 1024);
@@ -704,8 +703,7 @@ void test_pagebuilder_page_boundaries() {
   crosspoint::heap::clearLargestFreeBlockOverride();
   FootnotePlacer fp;
   int emitted = 0;
-  PageBuilder pb(
-      pbCfg(), fp, [&emitted](std::unique_ptr<Page>) { ++emitted; }, [](const std::string&, uint16_t) {});
+  PageBuilder pb(pbCfg(), fp, [&emitted](std::unique_ptr<Page>) { ++emitted; }, [](const std::string&, uint16_t) {});
   for (int i = 0; i < 45; ++i) {
     TEST_ASSERT_TRUE(ok(pb.addLine(makePageLine())));
   }
@@ -721,8 +719,7 @@ void test_pagebuilder_oom_probe_is_explicit() {
   using namespace crosspoint::page;
   FootnotePlacer fp;
   int emitted = 0;
-  PageBuilder pb(
-      pbCfg(), fp, [&emitted](std::unique_ptr<Page>) { ++emitted; }, [](const std::string&, uint16_t) {});
+  PageBuilder pb(pbCfg(), fp, [&emitted](std::unique_ptr<Page>) { ++emitted; }, [](const std::string&, uint16_t) {});
   crosspoint::heap::setLargestFreeBlockOverride(8);  // too small for the PageLine probe
   const PageStatus s = pb.addLine(makePageLine());
   crosspoint::heap::clearLargestFreeBlockOverride();
@@ -735,8 +732,7 @@ void test_pagebuilder_null_line_is_oom() {
   using namespace crosspoint::page;
   crosspoint::heap::clearLargestFreeBlockOverride();
   FootnotePlacer fp;
-  PageBuilder pb(
-      pbCfg(), fp, [](std::unique_ptr<Page>) {}, [](const std::string&, uint16_t) {});
+  PageBuilder pb(pbCfg(), fp, [](std::unique_ptr<Page>) {}, [](const std::string&, uint16_t) {});
   TEST_ASSERT_TRUE(pb.addLine(nullptr) == PageStatus::Oom);
 }
 
@@ -751,13 +747,12 @@ void test_pagebuilder_top_spacing_survives_fresh_page() {
   using namespace crosspoint::page;
   crosspoint::heap::clearLargestFreeBlockOverride();
   FootnotePlacer fp;
-  PageBuilder pb(
-      pbCfg(), fp, [](std::unique_ptr<Page>) {}, [](const std::string&, uint16_t) {});
+  PageBuilder pb(pbCfg(), fp, [](std::unique_ptr<Page>) {}, [](const std::string&, uint16_t) {});
   TEST_ASSERT_TRUE(ok(pb.ensureOpenPage()));
-  pb.advanceY(100);                              // paragraph top margin on a fresh page
+  pb.advanceY(100);  // paragraph top margin on a fresh page
   TEST_ASSERT_EQUAL_INT(100, pb.cursorY());
   TEST_ASSERT_TRUE(ok(pb.addLine(makePageLine())));  // baseLineHeight 40
-  TEST_ASSERT_EQUAL_INT(140, pb.cursorY());      // line landed at y=100, NOT reset to 0
+  TEST_ASSERT_EQUAL_INT(140, pb.cursorY());          // line landed at y=100, NOT reset to 0
 }
 
 // finish() must NOT emit a trailing empty page (e.g. left open by a final
@@ -767,9 +762,8 @@ void test_pagebuilder_finish_skips_empty_page() {
   crosspoint::heap::clearLargestFreeBlockOverride();
   FootnotePlacer fp;
   int emitted = 0;
-  PageBuilder pb(
-      pbCfg(), fp, [&emitted](std::unique_ptr<Page>) { ++emitted; }, [](const std::string&, uint16_t) {});
-  TEST_ASSERT_TRUE(ok(pb.ensureOpenPage()));     // open an empty page
+  PageBuilder pb(pbCfg(), fp, [&emitted](std::unique_ptr<Page>) { ++emitted; }, [](const std::string&, uint16_t) {});
+  TEST_ASSERT_TRUE(ok(pb.ensureOpenPage()));  // open an empty page
   pb.finish();
   TEST_ASSERT_EQUAL_UINT(0, pb.completedPageCount());
   TEST_ASSERT_EQUAL_INT(0, emitted);
@@ -788,7 +782,7 @@ void test_pagebuilder_trailing_anchors() {
   pb.queueAnchors({"a1"});
   TEST_ASSERT_TRUE(ok(pb.addLine(makePageLine())));  // a1 binds to page 0 as the line lands
   pb.queueAnchors({"a2"});
-  TEST_ASSERT_TRUE(ok(pb.bindTrailingAnchors()));    // a2 binds to the same non-empty page 0
+  TEST_ASSERT_TRUE(ok(pb.bindTrailingAnchors()));  // a2 binds to the same non-empty page 0
   TEST_ASSERT_EQUAL_UINT(2, binds.size());
   TEST_ASSERT_EQUAL_STRING("a1", binds[0].first.c_str());
   TEST_ASSERT_EQUAL_STRING("a2", binds[1].first.c_str());
@@ -799,7 +793,7 @@ void test_pagebuilder_trailing_anchors() {
       [&binds](const std::string& a, uint16_t p) { binds.emplace_back(a, p); });
   pb2.queueAnchors({"a3"});
   TEST_ASSERT_TRUE(ok(pb2.bindTrailingAnchors()));
-  TEST_ASSERT_EQUAL_UINT(2, binds.size());           // unchanged: a3 not bound
+  TEST_ASSERT_EQUAL_UINT(2, binds.size());  // unchanged: a3 not bound
 }
 
 // addImage page-breaks only when the current page is non-empty and the image
@@ -809,13 +803,12 @@ void test_pagebuilder_image_break() {
   crosspoint::heap::clearLargestFreeBlockOverride();
   FootnotePlacer fp;
   int emitted = 0;
-  PageBuilder pb(
-      pbCfg(), fp, [&emitted](std::unique_ptr<Page>) { ++emitted; }, [](const std::string&, uint16_t) {});
+  PageBuilder pb(pbCfg(), fp, [&emitted](std::unique_ptr<Page>) { ++emitted; }, [](const std::string&, uint16_t) {});
   auto img = std::make_shared<ImageBlock>("/x.bmp", 600, 100);
   for (int i = 0; i < 19; ++i) TEST_ASSERT_TRUE(ok(pb.addLine(makePageLine())));  // cursor 760/800
-  TEST_ASSERT_TRUE(ok(pb.addImage(img, 600, 100)));  // 760+100>800 + non-empty -> break
+  TEST_ASSERT_TRUE(ok(pb.addImage(img, 600, 100)));                               // 760+100>800 + non-empty -> break
   TEST_ASSERT_EQUAL_UINT(1, pb.completedPageCount());
-  TEST_ASSERT_EQUAL_INT(100, pb.cursorY());          // image at y=0 on the new page, cursor=100
+  TEST_ASSERT_EQUAL_INT(100, pb.cursorY());  // image at y=0 on the new page, cursor=100
 }
 
 int main(int, char**) {

--- a/test/test_reader_sim_zip/test_main.cpp
+++ b/test/test_reader_sim_zip/test_main.cpp
@@ -4,11 +4,10 @@
 // every chapter open inflates from the EPUB zip).
 //
 // Run via: pio test -e test_sim_zip -f test_reader_sim_zip
-#include <unity.h>
-
 #include <HalStorage.h>
 #include <Print.h>
 #include <ZipFile.h>
+#include <unity.h>
 
 #include <chrono>
 #include <cstdint>
@@ -90,8 +89,7 @@ void test_inflate_chapter_under_fragmentation() {
   SimHeap::disarm();
 
   char msg[128];
-  snprintf(msg, sizeof(msg), "INFLATE@frag(11764): bytes=%zu threw=%d wouldAbort=%u", bytes, threw ? 1 : 0,
-           wouldAbort);
+  snprintf(msg, sizeof(msg), "INFLATE@frag(11764): bytes=%zu threw=%d wouldAbort=%u", bytes, threw ? 1 : 0, wouldAbort);
   TEST_MESSAGE(msg);
 
   // Reaching here without the host process crashing is the minimum bar. The

--- a/test/test_sim_heap/test_main.cpp
+++ b/test/test_sim_heap/test_main.cpp
@@ -104,8 +104,8 @@ void test_armed_budget_exhaustion() {
 // Throwing new -> device abort (the crash). Nothrow new -> nullptr, the path
 // FontDecompressor takes (and the render-OOM guard then discards the frame).
 void test_reproduces_v301_render_oom_incident() {
-  constexpr size_t kUserLargestBlock = 11764;   // heap_report.txt "Largest 8-bit"
-  constexpr size_t kUserTotalHeap = 142824;     // heap_report.txt "Total heap"
+  constexpr size_t kUserLargestBlock = 11764;     // heap_report.txt "Largest 8-bit"
+  constexpr size_t kUserTotalHeap = 142824;       // heap_report.txt "Total heap"
   constexpr size_t kHotGroupRequest = 20 * 1024;  // representative glyph group
 
   // Throwing path = what an unguarded `new`/vector::resize does on-device.
@@ -126,9 +126,9 @@ void test_reproduces_v301_render_oom_incident() {
   const unsigned nn = SimHeap::nothrowNulls();
   SimHeap::disarm();
 
-  TEST_ASSERT_TRUE(threw);          // unguarded alloc WOULD crash the firmware
+  TEST_ASSERT_TRUE(threw);  // unguarded alloc WOULD crash the firmware
   TEST_ASSERT_EQUAL_UINT(1, wa);
-  TEST_ASSERT_NULL(survived);       // guarded alloc fails cleanly instead
+  TEST_ASSERT_NULL(survived);  // guarded alloc fails cleanly instead
   TEST_ASSERT_EQUAL_UINT(1, nn);
 }
 


### PR DESCRIPTION
## Summary

Pure formatting pass to clear the repo's accumulated **clang-format-21** drift. The CI `clang-format` job (pinned to clang-format-21 via `llvm.sh`) runs `bin/clang-format-fix` across the whole tree and gates on `git diff --exit-code`. The tree had drifted across **53 source/test files**, leaving that check — and the aggregate CI gate (`Test Status`) — red on `main` for many commits.

This was split out of the `HttpUploadSink` simplify PR (#172), whose own code is correctly formatted; #172's red `clang-format`/`Test Status` checks are this pre-existing drift, not anything that PR introduced.

## What this is

- Ran `bin/clang-format-fix` with **clang-format-21.1.2** (matching CI's pinned major version).
- **No behavior changes** — only comment alignment, include ordering, and statement reflowing that clang-format-21 normalizes.
- **Idempotent**: re-running `bin/clang-format-fix` afterward produces zero further changes, confirming the output is stable under the CI-pinned formatter.

## Verification

- `bin/clang-format-fix` re-run → no diff (stable).
- Diff is formatting-only across the 53 drifted files; no logic touched.

Reviewers: this is mechanical formatter output, best reviewed by confirming CI's `clang-format` check passes rather than reading line-by-line.

https://claude.ai/code/session_01PkCbK9arkFYXpkcCr9ASHY

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkCbK9arkFYXpkcCr9ASHY)_