### PR TITLE
refactor(sleep): make wallpaper rotation memory-safe and allocation-lean

### DIFF
--- a/src/sleep/SdFatSleepFs.cpp
+++ b/src/sleep/SdFatSleepFs.cpp
@@ -91,7 +91,7 @@ std::vector<std::string> SdFatSleepFs::listSleepBmps(size_t maxEntries) {
   return out;
 }
 
-void SdFatSleepFs::walkSleepBmps(const std::function<void(const std::string&, uint32_t)>& cb) {
+void SdFatSleepFs::walkSleepBmps(const std::function<void(const char*, size_t, uint32_t)>& cb) {
   auto dir = Storage.open(kSleepDir);
   if (!dir || !dir.isDirectory()) {
     if (dir) dir.close();
@@ -106,10 +106,10 @@ void SdFatSleepFs::walkSleepBmps(const std::function<void(const std::string&, ui
         uint16_t fdate = 0, ftime = 0;
         file.getModifyDateTime(&fdate, &ftime);
         const uint32_t mtime = (static_cast<uint32_t>(fdate) << 16) | ftime;
-        // Construct a small temporary string for the callback. Heap cost is
-        // one short alloc per file, freed before the next iteration. Caller
-        // decides what (if anything) to retain.
-        cb(std::string(name), mtime);
+        // Hand the callback the name straight off the stack buffer — zero heap
+        // per file. It is valid only for the duration of the call; the caller
+        // copies only the files it actually retains (typically 0-3 new ones).
+        cb(name, std::strlen(name), mtime);
       }
     }
     file.close();

--- a/src/sleep/SdFatSleepFs.h
+++ b/src/sleep/SdFatSleepFs.h
@@ -18,7 +18,7 @@ class SdFatSleepFs final : public ISleepFs {
   size_t countSleepBmps(size_t scanCap) override;
   std::vector<std::string> listSleepBmps(size_t maxEntries) override;
   std::vector<SleepBmpEntry> listSleepBmpsWithMtime(size_t maxEntries) override;
-  void walkSleepBmps(const std::function<void(const std::string&, uint32_t)>& cb) override;
+  void walkSleepBmps(const std::function<void(const char*, size_t, uint32_t)>& cb) override;
   std::string nextSleepBmpAfter(const std::string& after) override;
   std::string nthSleepBmp(size_t n) override;
   NextBmpResult nextSleepBmpAfterWithCount(const std::string& after, size_t scanCap) override;

--- a/src/sleep/SleepFs.h
+++ b/src/sleep/SleepFs.h
@@ -76,16 +76,21 @@ struct ISleepFs {
     return out;
   }
 
-  // V2 streaming walk: invoke `cb(name, mtime)` once per .bmp under /sleep, in
-  // SD iteration order. Caller decides what to retain — typically only NEW
+  // V2 streaming walk: invoke `cb(name, len, mtime)` once per .bmp under /sleep,
+  // in SD iteration order. Caller decides what to retain — typically only NEW
   // files vs. an existing buffer set, keeping peak heap proportional to the
   // delta (usually 0-3 entries) rather than the full /sleep listing.
   // Required for the boot/home-route reconcile path where materializing all
   // 500 entries as a vector trips bad_alloc on a fragmented heap.
-  // Default impl falls back to listSleepBmpsWithMtime so existing fakes link.
-  virtual void walkSleepBmps(const std::function<void(const std::string& /*name*/, uint32_t /*mtime*/)>& cb) {
+  //
+  // `name` points at storage owned by the callee for the duration of the call
+  // only (the SD impl hands the raw directory-entry buffer) — the callback must
+  // copy if it needs to retain it. Passing char*+len instead of std::string
+  // lets the production impl avoid one heap allocation per file. Default impl
+  // falls back to listSleepBmpsWithMtime so existing fakes link.
+  virtual void walkSleepBmps(const std::function<void(const char* /*name*/, size_t /*len*/, uint32_t /*mtime*/)>& cb) {
     auto entries = listSleepBmpsWithMtime(1024);
-    for (const auto& e : entries) cb(e.name, e.mtime);
+    for (const auto& e : entries) cb(e.name.c_str(), e.name.size(), e.mtime);
   }
 
   // Generic storage ops used during trim / rename bookkeeping.

--- a/src/sleep/WallpaperPlaylistV2.cpp
+++ b/src/sleep/WallpaperPlaylistV2.cpp
@@ -3,8 +3,6 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
-#include <unordered_map>
-#include <unordered_set>
 
 namespace crosspoint {
 namespace sleep {
@@ -14,7 +12,6 @@ namespace {
 
 constexpr const char* kSleepDir = "/sleep";
 constexpr const char* kSleepPauseDir = "/sleep pause";
-constexpr size_t kHeaderMaxLen = 32;
 
 // Headroom over the requested allocation when probing the heap. Covers the
 // transient std::string growth peak (capacity often rounded up to the next
@@ -33,28 +30,21 @@ std::string makePausePath(const std::string& filename) {
   return std::string(kSleepPauseDir) + "/" + filename;
 }
 
-// Format: "v1 cursor=N\n<name1>\n<name2>\n..."
-std::string serializeOrderFile(const std::string& namesRegion, size_t cursor) {
-  char header[kHeaderMaxLen];
-  const int n = std::snprintf(header, sizeof(header), "v1 cursor=%zu\n", cursor);
-  std::string out;
-  out.reserve(static_cast<size_t>(n) + namesRegion.size());
-  out.append(header, static_cast<size_t>(n));
-  out.append(namesRegion);
-  return out;
-}
-
-bool parseOrderFile(const std::string& blob, std::string& namesRegion, size_t& cursor) {
+// Parse the "v1 cursor=N\n" header in place. On success, `namesStart` is the
+// byte offset where the names region begins (one past the header newline) and
+// `cursor` holds the parsed value. The caller strips the header by erasing
+// [0, namesStart) and moving the blob straight into buffer_ — no second
+// full-size copy of the names region (the old substr path doubled peak heap).
+bool parseOrderHeader(const std::string& blob, size_t& namesStart, size_t& cursor) {
   cursor = 0;
-  namesRegion.clear();
+  namesStart = 0;
   if (blob.size() < 3 || blob.compare(0, 3, "v1 ") != 0) return false;
   const auto firstNewline = blob.find('\n');
   if (firstNewline == std::string::npos) return false;
-  const std::string header = blob.substr(0, firstNewline);
-  const auto eq = header.find("cursor=");
-  if (eq == std::string::npos) return false;
-  cursor = static_cast<size_t>(std::strtoul(header.c_str() + eq + 7, nullptr, 10));
-  namesRegion = blob.substr(firstNewline + 1);
+  const auto eq = blob.find("cursor=");
+  if (eq == std::string::npos || eq >= firstNewline) return false;
+  cursor = static_cast<size_t>(std::strtoul(blob.c_str() + eq + 7, nullptr, 10));
+  namesStart = firstNewline + 1;
   return true;
 }
 
@@ -97,31 +87,34 @@ bool WallpaperPlaylistV2::ensureLoaded() {
 
 bool WallpaperPlaylistV2::loadFromDisk() {
   if (!deps_.fileIO) return false;
-  const std::string blob = deps_.fileIO->safeRead(deps_.orderFilePath);
+  std::string blob = deps_.fileIO->safeRead(deps_.orderFilePath);
   if (blob.empty()) {
     buffer_.clear();
     cursor_ = 0;
     return false;
   }
-  std::string names;
+  size_t namesStart = 0;
   size_t cursor = 0;
-  if (!parseOrderFile(blob, names, cursor)) {
+  if (!parseOrderHeader(blob, namesStart, cursor)) {
     buffer_.clear();
     cursor_ = 0;
     return false;
   }
-  buffer_ = std::move(names);
+  // Strip the header in place (memmove, no allocation) and take ownership of
+  // the buffer — peak heap is one blob, not blob + a substr copy.
+  blob.erase(0, namesStart);
+  buffer_ = std::move(blob);
   cursor_ = cursor;
   return true;
 }
 
 bool WallpaperPlaylistV2::saveToDisk() const {
   if (!deps_.fileIO) return false;
-  // Stream the write so peak heap is bounded — serializeOrderFile would
-  // concatenate header + buffer_ into a fresh std::string of full size,
-  // which doubles transient memory pressure right when reconcile already
-  // holds two buffer copies. safeWriteStreamed hands us a JsonSink-like
-  // byte sink wired straight to the .tmp file; no intermediate copy.
+  // Stream the write so peak heap is bounded — concatenating header + buffer_
+  // into a fresh full-size std::string would double transient memory pressure
+  // right when reconcile already holds two buffer copies. safeWriteStreamed
+  // hands us a JsonSink-like byte sink wired straight to the .tmp file; no
+  // intermediate copy.
   return deps_.fileIO->safeWriteStreamed(deps_.orderFilePath, [this](crosspoint::persist::JsonSink& sink) {
     char header[32];
     const int hn = std::snprintf(header, sizeof(header), "v1 cursor=%zu\n", cursor_);
@@ -156,19 +149,6 @@ void WallpaperPlaylistV2::writeBuffer(const std::vector<std::string>& names, siz
   saveToDisk();
 }
 
-std::vector<std::string> WallpaperPlaylistV2::bufferEntries() const {
-  std::vector<std::string> out;
-  if (buffer_.empty()) return out;
-  size_t start = 0;
-  for (size_t i = 0; i < buffer_.size(); ++i) {
-    if (buffer_[i] == '\n') {
-      if (i > start) out.emplace_back(buffer_.data() + start, i - start);
-      start = i + 1;
-    }
-  }
-  return out;
-}
-
 size_t WallpaperPlaylistV2::entryCountForTest() const {
   size_t n = 0;
   for (char c : buffer_) {
@@ -198,67 +178,70 @@ uint16_t WallpaperPlaylistV2::trimToCap(std::vector<SleepBmpEntry>& entries, boo
   favoritesCapBlocked = false;
   if (entries.size() <= kSleepFolderCap) return 0;
 
-  // Bug A (RFC #156): trim partitions `entries` into up to three transient
-  // vectors (nonFav + favs + surviving), whose backbones peak at ~3x the entry
-  // vector. Production reconcile already runs under the sleep-playlist heap
-  // gate, but probe here too so the module is self-safe if a future caller
-  // invokes it ungated — a bad_alloc would abort the -fno-exceptions build.
-  // Bail (no trim this cycle) when the heap is too tight; the next reconcile
-  // retries once it recovers, and the over-cap files simply wait in /sleep.
-  const size_t transientPeak = entries.size() * sizeof(SleepBmpEntry) * 3;
-  if (!heapHasContiguous(transientPeak)) {
+  // RFC #156 Bug A: the old trim partitioned `entries` into three transient
+  // vectors (nonFav + favs + surviving), peaking at ~3x the entry vector — the
+  // largest sleep-path allocation and the one most likely to bail on (or, if
+  // ever called ungated, abort) a fragmented heap. This rewrite works in place
+  // on the single `entries` vector, so peak is ~1x. Production reconcile still
+  // runs under the sleep-playlist heap gate; we keep a self-safety probe (now
+  // sized to that single vector) so an ungated future caller still bails rather
+  // than risk a bad_alloc under -fno-exceptions. Bail = no trim this cycle; the
+  // next reconcile retries once heap recovers and the over-cap files wait in
+  // /sleep meanwhile.
+  if (!heapHasContiguous(entries.size() * sizeof(SleepBmpEntry))) {
     return 0;
   }
 
-  std::vector<SleepBmpEntry> nonFav;
-  nonFav.reserve(entries.size());
-  std::vector<SleepBmpEntry> favs;
-  favs.reserve(entries.size());
-  for (auto& e : entries) {
-    const bool fav = deps_.isFavorite && deps_.isFavorite(makeSleepPath(e.name));
-    if (fav)
-      favs.push_back(std::move(e));
-    else
-      nonFav.push_back(std::move(e));
-  }
+  // Partition non-favorites to the front (favorites are never moved). isFavorite
+  // is evaluated once per entry. std::partition is in place — no temp vector;
+  // relative order is not relied upon (the favorites-saturated branch demotes
+  // every non-favorite regardless of order, and the normal branch re-sorts the
+  // non-favorite prefix by mtime below).
+  const auto firstFav = std::partition(entries.begin(), entries.end(), [this](const SleepBmpEntry& e) {
+    return !(deps_.isFavorite && deps_.isFavorite(makeSleepPath(e.name)));
+  });
+  const size_t nonFavCount = static_cast<size_t>(firstFav - entries.begin());
+  const size_t favCount = entries.size() - nonFavCount;
 
-  const size_t excess = entries.size() - kSleepFolderCap;
-  if (favs.size() >= kSleepFolderCap) {
+  if (deps_.fs) deps_.fs->mkdir(kSleepPauseDir);
+
+  // Favorites alone fill the cap: demote every non-favorite (e.g. a fresh
+  // upload that has nowhere to go) and keep only the favorites.
+  if (favCount >= kSleepFolderCap) {
     favoritesCapBlocked = true;
-    if (deps_.fs) deps_.fs->mkdir(kSleepPauseDir);
     uint16_t moved = 0;
-    for (const auto& e : nonFav) {
-      const std::string from = makeSleepPath(e.name);
-      const std::string to = makePausePath(e.name);
+    for (size_t i = 0; i < nonFavCount; ++i) {
+      const std::string from = makeSleepPath(entries[i].name);
+      const std::string to = makePausePath(entries[i].name);
       if (deps_.fs && deps_.fs->rename(from, to)) {
         if (deps_.onPathRenamed) deps_.onPathRenamed(from, to);
         ++moved;
       }
     }
-    entries = std::move(favs);
+    entries.erase(entries.begin(), entries.begin() + nonFavCount);
     return moved;
   }
 
-  std::sort(nonFav.begin(), nonFav.end(),
+  // Normal branch: demote the oldest-by-mtime non-favorites. Sort only the
+  // non-favorite prefix [0, nonFavCount) ascending; favorites in the tail stay
+  // put. Renames happen oldest-first, matching the previous behaviour.
+  std::sort(entries.begin(), entries.begin() + nonFavCount,
             [](const SleepBmpEntry& a, const SleepBmpEntry& b) { return a.mtime < b.mtime; });
-
-  if (deps_.fs) deps_.fs->mkdir(kSleepPauseDir);
+  const size_t excess = entries.size() - kSleepFolderCap;
+  const size_t toMove = std::min(excess, nonFavCount);
   uint16_t moved = 0;
-  size_t toMove = std::min(excess, nonFav.size());
   for (size_t i = 0; i < toMove; ++i) {
-    const std::string from = makeSleepPath(nonFav[i].name);
-    const std::string to = makePausePath(nonFav[i].name);
+    const std::string from = makeSleepPath(entries[i].name);
+    const std::string to = makePausePath(entries[i].name);
     if (deps_.fs && deps_.fs->rename(from, to)) {
       if (deps_.onPathRenamed) deps_.onPathRenamed(from, to);
       ++moved;
     }
   }
-
-  std::vector<SleepBmpEntry> surviving;
-  surviving.reserve(favs.size() + nonFav.size() - toMove);
-  for (auto& e : favs) surviving.push_back(std::move(e));
-  for (size_t i = toMove; i < nonFav.size(); ++i) surviving.push_back(std::move(nonFav[i]));
-  entries = std::move(surviving);
+  // Drop the moved entries; favorites + surviving non-favorites remain. Order of
+  // the survivors is irrelevant — the caller re-derives newFiles from this set
+  // and re-sorts before splicing.
+  entries.erase(entries.begin(), entries.begin() + toMove);
   return moved;
 }
 
@@ -272,19 +255,27 @@ bool WallpaperPlaylistV2::heapHasContiguous(size_t needBytes) const {
   return deps_.largestFreeBlockFn() >= needBytes + kAllocProbeHeadroomBytes;
 }
 
+bool WallpaperPlaylistV2::nameIsInBuffer(const char* name, size_t len) const {
+  if (buffer_.empty() || !name || len == 0) return false;
+  // Walk the '\n'-delimited names in buffer_ and compare each whole line to
+  // `name`. No temporary needle string — the old path allocated a "\nname\n"
+  // needle on every call (~500-1000x per over-cap reconcile). Comparing whole
+  // lines (bounded by the separators) means prefix collisions like "a.bmp" vs
+  // "ab.bmp" can never false-match.
+  const char* data = buffer_.data();
+  const size_t bsize = buffer_.size();
+  size_t start = 0;
+  while (start < bsize) {
+    size_t nl = buffer_.find('\n', start);
+    if (nl == std::string::npos) nl = bsize;  // tolerate a missing final '\n'
+    if (nl - start == len && std::memcmp(data + start, name, len) == 0) return true;
+    start = nl + 1;
+  }
+  return false;
+}
+
 bool WallpaperPlaylistV2::nameIsInBuffer(const std::string& name) const {
-  if (buffer_.empty() || name.empty()) return false;
-  // Match "name\n" at position 0, or "\nname\n" anywhere. \n separators bound
-  // the search so prefix-collisions are not misreported (e.g. "a.bmp" vs "ab.bmp").
-  const size_t nlen = name.size();
-  if (buffer_.size() > nlen && buffer_.compare(0, nlen, name) == 0 && buffer_[nlen] == '\n') return true;
-  // Search for "\nname\n" — caller-side concat into a temporary needle.
-  std::string needle;
-  needle.reserve(nlen + 2);
-  needle.push_back('\n');
-  needle.append(name);
-  needle.push_back('\n');
-  return buffer_.find(needle) != std::string::npos;
+  return nameIsInBuffer(name.data(), name.size());
 }
 
 void WallpaperPlaylistV2::reconcile() {
@@ -305,12 +296,16 @@ void WallpaperPlaylistV2::reconcile() {
   std::vector<SleepBmpEntry> newFiles;
   newFiles.reserve(8);  // typical delta upper bound; grows if exceeded
   size_t diskCount = 0;
-  size_t favCount = 0;
 
-  deps_.fs->walkSleepBmps([&](const std::string& name, uint32_t mtime) {
+  // Zero-allocation walk: the callback receives the name straight off the SD
+  // layer's stack buffer (no per-file std::string), and nameIsInBuffer scans
+  // buffer_ in place. Only genuinely new files (typically 0-3) materialize a
+  // string. The former per-file favorite probe here was dead (its count was
+  // never read) and cost a makeSleepPath allocation + isFavorite call on every
+  // one of the ~500 files — removed.
+  deps_.fs->walkSleepBmps([&](const char* name, size_t len, uint32_t mtime) {
     ++diskCount;
-    if (deps_.isFavorite && deps_.isFavorite(makeSleepPath(name))) ++favCount;
-    if (!nameIsInBuffer(name)) newFiles.push_back({name, mtime});
+    if (!nameIsInBuffer(name, len)) newFiles.push_back({std::string(name, len), mtime});
   });
 
   // Trim path. Only enters here if /sleep is over the cap — gates the heavy

--- a/src/sleep/WallpaperPlaylistV2.h
+++ b/src/sleep/WallpaperPlaylistV2.h
@@ -118,14 +118,16 @@ class WallpaperPlaylistV2 {
   bool rebuildSequential();
   bool saveToDisk() const;
   void writeBuffer(const std::vector<std::string>& names, size_t cursor);
-  std::vector<std::string> bufferEntries() const;
   std::string peekAtCursor() const;
   void advanceCursor();
   uint16_t trimToCap(std::vector<SleepBmpEntry>& entries, bool& favoritesCapBlocked);
 
-  // Heap-cheap membership check via direct substring scan of buffer_. Avoids
-  // building the (~500-element) hash_set that materializing bufferEntries()
-  // would require. O(name + buffer_size) per query.
+  // Heap-cheap membership check: walk the '\n'-delimited names in buffer_ and
+  // compare each line to `name` in place — zero allocation, no temporary needle
+  // or materialized name set. O(buffer_size) per query. The char* overload lets
+  // the reconcile walk query straight off the SD layer's stack buffer; the
+  // std::string overload forwards to it.
+  bool nameIsInBuffer(const char* name, size_t len) const;
   bool nameIsInBuffer(const std::string& name) const;
 
   // Probe the heap for a contiguous block large enough for `needBytes`

--- a/test/test_wallpaper_playlist_v2/test_main.cpp
+++ b/test/test_wallpaper_playlist_v2/test_main.cpp
@@ -378,6 +378,37 @@ void test_healthy_heap_allows_reshuffle_and_advance_returns_name() {
   TEST_ASSERT_FALSE(wp.bufferForTest().empty());
 }
 
+// The zero-allocation membership scan matches whole '\n'-delimited names, so a
+// name that is a prefix (or superstring) of one already in the buffer must not
+// false-match. Here "ab.bmp" is buffered first; adding "a.bmp" (a prefix) must
+// be detected as NEW and spliced on top, while "ab.bmp" must NOT be re-added.
+void test_membership_scan_handles_prefix_collisions() {
+  Fixture fx;
+  fx.fs.seed("ab.bmp", 100);
+  auto& wp = crosspoint::sleep::v2::WallpaperPlaylistV2::instance();
+  wp.resetForTest();
+  fx.wire(wp);
+  wp.markFolderDirty();
+  wp.reconcile();  // buffer = "ab.bmp\n"
+
+  fx.fs.seed("a.bmp", 200);  // prefix of ab.bmp, newer mtime
+  wp.markFolderDirty();
+  wp.reconcile();
+
+  // a.bmp (newest) spliced to the front → shown next; not dropped as a false
+  // prefix match.
+  const auto first = wp.advance();
+  TEST_ASSERT_EQUAL_STRING("a.bmp", first.c_str());
+
+  // A full lap shows exactly the two distinct files — ab.bmp was not duplicated
+  // by a missed membership hit, and neither was dropped.
+  std::unordered_set<std::string> seen;
+  seen.insert(first);
+  seen.insert(wp.advance());
+  TEST_ASSERT_EQUAL(2u, seen.size());
+  TEST_ASSERT_TRUE(seen.count("a.bmp") == 1 && seen.count("ab.bmp") == 1);
+}
+
 void test_unset_heap_probe_treats_heap_as_unlimited() {
   // Mirrors pre-C2 host behaviour: with no probe wired, the playlist must
   // not gate any reserve — every existing test in this file relies on this
@@ -411,6 +442,7 @@ int main(int, char**) {
   RUN_TEST(test_reshuffle_does_not_repeat_just_shown_wallpaper);
   RUN_TEST(test_fragmented_heap_blocks_initial_reshuffle_buffer_stays_empty);
   RUN_TEST(test_healthy_heap_allows_reshuffle_and_advance_returns_name);
+  RUN_TEST(test_membership_scan_handles_prefix_collisions);
   RUN_TEST(test_unset_heap_probe_treats_heap_as_unlimited);
   return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Behavior-preserving memory hardening of the V2 wallpaper rotation (`WallpaperPlaylistV2`) and its SD filesystem layer (`ISleepFs` / `SdFatSleepFs`). **The rotation logic is unchanged** — sequential array order, new uploads spliced on top (newest mtime first), user-only reshuffle, 500-cap trim to `/sleep pause`, favorites protected. The goal was to remove every avoidable allocation on the sleep path and shrink the worst-case heap peak so a fragmented C3 heap can't trip it.

## Changes (all internal; no semantic change)

| # | Change | Before → after |
|---|--------|----------------|
| 1 | **Zero-alloc membership check** (`nameIsInBuffer`) | Allocated a `"\nname\n"` needle **per call** (~500–1000× per over-cap reconcile) → in-place whole-line scan, **0 allocs**. Whole-line compare keeps prefix collisions (`a.bmp` vs `ab.bmp`) from false-matching. |
| 2 | **In-place `trimToCap`** | Three transient `vector<SleepBmpEntry>` (~**3×** peak, the largest sleep-path allocation) → `partition` + `sort` + `erase` in place (~**1×**). Self-safety heap probe resized to match, so it now succeeds where it used to bail. Same files moved, same rename order, same `Notice`. |
| 3 | **Dead per-file work removed** from `reconcile` | A favorite count was computed (a `makeSleepPath` alloc + `isFavorite` call on every one of ~500 files) but **never read**. Removed. |
| 4 | **Allocation-free directory walk** | `ISleepFs::walkSleepBmps` now passes `(const char* name, size_t len, uint32_t mtime)` instead of `std::string`, so `SdFatSleepFs` no longer builds a `std::string` per file. Only genuinely new files (typically 0–3) materialize a string. |
| 5 | **Move-based order-file load** | `parseOrderFile` did a `substr()` copy of the whole names region before the move (~**2×** peak) → header stripped in place, blob **moved** into `buffer_` (~**1×**). |
| 6 | **Dead code deleted** | `serializeOrderFile()`, `bufferEntries()`, `kHeaderMaxLen`, two unused `<unordered_*>` includes. |

Net effect: a normal over-cap reconcile drops from ~1000+ small allocations to a handful, and the worst-case contiguous-block requirement drops from ~3× to ~1× the entry vector.

## Validation

PlatformIO isn't available in the CI-web sandbox, so I built the host tests directly with `g++ -std=c++17 -fno-exceptions -DUNIT_TEST_HOST -Wall -Wextra` against a minimal Unity shim:

- `test_wallpaper_playlist_v2`: **14/14** (added `test_membership_scan_handles_prefix_collisions` for the new scan).
- `test_memory_harness`: **6/6** (includes the fragmentation fuzz test).
- clang-format-21 clean on all changed files.

The `SdFatSleepFs.cpp` change (HalStorage-dependent) is covered by the firmware `build` job in CI.

## Out of scope

Rotation/order semantics, splice-on-top, shuffle, cap, favorites, and the persistence format are untouched. V1 removal (`nextSleepBmpAfter` et al.) remains a separate follow-up the code already flags.

https://claude.ai/code/session_01PkCbK9arkFYXpkcCr9ASHY

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkCbK9arkFYXpkcCr9ASHY)_