### PR TITLE
fix(sleep): keep strict wallpaper order on low-heap fallback

### DIFF
--- a/docs/wallpapers.md
+++ b/docs/wallpapers.md
@@ -77,18 +77,25 @@ The X4 firmware does **not** present as a USB drive — only a USB serial port. 
 
 ## Playlist behavior
 
-The playlist cap is **200 entries**.
+The playlist cap is **500 entries**.
 
-**Up to 200 images:**
-- A persisted playlist lives in memory and on SD.
-- Default order is stable and filename-based.
-- **Randomize Sleep Images** reshuffles the playlist.
-- New images added to `/sleep` are pushed near the front so they appear quickly.
+- A persisted order lives on SD (`/.crosspoint/sleep_order.txt`) and is rebuilt
+  in memory when the heap can afford it.
+- Default order is **newest first** — files are sorted by modification time
+  descending, so the most recently added wallpaper is on top.
+- New images added to `/sleep` are spliced at the **front** of the order and
+  the rotation resets to them, so a fresh upload is the next wallpaper shown.
+- On reaching the end of the list the rotation replays the same order from the
+  top — it never auto-shuffles. Only **Randomize Sleep Images** reshuffles.
 
-**More than 200 images:**
-- The firmware avoids storing the full playlist (ESP32-C3 RAM is tight).
-- **Randomize Sleep Images** picks a random starting file.
-- After that, the device advances sequentially through sorted filenames.
+### Ordering under memory pressure
+
+When the ESP32-C3 heap is too fragmented to materialize the full order list,
+the firmware falls back to a streaming, O(1)-heap pick. That fallback still
+follows the **same strict newest-first order**, continuing from the
+last-shown wallpaper — it does not jump to a random file. New uploads (newest
+modification time) still lead each lap. So the rotation order is honored
+whether or not the heap is under pressure.
 
 ## Favorites
 

--- a/src/sleep/SdFatSleepFs.cpp
+++ b/src/sleep/SdFatSleepFs.cpp
@@ -271,6 +271,98 @@ std::string SdFatSleepFs::nthSleepBmp(size_t n) {
   return result;
 }
 
+std::string SdFatSleepFs::nextSleepBmpByMtimeDesc(const std::string& afterName) {
+  auto dir = Storage.open(kSleepDir);
+  if (!dir || !dir.isDirectory()) {
+    if (dir) dir.close();
+    return "";
+  }
+
+  // Position in the rotation order: lower index == shown earlier. Newest mtime
+  // leads; equal mtimes order by name ascending so the sequence is total and
+  // deterministic (batch imports share an mtime). `seqLess(a, b)` is true when
+  // a comes BEFORE b.
+  auto seqLess = [](uint32_t am, const char* an, uint32_t bm, const char* bn) -> bool {
+    if (am != bm) return am > bm;
+    return std::strcmp(an, bn) < 0;
+  };
+
+  // Pass 1: locate the front of the order (for wrap) and the mtime of the
+  // last-shown file, if it is still present. O(1) heap — only two bounded
+  // basenames are retained.
+  bool firstFound = false;
+  uint32_t firstMtime = 0;
+  std::string firstName;
+  bool afterFound = false;
+  uint32_t afterMtime = 0;
+  size_t iter = 0;
+  char name[256];
+  for (auto file = dir.openNextFile(); file; file = dir.openNextFile()) {
+    if (!file.isDirectory()) {
+      file.getName(name, sizeof(name));
+      if (isBmpName(name)) {
+        uint16_t fdate = 0, ftime = 0;
+        file.getModifyDateTime(&fdate, &ftime);
+        const uint32_t mtime = (static_cast<uint32_t>(fdate) << 16) | ftime;
+        if (!firstFound || seqLess(mtime, name, firstMtime, firstName.c_str())) {
+          firstFound = true;
+          firstMtime = mtime;
+          firstName = name;
+        }
+        if (!afterName.empty() && afterName == name) {
+          afterFound = true;
+          afterMtime = mtime;
+        }
+      }
+    }
+    file.close();
+    if (++iter % kWdtResetInterval == 0) {
+      esp_task_wdt_reset();
+      yield();
+    }
+  }
+
+  if (!firstFound) {
+    dir.close();
+    return "";  // /sleep has no wallpapers
+  }
+  if (!afterFound) {
+    dir.close();
+    return firstName;  // fresh start or last-shown deleted → lead with newest
+  }
+
+  // Pass 2: find the entry immediately after the last-shown one — the earliest
+  // entry that still sorts strictly after it. Wraps to the front at lap end.
+  dir.rewindDirectory();
+  bool succFound = false;
+  uint32_t succMtime = 0;
+  std::string succName;
+  iter = 0;
+  for (auto file = dir.openNextFile(); file; file = dir.openNextFile()) {
+    if (!file.isDirectory()) {
+      file.getName(name, sizeof(name));
+      if (isBmpName(name)) {
+        uint16_t fdate = 0, ftime = 0;
+        file.getModifyDateTime(&fdate, &ftime);
+        const uint32_t mtime = (static_cast<uint32_t>(fdate) << 16) | ftime;
+        if (seqLess(afterMtime, afterName.c_str(), mtime, name) &&
+            (!succFound || seqLess(mtime, name, succMtime, succName.c_str()))) {
+          succFound = true;
+          succMtime = mtime;
+          succName = name;
+        }
+      }
+    }
+    file.close();
+    if (++iter % kWdtResetInterval == 0) {
+      esp_task_wdt_reset();
+      yield();
+    }
+  }
+  dir.close();
+  return succFound ? succName : firstName;
+}
+
 bool SdFatSleepFs::exists(const std::string& path) { return Storage.exists(path.c_str()); }
 
 bool SdFatSleepFs::mkdir(const std::string& path) { return Storage.mkdir(path.c_str()); }

--- a/src/sleep/SdFatSleepFs.h
+++ b/src/sleep/SdFatSleepFs.h
@@ -21,6 +21,7 @@ class SdFatSleepFs final : public ISleepFs {
   void walkSleepBmps(const std::function<void(const char*, size_t, uint32_t)>& cb) override;
   std::string nextSleepBmpAfter(const std::string& after) override;
   std::string nthSleepBmp(size_t n) override;
+  std::string nextSleepBmpByMtimeDesc(const std::string& afterName) override;
   NextBmpResult nextSleepBmpAfterWithCount(const std::string& after, size_t scanCap) override;
   bool exists(const std::string& path) override;
   bool mkdir(const std::string& path) override;

--- a/src/sleep/SleepFs.h
+++ b/src/sleep/SleepFs.h
@@ -8,6 +8,7 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -53,6 +54,36 @@ struct ISleepFs {
   // O(n) time, O(1) heap. Order follows the SD iteration order (not sorted).
   // Returns empty if n >= total count.
   virtual std::string nthSleepBmp(size_t n) = 0;
+
+  // Streaming successor in the V2 canonical rotation order: mtime DESCENDING
+  // (newest first), then name ascending as a deterministic tiebreak — the exact
+  // order the buffer-backed playlist materializes. Returns the basename that
+  // comes immediately after `afterName` in that order, wrapping to the FRONT
+  // (newest) when `afterName` is the last entry, is empty, or is not present.
+  // Empty only when /sleep has no wallpapers.
+  //
+  // This lets the low-heap direct-pick fallback follow the STRICT rotation
+  // order — a freshly uploaded wallpaper (newest mtime) leads each lap, matching
+  // the "new wallpapers on top" semantics — instead of jumping to a random file
+  // whenever heap pressure forces the fallback. The default impl materializes
+  // the listing (fine for host tests); SdFatSleepFs overrides with an O(1)-heap
+  // streaming scan so the device never allocates the full listing on the very
+  // path the fallback exists to keep heap-cheap.
+  virtual std::string nextSleepBmpByMtimeDesc(const std::string& afterName) {
+    auto entries = listSleepBmpsWithMtime(1024);
+    if (entries.empty()) return {};
+    std::sort(entries.begin(), entries.end(), [](const SleepBmpEntry& a, const SleepBmpEntry& b) {
+      if (a.mtime != b.mtime) return a.mtime > b.mtime;
+      return a.name < b.name;
+    });
+    if (afterName.empty()) return entries.front().name;
+    for (size_t i = 0; i < entries.size(); ++i) {
+      if (entries[i].name == afterName) {
+        return (i + 1 < entries.size()) ? entries[i + 1].name : entries.front().name;
+      }
+    }
+    return entries.front().name;
+  }
 
   // Combined count + lex-next in a single directory scan. Large strategy
   // steady state needs both (count for hysteresis, next for advance) —

--- a/src/sleep/Wallpaper.cpp
+++ b/src/sleep/Wallpaper.cpp
@@ -156,28 +156,23 @@ bool sequentialPlaylistAffordable() {
          crosspoint::mem::totalFreeBytes() >= totalNeed;
 }
 
-// Streaming fragment-safe pick — direct mirror of SleepActivity's
-// pickSleepFileDirect helper. Touches O(1) heap beyond the returned
-// basename. Empty if /sleep is empty or fs not wired.
-std::string pickDirectBasename() {
+// Streaming fragment-safe pick that still honors the rotation ORDER. Touches
+// O(1) heap beyond the returned basename. Empty if /sleep is empty or fs not
+// wired.
+//
+// Returns the wallpaper immediately after `after` in the V2 canonical order
+// (newest mtime first, then name), i.e. the same strict sequence the
+// buffer-backed playlist walks. A new upload (newest mtime) leads each lap, so
+// "new wallpapers on top" holds even here. This replaces the former RANDOM
+// last-resort pick, which abandoned the rotation order whenever heap pressure
+// forced this fallback — the "wallpapers stop following their order under
+// memory pressure" report. Anti-repeat is inherent: the successor is strictly
+// past `after` (or wraps to the newest, which differs from `after` unless
+// /sleep holds a single file).
+std::string pickDirectBasename(const std::string& after) {
   auto* sfs = v2::WallpaperPlaylistV2::instance().deps().fs;
   if (!sfs) return {};
-  const size_t count = sfs->countSleepBmps(kSleepFolderCap);
-  if (count == 0) return {};
-  // Anti-repeat: this random last-resort has no playlist cursor, so a naive
-  // single roll can return the wallpaper we just showed (a 1/N chance —
-  // glaring on small libraries). Re-roll a few times to avoid the last-shown
-  // basename. With >1 file this converges almost immediately; with exactly
-  // one file we accept it (nothing else to show). lastShownSleepFilename and
-  // nthSleepBmp both deal in basenames, so the comparison is apples-to-apples.
-  const std::string& lastShown = APP_STATE.lastShownSleepFilename;
-  std::string pick;
-  for (int tries = 0; tries < 5; ++tries) {
-    const size_t idx = static_cast<size_t>(::random(static_cast<long>(count)));
-    pick = sfs->nthSleepBmp(idx);
-    if (count <= 1 || pick.empty() || pick != lastShown) break;
-  }
-  return pick;
+  return sfs->nextSleepBmpByMtimeDesc(after);
 }
 
 SleepPick makePickFromBasename(const std::string& basename) {
@@ -222,18 +217,31 @@ SleepPick nextSleepFile(const RenderProbe& probe) {
   // entry at a time and never builds a list, so it is safe at any folder size.
   const bool useDirectPick = !sequentialPlaylistAffordable();
 
+  // Cursor for the ordered direct pick. Seeded with the last-shown wallpaper so
+  // the fallback continues the strict rotation from wherever the buffer-backed
+  // playlist left off, and advanced on every pick so a candidate the probe
+  // rejects is skipped forward in order (mirrors the buffer path's
+  // advanceCursor-on-failure) instead of being re-offered each retry.
+  std::string directCursor = APP_STATE.lastShownSleepFilename;
+  auto orderedDirectPick = [&]() -> std::string {
+    std::string n = pickDirectBasename(directCursor);
+    if (!n.empty()) directCursor = n;
+    return n;
+  };
+
   for (int attempt = 0; attempt < kNextSleepFileRetries; ++attempt) {
     std::string basename;
     if (useDirectPick) {
-      basename = pickDirectBasename();
+      basename = orderedDirectPick();
     } else {
       // Buffer-backed playlist advance via the facade entry point, so the
       // RFC #145 reconcile notice is drained + persisted here too (a direct
       // v2 advance would skip applyReconcileNotice). advance() can still bail to
-      // empty under its internal heap probes — fall through to the direct pick.
+      // empty under its internal heap probes — fall through to the ordered
+      // direct pick, which keeps the rotation order rather than jumping randomly.
       basename = advance();
       if (basename.empty()) {
-        basename = pickDirectBasename();
+        basename = orderedDirectPick();
       }
     }
     if (basename.empty()) {

--- a/test/test_wallpaper_playlist_v2/test_main.cpp
+++ b/test/test_wallpaper_playlist_v2/test_main.cpp
@@ -508,6 +508,64 @@ void test_trim_branch_rederive_capped_per_pass() {
   TEST_ASSERT_EQUAL(501u, wp.entryCountForTest());
 }
 
+// The low-heap direct-pick fallback (Wallpaper.cpp pickDirectBasename) follows
+// nextSleepBmpByMtimeDesc, which must reproduce the buffer's canonical order
+// STRICTLY: newest mtime first, deterministic, never random. Exercises the
+// ISleepFs contract that backs that fallback.
+void test_direct_order_successor_follows_mtime_desc_strictly() {
+  FakeSleepFs fs;
+  fs.seed("a.bmp", 100);
+  fs.seed("b.bmp", 300);
+  fs.seed("c.bmp", 200);
+  // Canonical order newest-first: b(300) → c(200) → a(100).
+  TEST_ASSERT_EQUAL_STRING("b.bmp", fs.nextSleepBmpByMtimeDesc("").c_str());       // fresh start → newest
+  TEST_ASSERT_EQUAL_STRING("c.bmp", fs.nextSleepBmpByMtimeDesc("b.bmp").c_str());
+  TEST_ASSERT_EQUAL_STRING("a.bmp", fs.nextSleepBmpByMtimeDesc("c.bmp").c_str());
+  TEST_ASSERT_EQUAL_STRING("b.bmp", fs.nextSleepBmpByMtimeDesc("a.bmp").c_str());  // lap end wraps to newest
+  // A last-shown name no longer on disk wraps to the front — never a random jump.
+  TEST_ASSERT_EQUAL_STRING("b.bmp", fs.nextSleepBmpByMtimeDesc("ghost.bmp").c_str());
+}
+
+// "New wallpapers on top" must hold on the fallback path too: a fresh upload
+// (newest mtime) leads the order and re-leads each lap.
+void test_direct_order_new_upload_leads_each_lap() {
+  FakeSleepFs fs;
+  fs.seed("old1.bmp", 100);
+  fs.seed("old2.bmp", 110);
+  fs.seed("fresh.bmp", 999);  // newest upload
+  TEST_ASSERT_EQUAL_STRING("fresh.bmp", fs.nextSleepBmpByMtimeDesc("").c_str());
+  // After the oldest file (lap end), the order wraps back to the newest upload.
+  TEST_ASSERT_EQUAL_STRING("fresh.bmp", fs.nextSleepBmpByMtimeDesc("old1.bmp").c_str());
+}
+
+// Equal mtimes (e.g. a batch import) order by name ascending so the sequence is
+// total and reproducible — strict, not random.
+void test_direct_order_mtime_ties_break_by_name() {
+  FakeSleepFs fs;
+  fs.seed("b.bmp", 100);
+  fs.seed("a.bmp", 100);
+  fs.seed("c.bmp", 100);
+  TEST_ASSERT_EQUAL_STRING("a.bmp", fs.nextSleepBmpByMtimeDesc("").c_str());
+  TEST_ASSERT_EQUAL_STRING("b.bmp", fs.nextSleepBmpByMtimeDesc("a.bmp").c_str());
+  TEST_ASSERT_EQUAL_STRING("c.bmp", fs.nextSleepBmpByMtimeDesc("b.bmp").c_str());
+  TEST_ASSERT_EQUAL_STRING("a.bmp", fs.nextSleepBmpByMtimeDesc("c.bmp").c_str());  // wrap
+}
+
+void test_direct_order_empty_folder_returns_empty() {
+  FakeSleepFs fs;
+  TEST_ASSERT_TRUE(fs.nextSleepBmpByMtimeDesc("").empty());
+  TEST_ASSERT_TRUE(fs.nextSleepBmpByMtimeDesc("whatever.bmp").empty());
+}
+
+// A single wallpaper is the only thing to show: the successor stays on it
+// rather than returning empty, so the fallback never blanks a non-empty folder.
+void test_direct_order_single_file_repeats() {
+  FakeSleepFs fs;
+  fs.seed("only.bmp", 100);
+  TEST_ASSERT_EQUAL_STRING("only.bmp", fs.nextSleepBmpByMtimeDesc("").c_str());
+  TEST_ASSERT_EQUAL_STRING("only.bmp", fs.nextSleepBmpByMtimeDesc("only.bmp").c_str());
+}
+
 }  // namespace
 
 int main(int, char**) {
@@ -529,5 +587,10 @@ int main(int, char**) {
   RUN_TEST(test_truncated_reconcile_stays_dirty_and_converges);
   RUN_TEST(test_reshuffle_bails_before_listing_on_fragmented_heap);
   RUN_TEST(test_trim_branch_rederive_capped_per_pass);
+  RUN_TEST(test_direct_order_successor_follows_mtime_desc_strictly);
+  RUN_TEST(test_direct_order_new_upload_leads_each_lap);
+  RUN_TEST(test_direct_order_mtime_ties_break_by_name);
+  RUN_TEST(test_direct_order_empty_folder_returns_empty);
+  RUN_TEST(test_direct_order_single_file_repeats);
   return UNITY_END();
 }


### PR DESCRIPTION
## Problem

Wallpapers were "not always following the order they should" under memory pressure. The root cause is the wallpaper facade's fallback path: when the ESP32-C3 heap is too fragmented to materialize the order buffer (`sequentialPlaylistAffordable()` returns false, or `advance()` bails on its internal heap probes), `nextSleepFile()` fell back to `pickDirectBasename()`, which picked a **random** file via `::random()` over `/sleep`. So whenever the heap was pressured, the rotation order was abandoned and a random wallpaper showed instead.

## Fix

Make the low-heap fallback follow the **same strict order** as the buffer-backed playlist, while staying O(1)-heap:

- **New primitive `ISleepFs::nextSleepBmpByMtimeDesc(afterName)`** — returns the wallpaper immediately after `afterName` in the playlist's canonical order (modification time **descending** = newest first, then filename ascending as a deterministic tiebreak), wrapping to the front (newest) at lap end. Empty only when `/sleep` is empty.
  - `SdFatSleepFs` overrides it with a streaming two-pass directory scan that never allocates the full listing — safe on the exact heap-pressured path the fallback exists for.
  - The header default impl (materialize + sort) backs the host tests.
- **Facade (`Wallpaper.cpp`)** — `pickDirectBasename` now takes an `after` cursor and returns the ordered successor instead of a random roll. `nextSleepFile` seeds the cursor with the last-shown wallpaper (so the fallback continues the strict sequence from wherever the buffer playlist left off) and advances it on each pick (so a probe-rejected candidate skips forward in order, mirroring the buffer path's `advanceCursor`-on-failure).

"New wallpapers on top" still holds on both paths: a fresh upload has the newest mtime, so it leads the order and re-leads each lap. Anti-repeat is now inherent (the successor is strictly past the last-shown file), replacing the old random re-roll loop.

## Tests

Added host tests in `test_wallpaper_playlist_v2` covering the ordering contract: strict newest-first succession, new-upload-leads-each-lap, equal-mtime tiebreak by name, empty folder, and single-file repeat. The pre-existing playlist tests are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLjnDwcFJksBD1yGoVedUm

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLjnDwcFJksBD1yGoVedUm)_