### PR TITLE
feat(reader): show estimated chapter page length in chapter selector

### DIFF
--- a/docs/reader.md
+++ b/docs/reader.md
@@ -19,7 +19,7 @@ Pressing **OK** while reading opens the menu. Items adapt to context — footnot
 
 | Item | What it does |
 |------|--------------|
-| Select Chapter | Jump to any chapter |
+| Select Chapter | Jump to any chapter; each row shows the chapter's estimated page length (e.g. `12p`) for the current font/settings |
 | Highlight Mode | Enter quote selection |
 | View Quotes | Open saved quotes for this book |
 | Bookmark (Add / Remove) | Toggle bookmark on the current page |

--- a/lib/EpdFont/EpdBinFontLoader.cpp
+++ b/lib/EpdFont/EpdBinFontLoader.cpp
@@ -1,9 +1,9 @@
 #include "EpdBinFontLoader.h"
-#include <Memory.h>
 
 #include <HalStorage.h>
 #include <InflateReader.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <esp_task_wdt.h>
 
 #include <cstdlib>
@@ -178,7 +178,7 @@ bool EpdBinFontLoader::openFromFileExternalBuf(const std::string& path, uint8_t*
   const auto& g0 = groupsPtr[0];
   if (g0.compressedSize > 0 && g0.uncompressedSize > 0 && g0.compressedSize <= hdr.bitmapBlobSize) {
     auto* compressed = static_cast<uint8_t*>(crosspoint::mem::tryMalloc(g0.compressedSize));  // alloc-ok
-    auto* probe = static_cast<uint8_t*>(crosspoint::mem::tryMalloc(g0.uncompressedSize));  // alloc-ok
+    auto* probe = static_cast<uint8_t*>(crosspoint::mem::tryMalloc(g0.uncompressedSize));     // alloc-ok
     if (!compressed || !probe) {
       free(compressed);
       free(probe);

--- a/lib/EpdFont/FontDecompressor.cpp
+++ b/lib/EpdFont/FontDecompressor.cpp
@@ -1,8 +1,8 @@
 #include "FontDecompressor.h"
-#include <Memory.h>
 
 #include <Arduino.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <Utf8.h>
 
 #include <cstdlib>
@@ -358,7 +358,8 @@ int FontDecompressor::prewarmCache(const EpdFontData* fontData, const char* utf8
 
   // Step 3: Allocate page buffer and lookup table for this slot
   slot.buffer = static_cast<uint8_t*>(crosspoint::mem::tryMalloc(totalBytes));  // alloc-ok
-  slot.glyphs = static_cast<PageGlyphEntry*>(crosspoint::mem::tryMalloc(glyphCount * sizeof(PageGlyphEntry)));  // alloc-ok
+  slot.glyphs =
+      static_cast<PageGlyphEntry*>(crosspoint::mem::tryMalloc(glyphCount * sizeof(PageGlyphEntry)));  // alloc-ok
   if (!slot.buffer || !slot.glyphs) {
     LOG_ERR("FDC", "Failed to allocate page buffer (%u bytes, %u glyphs)", totalBytes, glyphCount);
     free(slot.buffer);

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1,11 +1,11 @@
 #include "Epub.h"
-#include <Memory.h>
 
 #include <Arduino.h>
 #include <FsHelpers.h>
 #include <HalStorage.h>
 #include <JpegToBmpConverter.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <PngToBmpConverter.h>
 #include <ZipFile.h>
 #include <esp_heap_caps.h>

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1,9 +1,9 @@
 #include "GfxRenderer.h"
-#include <Memory.h>
 
 #include <FontCacheManager.h>
 #include <FontDecompressor.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <Utf8.h>
 
 GfxRenderer::~GfxRenderer() { freeBwBufferChunks(); }
@@ -646,7 +646,7 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
   // IMPORTANT: Use int, not uint8_t, to avoid overflow for images > 1020 pixels
   // wide
   const int outputRowSize = (bitmap.getWidth() + 3) / 4;
-  auto* outputRow = static_cast<uint8_t*>(crosspoint::mem::tryMalloc(outputRowSize));  // alloc-ok
+  auto* outputRow = static_cast<uint8_t*>(crosspoint::mem::tryMalloc(outputRowSize));        // alloc-ok
   auto* rowBytes = static_cast<uint8_t*>(crosspoint::mem::tryMalloc(bitmap.getRowBytes()));  // alloc-ok
 
   if (!outputRow || !rowBytes) {
@@ -735,7 +735,7 @@ void GfxRenderer::drawBitmap1Bit(const Bitmap& bitmap, const int x, const int y,
   // For 1-bit BMP, output is still 2-bit packed (for consistency with
   // readNextRow)
   const int outputRowSize = (bitmap.getWidth() + 3) / 4;
-  auto* outputRow = static_cast<uint8_t*>(crosspoint::mem::tryMalloc(outputRowSize));  // alloc-ok
+  auto* outputRow = static_cast<uint8_t*>(crosspoint::mem::tryMalloc(outputRowSize));        // alloc-ok
   auto* rowBytes = static_cast<uint8_t*>(crosspoint::mem::tryMalloc(bitmap.getRowBytes()));  // alloc-ok
 
   if (!outputRow || !rowBytes) {

--- a/lib/Memory/Memory.h
+++ b/lib/Memory/Memory.h
@@ -28,8 +28,7 @@
 
 // SFINAE (not a C++20 `requires` clause) so this header compiles on the
 // framework's GCC 8 toolchain, which only partially supports C++20 concepts.
-template <typename T, typename... Args,
-          typename std::enable_if<!std::is_array<T>::value, int>::type = 0>
+template <typename T, typename... Args, typename std::enable_if<!std::is_array<T>::value, int>::type = 0>
 std::unique_ptr<T> makeUniqueNoThrow(Args&&... args) {
   return std::unique_ptr<T>(new (std::nothrow) T(std::forward<Args>(args)...));
 }

--- a/lib/MemoryPolicy/MemoryPolicy.h
+++ b/lib/MemoryPolicy/MemoryPolicy.h
@@ -184,7 +184,7 @@ enum class RecoveryRun : uint8_t {
 // the first probe). Mirrors the fields the old hand-rolled ctx set up.
 struct RecoverySeed {
   bool anchorHeld = false;
-  bool bookOpen = false;     // silent-restart-to-reader needs an open EPUB
+  bool bookOpen = false;      // silent-restart-to-reader needs an open EPUB
   uint8_t restartBudget = 0;  // remainingAutoSilentRestarts() (0..2)
 };
 

--- a/lib/PngToBmpConverter/PngToBmpConverter.cpp
+++ b/lib/PngToBmpConverter/PngToBmpConverter.cpp
@@ -1,8 +1,8 @@
 #include "PngToBmpConverter.h"
-#include <Memory.h>
 
 #include <HalStorage.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <miniz.h>
 
 #include <cstdio>
@@ -201,8 +201,8 @@ struct PngDecodeContext {
   // File read buffer for feeding zlib + palette for indexed color (type 3).
   // Heap-backed (not inline arrays) to keep the struct off the stack — see the
   // allocation in pngFileToBmpStreamInternal.
-  std::unique_ptr<uint8_t[]> readBuf;   // kReadBufSize bytes
-  std::unique_ptr<uint8_t[]> palette;   // kPaletteBytes bytes
+  std::unique_ptr<uint8_t[]> readBuf;  // kReadBufSize bytes
+  std::unique_ptr<uint8_t[]> palette;  // kPaletteBytes bytes
   int paletteSize;
 };
 
@@ -554,7 +554,7 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(FsFile& pngFile, Print& bmpOu
   }
 
   // Allocate scanline buffers
-  ctx.currentRow = static_cast<uint8_t*>(crosspoint::mem::tryMalloc(rawRowBytes));  // alloc-ok
+  ctx.currentRow = static_cast<uint8_t*>(crosspoint::mem::tryMalloc(rawRowBytes));      // alloc-ok
   ctx.previousRow = static_cast<uint8_t*>(crosspoint::mem::tryCalloc(rawRowBytes, 1));  // alloc-ok
   if (!ctx.currentRow || !ctx.previousRow) {
     LOG_ERR("PNG", "Failed to allocate scanline buffers (%u bytes each)", rawRowBytes);

--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -6,10 +6,10 @@
  */
 
 #include "Xtc.h"
-#include <Memory.h>
 
 #include <HalStorage.h>
 #include <Logging.h>
+#include <Memory.h>
 
 #include <new>
 

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -261,8 +261,8 @@ bool ZipFile::loadZipDetails() {
   // We scan the last 1KB (or the whole file if smaller) for the EOCD signature
   // 0x06054b50 is stored as 0x50, 0x4b, 0x05, 0x06 in little-endian
   const int scanRange = fileSize > 1024 ? 1024 : fileSize;
-  const auto buffer = crosspoint::mem::CMallocPtr<uint8_t>(
-      static_cast<uint8_t*>(crosspoint::mem::tryMalloc(scanRange)));
+  const auto buffer =
+      crosspoint::mem::CMallocPtr<uint8_t>(static_cast<uint8_t*>(crosspoint::mem::tryMalloc(scanRange)));
   if (!buffer) {
     LOG_ERR("ZIP", "Failed to allocate memory for EOCD scan buffer");
     if (!wasOpen) {
@@ -466,8 +466,8 @@ uint8_t* ZipFile::readFileToMemory(const char* filename, size_t* size, const boo
   } else if (fileStat.method == MZ_DEFLATED) {
     // Read out deflated content from file. Scope-local: RAII frees it on every
     // exit path, so a future edit cannot orphan the decompression buffer.
-    auto deflatedData = crosspoint::mem::CMallocPtr<uint8_t>(
-        static_cast<uint8_t*>(crosspoint::mem::tryMalloc(deflatedDataSize)));
+    auto deflatedData =
+        crosspoint::mem::CMallocPtr<uint8_t>(static_cast<uint8_t*>(crosspoint::mem::tryMalloc(deflatedDataSize)));
     if (deflatedData == nullptr) {
       LOG_ERR("ZIP", "Failed to allocate memory for decompression buffer");
       free(data);

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -11,7 +11,18 @@ void HalGPIO::update() { inputMgr.update(); }
 
 bool HalGPIO::isPressed(uint8_t buttonIndex) const { return inputMgr.isPressed(buttonIndex); }
 
-bool HalGPIO::isAnyPressed() const { return inputMgr.isAnyPressed(); }
+bool HalGPIO::isAnyPressed() const {
+  // The SDK's InputManager exposes per-button isPressed() plus edge events, but
+  // no single "is any button currently held" query, so OR isPressed() across
+  // every button. This reproduces the level-triggered any-button-held check
+  // main.cpp uses to keep the CPU at full clock while a button is depressed.
+  // isPressed() returns false during input suppression, so this stays
+  // suppression-aware too.
+  for (uint8_t i = BTN_BACK; i <= BTN_POWER; ++i) {
+    if (inputMgr.isPressed(i)) return true;
+  }
+  return false;
+}
 
 bool HalGPIO::wasPressed(uint8_t buttonIndex) const { return inputMgr.wasPressed(buttonIndex); }
 

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -28,7 +28,7 @@ class HalPowerManager {
   // crawled — ADC sampling + the idle-loop tick both ran at 1/24th clock, so a
   // page-turn after any reading pause felt unresponsive. 80 MHz keeps a real
   // power saving (1/3 of the 240 MHz normal freq) while restoring snappy wake.
-  static constexpr int LOW_POWER_FREQ = 80;                   // MHz
+  static constexpr int LOW_POWER_FREQ = 80;                    // MHz
   static constexpr unsigned long IDLE_POWER_SAVING_MS = 3000;  // ms
 
   void begin();

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,7 +2,7 @@
 default_envs = default
 
 [crosspoint]
-version = v5.5.11
+version = v5.5.12
 
 [base]
 platform = espressif32 @ 6.12.0

--- a/src/FontFamilyApply.cpp
+++ b/src/FontFamilyApply.cpp
@@ -66,8 +66,8 @@ FontApplyResult applyFontFamilyByDisplayIndex(std::size_t displayIndex, std::siz
     return {false, false};
   }
 
-  const bool changed = prevFamily != SETTINGS.fontFamily || prevName != SETTINGS.customFontName ||
-                       prevSize != SETTINGS.customFontSizePt;
+  const bool changed =
+      prevFamily != SETTINGS.fontFamily || prevName != SETTINGS.customFontName || prevSize != SETTINGS.customFontSizePt;
   return {true, changed};
 }
 

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -892,24 +892,24 @@ bool JsonSettingsIO::saveWifi(const WifiCredentialStore& store, const char* path
 // widely-included store header, which leaks `using namespace ArduinoJson` and
 // breaks unqualified `detail::` references across the tree). Both friended
 // entry points below expand it.
-#define CROSSPOINT_POPULATE_WIFI(store, doc, needsResave)                                    \
-  do {                                                                                       \
-    (store).lastConnectedSsid = (doc)["lastConnectedSsid"] | std::string("");                \
-    (store).credentials.clear();                                                             \
-    JsonArray arr = (doc)["credentials"].as<JsonArray>();                                    \
-    for (JsonObject obj : arr) {                                                             \
-      if ((store).credentials.size() >= (store).MAX_NETWORKS) break;                         \
-      WifiCredential cred;                                                                   \
-      cred.ssid = obj["ssid"] | std::string("");                                             \
-      bool ok = false;                                                                       \
-      cred.password = obfuscation::deobfuscateFromBase64(obj["password_obf"] | "", &ok);     \
-      if (!ok || cred.password.empty()) {                                                    \
-        cred.password = obj["password"] | std::string("");                                   \
-        if (!cred.password.empty() && (needsResave)) *(needsResave) = true;                  \
-      }                                                                                       \
-      (store).credentials.push_back(cred);                                                   \
-    }                                                                                         \
-    LOG_DBG("WCS", "Loaded %zu WiFi credentials from file", (store).credentials.size());     \
+#define CROSSPOINT_POPULATE_WIFI(store, doc, needsResave)                                \
+  do {                                                                                   \
+    (store).lastConnectedSsid = (doc)["lastConnectedSsid"] | std::string("");            \
+    (store).credentials.clear();                                                         \
+    JsonArray arr = (doc)["credentials"].as<JsonArray>();                                \
+    for (JsonObject obj : arr) {                                                         \
+      if ((store).credentials.size() >= (store).MAX_NETWORKS) break;                     \
+      WifiCredential cred;                                                               \
+      cred.ssid = obj["ssid"] | std::string("");                                         \
+      bool ok = false;                                                                   \
+      cred.password = obfuscation::deobfuscateFromBase64(obj["password_obf"] | "", &ok); \
+      if (!ok || cred.password.empty()) {                                                \
+        cred.password = obj["password"] | std::string("");                               \
+        if (!cred.password.empty() && (needsResave)) *(needsResave) = true;              \
+      }                                                                                  \
+      (store).credentials.push_back(cred);                                               \
+    }                                                                                    \
+    LOG_DBG("WCS", "Loaded %zu WiFi credentials from file", (store).credentials.size()); \
   } while (0)
 
 bool JsonSettingsIO::loadWifi(WifiCredentialStore& store, const char* json, bool* needsResave) {
@@ -976,22 +976,22 @@ bool JsonSettingsIO::saveRecentBooks(const RecentBooksStore& store, const char* 
 
 // Populate from an already-parsed document. Macro, not a shared function, for
 // the same friendship/header reason as the Wifi loader above.
-#define CROSSPOINT_POPULATE_RECENT_BOOKS(store, doc)                                    \
-  do {                                                                                  \
-    (store).recentBooks.clear();                                                        \
-    JsonArray arr = (doc)["books"].as<JsonArray>();                                     \
-    for (JsonObject obj : arr) {                                                        \
-      if ((store).getCount() >= RecentBooksStore::MAX_RECENT_BOOKS) break;              \
-      RecentBook book;                                                                  \
-      book.path = obj["path"] | std::string("");                                        \
-      book.title = obj["title"] | std::string("");                                      \
-      book.author = obj["author"] | std::string("");                                    \
-      book.coverBmpPath = obj["coverBmpPath"] | std::string("");                        \
-      book.boldSwap = (obj["boldSwap"] | (uint8_t)0) != 0 ? 1 : 0;                      \
-      book.percent = static_cast<int8_t>(obj["percent"] | -1);                          \
-      (store).recentBooks.push_back(book);                                              \
-    }                                                                                   \
-    LOG_DBG("RBS", "Recent books loaded from file (%d entries)", (store).getCount());   \
+#define CROSSPOINT_POPULATE_RECENT_BOOKS(store, doc)                                  \
+  do {                                                                                \
+    (store).recentBooks.clear();                                                      \
+    JsonArray arr = (doc)["books"].as<JsonArray>();                                   \
+    for (JsonObject obj : arr) {                                                      \
+      if ((store).getCount() >= RecentBooksStore::MAX_RECENT_BOOKS) break;            \
+      RecentBook book;                                                                \
+      book.path = obj["path"] | std::string("");                                      \
+      book.title = obj["title"] | std::string("");                                    \
+      book.author = obj["author"] | std::string("");                                  \
+      book.coverBmpPath = obj["coverBmpPath"] | std::string("");                      \
+      book.boldSwap = (obj["boldSwap"] | (uint8_t)0) != 0 ? 1 : 0;                    \
+      book.percent = static_cast<int8_t>(obj["percent"] | -1);                        \
+      (store).recentBooks.push_back(book);                                            \
+    }                                                                                 \
+    LOG_DBG("RBS", "Recent books loaded from file (%d entries)", (store).getCount()); \
   } while (0)
 
 bool JsonSettingsIO::loadRecentBooks(RecentBooksStore& store, const char* json) {
@@ -1072,29 +1072,27 @@ bool JsonSettingsIO::saveReadingThemes(const ReadingThemeStore& store, const cha
 // the same friendship/header reason as the loaders above. Note: it can `return
 // false` from the enclosing function on the corruption-guard path (parsed 0
 // themes while some are held in memory), which both entry points below want.
-#define CROSSPOINT_POPULATE_READING_THEMES(store, doc)                                       \
-  do {                                                                                       \
-    /* Parse into a temporary list first — never clear in-memory themes until we know the */ \
-    /* file actually contained data, so a valid-but-empty JSON can't wipe the user's set. */ \
-    std::vector<ReadingTheme> parsed;                                                        \
-    JsonArray arr = (doc)["themes"].as<JsonArray>();                                         \
-    for (JsonObject obj : arr) {                                                             \
-      if (parsed.size() >= ReadingThemeStore::MAX_THEMES) break;                             \
-      ReadingTheme theme;                                                                    \
-      readReadingThemeObject(obj, theme);                                                    \
-      parsed.push_back(theme);                                                               \
-    }                                                                                        \
-    if (parsed.empty() && !(store).themes.empty()) {                                         \
-      LOG_ERR("RTH", "Parsed 0 themes from JSON but %u in memory — rejecting load",          \
-              (unsigned)(store).themes.size());                                              \
-      return false;                                                                          \
-    }                                                                                        \
-    (store).themes = std::move(parsed);                                                      \
-    (store).lastEditedThemeIndex = (doc)["lastEditedThemeIndex"] | -1;                       \
-    if ((store).lastEditedThemeIndex < 0 ||                                                  \
-        (store).lastEditedThemeIndex >= static_cast<int>((store).themes.size())) {           \
-      (store).lastEditedThemeIndex = -1;                                                     \
-    }                                                                                        \
+#define CROSSPOINT_POPULATE_READING_THEMES(store, doc)                                                                 \
+  do {                                                                                                                 \
+    /* Parse into a temporary list first — never clear in-memory themes until we know the */                           \
+    /* file actually contained data, so a valid-but-empty JSON can't wipe the user's set. */                           \
+    std::vector<ReadingTheme> parsed;                                                                                  \
+    JsonArray arr = (doc)["themes"].as<JsonArray>();                                                                   \
+    for (JsonObject obj : arr) {                                                                                       \
+      if (parsed.size() >= ReadingThemeStore::MAX_THEMES) break;                                                       \
+      ReadingTheme theme;                                                                                              \
+      readReadingThemeObject(obj, theme);                                                                              \
+      parsed.push_back(theme);                                                                                         \
+    }                                                                                                                  \
+    if (parsed.empty() && !(store).themes.empty()) {                                                                   \
+      LOG_ERR("RTH", "Parsed 0 themes from JSON but %u in memory — rejecting load", (unsigned)(store).themes.size());  \
+      return false;                                                                                                    \
+    }                                                                                                                  \
+    (store).themes = std::move(parsed);                                                                                \
+    (store).lastEditedThemeIndex = (doc)["lastEditedThemeIndex"] | -1;                                                 \
+    if ((store).lastEditedThemeIndex < 0 || (store).lastEditedThemeIndex >= static_cast<int>((store).themes.size())) { \
+      (store).lastEditedThemeIndex = -1;                                                                               \
+    }                                                                                                                  \
   } while (0)
 
 bool JsonSettingsIO::loadReadingThemes(ReadingThemeStore& store, const char* json) {

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -109,11 +109,10 @@ inline const std::vector<SettingInfo>& getSettingsList() {
                                   {StrId::STR_WSPACING_M30, StrId::STR_WSPACING_0, StrId::STR_WSPACING_P80,
                                    StrId::STR_WSPACING_P150, StrId::STR_WSPACING_P240},
                                   "wordSpacingPercent", StrId::STR_CAT_READER));
-    s.push_back(SettingInfo::Enum(
-        StrId::STR_EXTRA_SPACING, &CrossPointSettings::extraParagraphSpacingLevel,
-        {StrId::STR_NONE_OPT, StrId::STR_PARA_SPACING_17, StrId::STR_PARA_SPACING_25, StrId::STR_PARA_SPACING_33,
-         StrId::STR_PARA_SPACING_42, StrId::STR_PARA_SPACING_50},
-        "extraParagraphSpacingLevel", StrId::STR_CAT_READER));
+    s.push_back(SettingInfo::Enum(StrId::STR_EXTRA_SPACING, &CrossPointSettings::extraParagraphSpacingLevel,
+                                  {StrId::STR_NONE_OPT, StrId::STR_PARA_SPACING_17, StrId::STR_PARA_SPACING_25,
+                                   StrId::STR_PARA_SPACING_33, StrId::STR_PARA_SPACING_42, StrId::STR_PARA_SPACING_50},
+                                  "extraParagraphSpacingLevel", StrId::STR_CAT_READER));
     s.push_back(SettingInfo::Enum(StrId::STR_TEXT_RENDER_MODE, &CrossPointSettings::textRenderMode,
                                   {StrId::STR_RENDER_CRISP, StrId::STR_RENDER_DARK, StrId::STR_RENDER_BIONIC},
                                   "textRenderMode", StrId::STR_CAT_READER));

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -10,11 +10,11 @@
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
 #include "Paths.h"
-#include "network/WifiTeardown.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"
 #include "network/HttpDownloader.h"
+#include "network/WifiTeardown.h"
 #include "util/StringUtils.h"
 #include "util/UrlUtils.h"
 
@@ -371,8 +371,8 @@ void OpdsBookBrowserActivity::launchWifiSelection() {
   state = BrowserState::WIFI_SELECTION;
   requestUpdate();
 
-  enterNewActivity(new (std::nothrow) WifiSelectionActivity(renderer, mappedInput,
-                                             [this](const bool connected) { onWifiSelectionComplete(connected); }));
+  enterNewActivity(new (std::nothrow) WifiSelectionActivity(
+      renderer, mappedInput, [this](const bool connected) { onWifiSelectionComplete(connected); }));
 }
 
 void OpdsBookBrowserActivity::onWifiSelectionComplete(const bool connected) {

--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -240,8 +240,7 @@ void MyLibraryActivity::loadFilesWithLimit() {
       // Check if there are more relevant files in the directory
       for (auto next = root.openNextFile(); next; next = root.openNextFile()) {
         next.getName(name, sizeof(name));
-        const bool skip =
-            (!env_.showHiddenFiles() && name[0] == '.') || strcmp(name, "System Volume Information") == 0;
+        const bool skip = (!env_.showHiddenFiles() && name[0] == '.') || strcmp(name, "System Volume Information") == 0;
         const bool relevant = !skip && (next.isDirectory() || isManagedFile(std::string(name)));
         next.close();
         esp_task_wdt_reset();

--- a/src/activities/network/CalibreConnectActivity.cpp
+++ b/src/activities/network/CalibreConnectActivity.cpp
@@ -10,9 +10,9 @@
 
 #include "MappedInputManager.h"
 #include "WifiSelectionActivity.h"
-#include "network/WifiTeardown.h"
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"
+#include "network/WifiTeardown.h"
 
 namespace {
 constexpr const char* HOSTNAME = "crosspoint-mod-dx34";
@@ -35,8 +35,8 @@ void CalibreConnectActivity::onEnter() {
   exitRequested = false;
 
   if (WiFi.status() != WL_CONNECTED) {
-    enterNewActivity(new (std::nothrow) WifiSelectionActivity(renderer, mappedInput,
-                                               [this](const bool connected) { onWifiSelectionComplete(connected); }));
+    enterNewActivity(new (std::nothrow) WifiSelectionActivity(
+        renderer, mappedInput, [this](const bool connected) { onWifiSelectionComplete(connected); }));
   } else {
     connectedIP = WiFi.localIP().toString().c_str();
     connectedSSID = WiFi.SSID().c_str();

--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -14,11 +14,11 @@
 
 #include "MappedInputManager.h"
 #include "NetworkModeSelectionActivity.h"
-#include "network/WifiTeardown.h"
 #include "WifiSelectionActivity.h"
 #include "activities/network/CalibreConnectActivity.h"
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"
+#include "network/WifiTeardown.h"
 
 namespace {
 // AP Mode configuration
@@ -125,8 +125,8 @@ void CrossPointWebServerActivity::onNetworkModeSelected(const NetworkMode mode) 
 
     state = WebServerActivityState::WIFI_SELECTION;
     LOG_DBG("WEBACT", "Launching WifiSelectionActivity...");
-    enterNewActivity(new (std::nothrow) WifiSelectionActivity(renderer, mappedInput,
-                                               [this](const bool connected) { onWifiSelectionComplete(connected); }));
+    enterNewActivity(new (std::nothrow) WifiSelectionActivity(
+        renderer, mappedInput, [this](const bool connected) { onWifiSelectionComplete(connected); }));
   } else {
     // AP mode - start access point
     state = WebServerActivityState::AP_STARTING;

--- a/src/activities/network/QRShareActivity.cpp
+++ b/src/activities/network/QRShareActivity.cpp
@@ -8,10 +8,10 @@
 #include <esp_task_wdt.h>
 #include <qrcode.h>
 
-#include "network/WifiTeardown.h"
 #include "WifiSelectionActivity.h"
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"
+#include "network/WifiTeardown.h"
 
 namespace {
 
@@ -64,8 +64,8 @@ void QRShareActivity::onEnter() {
     LOG_INF("QRSHARE", "WiFi not connected, launching WiFi selection...");
     WiFi.mode(WIFI_STA);
     state = QRShareState::WIFI_SELECTION;
-    enterNewActivity(new (std::nothrow) WifiSelectionActivity(renderer, mappedInput,
-                                               [this](const bool connected) { onWifiSelectionComplete(connected); }));
+    enterNewActivity(new (std::nothrow) WifiSelectionActivity(
+        renderer, mappedInput, [this](const bool connected) { onWifiSelectionComplete(connected); }));
   }
 }
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1139,6 +1139,8 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       const int spineIdx = currentSpineIndex;
       const int currentTocIndex = section ? section->getTocIndexForPage(section->currentPage)
                                           : resolveCurrentTocIndex(epub, section.get(), currentSpineIndex);
+      // Exact page count of the chapter being read, used to estimate every chapter's length.
+      const int currentSectionPageCount = section ? section->pageCount : 0;
       const std::string path = epub->getPath();
 
       // 1. Close the menu
@@ -1146,7 +1148,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
 
       // 2. Open the Chapter Selector
       enterNewActivity(new (std::nothrow) EpubReaderChapterSelectionActivity(
-          this->renderer, this->mappedInput, epub, path, spineIdx, currentTocIndex,
+          this->renderer, this->mappedInput, epub, path, spineIdx, currentTocIndex, currentSectionPageCount,
           [this] {
             exitActivity();
             requestUpdate();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -432,7 +432,7 @@ bool EpubReaderActivity::heapHeadroomOkForLayout() {
     LOG_DIAG("ERS", "pre-flight gate: triggering silent restart to clear fragmentation");
     self->persistProgressBeforeRestart();
     silentRestartToReader("reader-preflight-frag-recovery");  // does not return
-    return true;  // unreachable
+    return true;                                              // unreachable
   };
 
   return mem::layoutHeapRecovered(seed, acts);
@@ -1131,7 +1131,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       }
       exitActivity();
       enterNewActivity(new (std::nothrow) QuotesViewerActivity(this->renderer, this->mappedInput, quotesPath,
-                                                [this] { pendingSubactivityExit = true; }));
+                                                               [this] { pendingSubactivityExit = true; }));
       break;
     }
     case EpubReaderMenuActivity::MenuAction::SELECT_CHAPTER: {

--- a/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
@@ -16,10 +16,31 @@ constexpr int kButtonHintsReserve = 50;
 
 int EpubReaderChapterSelectionActivity::getTotalItems() const { return epub->getTocItemsCount(); }
 
+int EpubReaderChapterSelectionActivity::estimateChapterPages(int tocIndex) const {
+  if (!epub) return 0;
+  const int spineIndex = epub->getTocItem(tocIndex).spineIndex;
+  if (spineIndex < 0) return 0;
+
+  // The chapter currently being read has an exact, already-paginated count — use it directly.
+  if (spineIndex == currentSpineIndex && currentSectionPageCount > 0) {
+    return currentSectionPageCount;
+  }
+
+  // Otherwise extrapolate from the current chapter's pages-per-byte ratio. This mirrors the
+  // status bar's book-page-counter estimate: approximate by design (image/code-heavy chapters
+  // have a different density than prose) but avoids laying out every chapter on open.
+  if (pagesPerByte <= 0.0f) return 0;
+  const size_t prevSize = (spineIndex >= 1) ? epub->getCumulativeSpineItemSize(spineIndex - 1) : 0;
+  const size_t chapterSize = epub->getCumulativeSpineItemSize(spineIndex) - prevSize;
+  if (chapterSize == 0) return 0;
+  return std::max(1, static_cast<int>(pagesPerByte * static_cast<float>(chapterSize) + 0.5f));
+}
+
 int EpubReaderChapterSelectionActivity::getItemLineCount(int itemIndex, int maxTextWidth) const {
   const auto item = epub->getTocItem(itemIndex);
   const int indentSize = 20 + (item.level - 1) * 15;
-  const int textWidth = maxTextWidth - 40 - indentSize;
+  const int countReserve = (pagesPerByte > 0.0f) ? kPageCountReserve : 0;
+  const int textWidth = maxTextWidth - 40 - indentSize - countReserve;
   if (textWidth <= 0) return 1;
   const auto lines = ReaderLayoutSafety::wrapText(renderer, UI_10_FONT_ID, item.title, textWidth);
   return std::max(1, static_cast<int>(lines.size()));
@@ -62,6 +83,18 @@ void EpubReaderChapterSelectionActivity::onEnter() {
     selectorIndex = 0;
   }
   resolvedCurrentTocIndex = selectorIndex;
+
+  // Derive the pages-per-byte ratio from the chapter currently being read so we can estimate
+  // the page length of the other chapters at the active font/settings.
+  pagesPerByte = 0.0f;
+  if (currentSectionPageCount > 0) {
+    const size_t prevSize =
+        (currentSpineIndex >= 1) ? epub->getCumulativeSpineItemSize(currentSpineIndex - 1) : 0;
+    const size_t curSize = epub->getCumulativeSpineItemSize(currentSpineIndex) - prevSize;
+    if (curSize > 0) {
+      pagesPerByte = static_cast<float>(currentSectionPageCount) / static_cast<float>(curSize);
+    }
+  }
 
   lastNavReleaseMs = 0;
   lastNavDirection = 0;
@@ -184,7 +217,8 @@ void EpubReaderChapterSelectionActivity::render(Activity::RenderLock&&) {
   for (int itemIndex = pageStartIndex; itemIndex < totalItems; itemIndex++) {
     const auto item = epub->getTocItem(itemIndex);
     const int indentSize = contentX + 20 + (item.level - 1) * 15;
-    const int textWidth = maxTextWidth - 40 - indentSize;
+    const int countReserve = (pagesPerByte > 0.0f) ? kPageCountReserve : 0;
+    const int textWidth = maxTextWidth - 40 - indentSize - countReserve;
 
     std::vector<std::string> lines;
     if (textWidth > 0) {
@@ -229,6 +263,22 @@ void EpubReaderChapterSelectionActivity::render(Activity::RenderLock&&) {
     } else {
       for (int l = 0; l < static_cast<int>(lines.size()); l++) {
         renderer.drawText(UI_10_FONT_ID, indentSize, currentY + l * kLineHeight, lines[l].c_str(), !isSelected);
+      }
+    }
+
+    // Right-aligned chapter length badge (estimated pages at the active font/settings).
+    if (countReserve > 0) {
+      const int pages = estimateChapterPages(itemIndex);
+      if (pages > 0) {
+        const std::string badge = std::to_string(pages) + "p";
+        const int badgeWidth = renderer.getTextWidth(UI_10_FONT_ID, badge.c_str());
+        const int badgeX = contentX + contentWidth - 6 - badgeWidth;
+        // Match the title: dark text normally, light when the row is selected (inverted),
+        // and bold (double-draw) for the current chapter to mirror its emphasized title.
+        renderer.drawText(UI_10_FONT_ID, badgeX, currentY, badge.c_str(), !isSelected);
+        if (isCurrent && !isSelected) {
+          renderer.drawText(UI_10_FONT_ID, badgeX + 1, currentY, badge.c_str(), true);
+        }
       }
     }
 

--- a/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
@@ -88,8 +88,7 @@ void EpubReaderChapterSelectionActivity::onEnter() {
   // the page length of the other chapters at the active font/settings.
   pagesPerByte = 0.0f;
   if (currentSectionPageCount > 0) {
-    const size_t prevSize =
-        (currentSpineIndex >= 1) ? epub->getCumulativeSpineItemSize(currentSpineIndex - 1) : 0;
+    const size_t prevSize = (currentSpineIndex >= 1) ? epub->getCumulativeSpineItemSize(currentSpineIndex - 1) : 0;
     const size_t curSize = epub->getCumulativeSpineItemSize(currentSpineIndex) - prevSize;
     if (curSize > 0) {
       pagesPerByte = static_cast<float>(currentSectionPageCount) / static_cast<float>(curSize);

--- a/src/activities/reader/EpubReaderChapterSelectionActivity.h
+++ b/src/activities/reader/EpubReaderChapterSelectionActivity.h
@@ -13,8 +13,13 @@ class EpubReaderChapterSelectionActivity final : public ActivityWithSubactivity 
   ButtonNavigator buttonNavigator;
   int currentSpineIndex = 0;
   int currentTocIndex = 0;
+  int currentSectionPageCount = 0;  // Exact page count of the chapter currently being read (0 if unknown)
   int selectorIndex = 0;
   int resolvedCurrentTocIndex = 0;  // Resolved reading position in TOC, preserved during navigation
+
+  // Pages-per-byte ratio derived from the current chapter's layout, used to estimate the
+  // page length of every chapter at the active font/settings. <= 0 means "cannot estimate".
+  float pagesPerByte = 0.0f;
 
   // Double-tap Up/Down detection (jump to current chapter)
   unsigned long lastNavReleaseMs = 0;
@@ -26,6 +31,13 @@ class EpubReaderChapterSelectionActivity final : public ActivityWithSubactivity 
 
   static constexpr int kLineHeight = 30;
   static constexpr unsigned long kDoubleTapMs = 350;
+  // Width reserved on the right of each row for the chapter page-count badge.
+  static constexpr int kPageCountReserve = 52;
+
+  // Estimate the page length of the chapter at `tocIndex` for the active font/settings.
+  // Returns the exact count for the chapter currently being read, an extrapolated estimate
+  // for the others, or 0 when no estimate is possible.
+  int estimateChapterPages(int tocIndex) const;
 
   // Compute wrapped line count for a single TOC item given available width.
   int getItemLineCount(int itemIndex, int maxTextWidth) const;
@@ -41,6 +53,7 @@ class EpubReaderChapterSelectionActivity final : public ActivityWithSubactivity 
   explicit EpubReaderChapterSelectionActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
                                               const std::shared_ptr<Epub>& epub, const std::string& epubPath,
                                               const int currentSpineIndex, const int currentTocIndex,
+                                              const int currentSectionPageCount,
                                               const std::function<void()>& onGoBack,
                                               const std::function<void(int tocIndex)>& onSelectTocIndex,
                                               const std::function<void(int newSpineIndex, int newPage)>& onSyncPosition)
@@ -49,6 +62,7 @@ class EpubReaderChapterSelectionActivity final : public ActivityWithSubactivity 
         epubPath(epubPath),
         currentSpineIndex(currentSpineIndex),
         currentTocIndex(currentTocIndex),
+        currentSectionPageCount(currentSectionPageCount),
         onGoBack(onGoBack),
         onSelectTocIndex(onSelectTocIndex),
         onSyncPosition(onSyncPosition) {}

--- a/src/activities/reader/EpubReaderChapterSelectionActivity.h
+++ b/src/activities/reader/EpubReaderChapterSelectionActivity.h
@@ -53,8 +53,7 @@ class EpubReaderChapterSelectionActivity final : public ActivityWithSubactivity 
   explicit EpubReaderChapterSelectionActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
                                               const std::shared_ptr<Epub>& epub, const std::string& epubPath,
                                               const int currentSpineIndex, const int currentTocIndex,
-                                              const int currentSectionPageCount,
-                                              const std::function<void()>& onGoBack,
+                                              const int currentSectionPageCount, const std::function<void()>& onGoBack,
                                               const std::function<void(int tocIndex)>& onSelectTocIndex,
                                               const std::function<void(int newSpineIndex, int newPage)>& onSyncPosition)
       : ActivityWithSubactivity("EpubReaderChapterSelection", renderer, mappedInput),

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -9,10 +9,10 @@
 #include "KOReaderCredentialStore.h"
 #include "KOReaderDocumentId.h"
 #include "MappedInputManager.h"
-#include "network/WifiTeardown.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"
+#include "network/WifiTeardown.h"
 
 namespace {
 void syncTimeWithNTP() {
@@ -221,8 +221,8 @@ void KOReaderSyncActivity::onEnter() {
 
   // Launch WiFi selection subactivity
   LOG_DBG("KOSync", "Launching WifiSelectionActivity...");
-  enterNewActivity(new (std::nothrow) WifiSelectionActivity(renderer, mappedInput,
-                                             [this](const bool connected) { onWifiSelectionComplete(connected); }));
+  enterNewActivity(new (std::nothrow) WifiSelectionActivity(
+      renderer, mappedInput, [this](const bool connected) { onWifiSelectionComplete(connected); }));
 }
 
 void KOReaderSyncActivity::onExit() {

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -198,8 +198,8 @@ void ReaderActivity::openBookPath(const std::string& bookPath) {
 
   if (isQuotesFile(bookPath)) {
     exitActivity();
-    enterNewActivity(
-        new (std::nothrow) QuotesViewerActivity(renderer, mappedInput, bookPath, [this, bookPath] { goToLibrary(bookPath); }));
+    enterNewActivity(new (std::nothrow) QuotesViewerActivity(renderer, mappedInput, bookPath,
+                                                             [this, bookPath] { goToLibrary(bookPath); }));
     return;
   }
 

--- a/src/activities/reader/ReaderSettingsActivity.cpp
+++ b/src/activities/reader/ReaderSettingsActivity.cpp
@@ -304,10 +304,10 @@ void ReaderSettingsActivity::buildSettingsList() {
   pushReader(ReaderSettingInfo::Enum(StrId::STR_WORD_SPACING, &CrossPointSettings::wordSpacingPercent,
                                      {StrId::STR_WSPACING_M30, StrId::STR_WSPACING_0, StrId::STR_WSPACING_P80,
                                       StrId::STR_WSPACING_P150, StrId::STR_WSPACING_P240}));
-  pushReader(ReaderSettingInfo::Enum(
-      StrId::STR_EXTRA_SPACING, &CrossPointSettings::extraParagraphSpacingLevel,
-      {StrId::STR_NONE_OPT, StrId::STR_PARA_SPACING_17, StrId::STR_PARA_SPACING_25, StrId::STR_PARA_SPACING_33,
-       StrId::STR_PARA_SPACING_42, StrId::STR_PARA_SPACING_50}));
+  pushReader(
+      ReaderSettingInfo::Enum(StrId::STR_EXTRA_SPACING, &CrossPointSettings::extraParagraphSpacingLevel,
+                              {StrId::STR_NONE_OPT, StrId::STR_PARA_SPACING_17, StrId::STR_PARA_SPACING_25,
+                               StrId::STR_PARA_SPACING_33, StrId::STR_PARA_SPACING_42, StrId::STR_PARA_SPACING_50}));
   pushReader(ReaderSettingInfo::Enum(StrId::STR_TEXT_RENDER_MODE, &CrossPointSettings::textRenderMode,
                                      {StrId::STR_RENDER_CRISP, StrId::STR_RENDER_DARK, StrId::STR_RENDER_BIONIC}));
   if (!txt) {
@@ -545,8 +545,8 @@ void ReaderSettingsActivity::loop() {
     // Tap: +-1. A quick second tap (within kValueEditDoubleTapMs) jumps +-10.
     buttonNavigator.onNextRelease([this] {
       const unsigned long now = millis();
-      adjustValueEdit(+crosspoint::settings::valueEditTapStep(lastValueUpTapMs, now,
-                                                              crosspoint::settings::kValueEditDoubleTapMs));
+      adjustValueEdit(
+          +crosspoint::settings::valueEditTapStep(lastValueUpTapMs, now, crosspoint::settings::kValueEditDoubleTapMs));
       lastValueUpTapMs = now;
       requestUpdate();
     });
@@ -854,7 +854,7 @@ void ReaderSettingsActivity::render(Activity::RenderLock&&) {
     rowYOffset += thisRowHeight;
   }
 
-  const char* confirmLabel = fontPicker.isOpen() ? tr(STR_SELECT)
+  const char* confirmLabel = fontPicker.isOpen()                   ? tr(STR_SELECT)
                              : (valueEditMode || fontSizeEditMode) ? tr(STR_CONFIRM)
                                                                    : tr(STR_TOGGLE);
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), confirmLabel, tr(STR_DIR_UP), tr(STR_DIR_DOWN));

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -271,15 +271,15 @@ void TxtReaderActivity::drawFlowLine(const FlowLine& line, const int x, const in
 void TxtReaderActivity::openReadingThemes() {
   flushProgressIfNeeded(true);
   exitActivity();
-  enterNewActivity(new (std::nothrow) ReadingThemesActivity(renderer, mappedInput, txt ? txt->getCachePath() : std::string(),
-                                             [this](const bool changed) {
-                                               pendingSubactivityExit = true;
-                                               if (changed) {
-                                                 reloadCurrentLayoutForDisplaySettings();
-                                               } else {
-                                                 requestUpdate();
-                                               }
-                                             }));
+  enterNewActivity(new (std::nothrow) ReadingThemesActivity(
+      renderer, mappedInput, txt ? txt->getCachePath() : std::string(), [this](const bool changed) {
+        pendingSubactivityExit = true;
+        if (changed) {
+          reloadCurrentLayoutForDisplaySettings();
+        } else {
+          requestUpdate();
+        }
+      }));
 }
 
 void TxtReaderActivity::reloadCurrentLayoutForDisplaySettings() {

--- a/src/activities/settings/FontFamilyPicker.cpp
+++ b/src/activities/settings/FontFamilyPicker.cpp
@@ -69,10 +69,10 @@ void FontFamilyPicker::render(GfxRenderer& renderer, int pageWidth, int pageHeig
   const int rowFont = UI_10_FONT_ID;
   const char* title = tr(STR_FONT_FAMILY);
 
-  constexpr int kPad = 16;       // padding inside the popup frame
-  constexpr int kRowPadV = 4;    // vertical padding inside each row
-  constexpr int kTitleH = 18;    // reserved height for the title line
-  constexpr int kTitleGap = 8;   // gap between title and first row
+  constexpr int kPad = 16;      // padding inside the popup frame
+  constexpr int kRowPadV = 4;   // vertical padding inside each row
+  constexpr int kTitleH = 18;   // reserved height for the title line
+  constexpr int kTitleGap = 8;  // gap between title and first row
   constexpr int kScreenInset = 20;
   constexpr int kVerticalInset = 40;
 

--- a/src/activities/settings/KOReaderAuthActivity.cpp
+++ b/src/activities/settings/KOReaderAuthActivity.cpp
@@ -7,10 +7,10 @@
 #include "KOReaderCredentialStore.h"
 #include "KOReaderSyncClient.h"
 #include "MappedInputManager.h"
-#include "network/WifiTeardown.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/themes/BaseTheme.h"
 #include "fontIds.h"
+#include "network/WifiTeardown.h"
 
 void KOReaderAuthActivity::onWifiSelectionComplete(const bool success) {
   exitActivity();
@@ -80,8 +80,8 @@ void KOReaderAuthActivity::onEnter() {
   }
 
   // Launch WiFi selection
-  enterNewActivity(new (std::nothrow) WifiSelectionActivity(renderer, mappedInput,
-                                             [this](const bool connected) { onWifiSelectionComplete(connected); }));
+  enterNewActivity(new (std::nothrow) WifiSelectionActivity(
+      renderer, mappedInput, [this](const bool connected) { onWifiSelectionComplete(connected); }));
 }
 
 void KOReaderAuthActivity::onExit() {

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -14,11 +14,11 @@
 #include "CrossPointState.h"
 #include "CustomFontsSettingsActivity.h"
 #include "FontFamilyApply.h"
-#include "ValueEditStep.h"
 #include "KOReaderSettingsActivity.h"
 #include "MappedInputManager.h"
 #include "OtaUpdateActivity.h"
 #include "SettingsList.h"
+#include "ValueEditStep.h"
 #include "activities/boot_sleep/SleepActivity.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "activities/util/FullScreenMessageActivity.h"
@@ -983,7 +983,7 @@ void SettingsActivity::render(Activity::RenderLock&&) {
   }
 
   // Draw help text
-  const char* confirmLabel = fontPicker.isOpen() ? tr(STR_SELECT)
+  const char* confirmLabel = fontPicker.isOpen()                   ? tr(STR_SELECT)
                              : (fontSizeEditMode || valueEditMode) ? tr(STR_CONFIRM)
                                                                    : tr(STR_TOGGLE);
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), confirmLabel, tr(STR_DIR_UP), tr(STR_DIR_DOWN));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -376,7 +376,8 @@ static void openReaderInline(const std::string& initialEpubPath) {
   // including the in-reader recent-switcher that bypasses this function. Drawing
   // it here too would just FAST_REFRESH the same popup twice.
   exitActivity();
-  enterNewActivity(new (std::nothrow) ReaderActivity(renderer, mappedInputManager, bookPath, onGoHome, onGoToMyLibraryWithPath));
+  enterNewActivity(new (std::nothrow)
+                       ReaderActivity(renderer, mappedInputManager, bookPath, onGoHome, onGoToMyLibraryWithPath));
 }
 
 void onGoToReader(const std::string& initialEpubPath) {
@@ -435,7 +436,8 @@ static void openHomeInline() {
   TransitionFeedback::resetStacking();
   TransitionFeedback::show(renderer, tr(STR_LOADING_HOME));
   exitActivity();
-  enterNewActivity(new (std::nothrow) HomeActivity(renderer, mappedInputManager, onGoToReader, onGoToMyLibrary, onGoToRecentBooks,
+  enterNewActivity(new (std::nothrow)
+                       HomeActivity(renderer, mappedInputManager, onGoToReader, onGoToMyLibrary, onGoToRecentBooks,
                                     onGoToSettings, onGoToFileTransfer, onGoToBrowser));
 }
 
@@ -682,8 +684,8 @@ void setup() {
     LOG_ERR("MAIN", "SD card initialization failed");
     setupDisplayAndFonts();
     exitActivity();
-    enterNewActivity(
-        new (std::nothrow) FullScreenMessageActivity(renderer, mappedInputManager, "SD card error", EpdFontFamily::REGULAR));
+    enterNewActivity(new (std::nothrow) FullScreenMessageActivity(renderer, mappedInputManager, "SD card error",
+                                                                  EpdFontFamily::REGULAR));
     return;
   }
 
@@ -961,8 +963,8 @@ void loop() {
     // loop task has ever had. A small/shrinking value warns of a stack-overflow
     // reset before it happens; logged alongside heap so both are visible.
     const unsigned loopStackFreeBytes = uxTaskGetStackHighWaterMark(nullptr) * sizeof(StackType_t);
-    LOG_INF("MEM", "Free: %d bytes, Total: %d bytes, Min Free: %d bytes, Loop stack free: %u bytes",
-            ESP.getFreeHeap(), ESP.getHeapSize(), ESP.getMinFreeHeap(), loopStackFreeBytes);
+    LOG_INF("MEM", "Free: %d bytes, Total: %d bytes, Min Free: %d bytes, Loop stack free: %u bytes", ESP.getFreeHeap(),
+            ESP.getHeapSize(), ESP.getMinFreeHeap(), loopStackFreeBytes);
     lastMemPrint = millis();
   }
 

--- a/src/network/WifiTeardown.h
+++ b/src/network/WifiTeardown.h
@@ -31,9 +31,7 @@ enum class WifiRestartTarget {
 // non-coalescing LWIP/netif scatter (see SilentRestart.h).
 //
 // Does NOT return when `wifiWasUp` is true.
-void teardownAndReclaim(bool wifiWasUp,
-                        WifiRestartTarget target = WifiRestartTarget::Home,
-                        const char* reason = "wifi-exit",
-                        bool apMode = false);
+void teardownAndReclaim(bool wifiWasUp, WifiRestartTarget target = WifiRestartTarget::Home,
+                        const char* reason = "wifi-exit", bool apMode = false);
 
 }  // namespace net

--- a/src/sleep/Wallpaper.cpp
+++ b/src/sleep/Wallpaper.cpp
@@ -152,8 +152,7 @@ bool sequentialPlaylistAffordable() {
   // std::string copy (~3x buffer) plus the entry vector and its per-name strings.
   const size_t totalNeed = bufferBytes * 3 + entryVecBytes * 2 + kSeqGateHeadroom;
 
-  return crosspoint::heap::largestFreeBlockBytes() >= contigNeed &&
-         crosspoint::mem::totalFreeBytes() >= totalNeed;
+  return crosspoint::heap::largestFreeBlockBytes() >= contigNeed && crosspoint::mem::totalFreeBytes() >= totalNeed;
 }
 
 // Streaming fragment-safe pick — touches O(1) heap beyond the returned

--- a/src/sleep/Wallpaper.cpp
+++ b/src/sleep/Wallpaper.cpp
@@ -156,28 +156,22 @@ bool sequentialPlaylistAffordable() {
          crosspoint::mem::totalFreeBytes() >= totalNeed;
 }
 
-// Streaming fragment-safe pick — direct mirror of SleepActivity's
-// pickSleepFileDirect helper. Touches O(1) heap beyond the returned
+// Streaming fragment-safe pick — touches O(1) heap beyond the returned
 // basename. Empty if /sleep is empty or fs not wired.
-std::string pickDirectBasename() {
+//
+// Sequential, NOT random: returns the lexicographically next .bmp/.pxc after
+// `after`, wrapping to the lex-min file at the end of the folder. This mirrors
+// the buffer playlist's strict no-repeat rotation. The previous implementation
+// rolled a random index with only single-file anti-repeat, which — on the small
+// libraries common in /sleep, and on the C3 where tight sleep-entry heap routes
+// here often — produced the "same wallpapers too frequently / no order" symptom:
+// a random pick that merely dodges the one last-shown file still revisits the
+// rest constantly and follows no order at all. nextSleepBmpAfter is a streaming
+// directory scan (no list materialized), so it stays safe at any folder size.
+std::string pickDirectBasename(const std::string& after) {
   auto* sfs = v2::WallpaperPlaylistV2::instance().deps().fs;
   if (!sfs) return {};
-  const size_t count = sfs->countSleepBmps(kSleepFolderCap);
-  if (count == 0) return {};
-  // Anti-repeat: this random last-resort has no playlist cursor, so a naive
-  // single roll can return the wallpaper we just showed (a 1/N chance —
-  // glaring on small libraries). Re-roll a few times to avoid the last-shown
-  // basename. With >1 file this converges almost immediately; with exactly
-  // one file we accept it (nothing else to show). lastShownSleepFilename and
-  // nthSleepBmp both deal in basenames, so the comparison is apples-to-apples.
-  const std::string& lastShown = APP_STATE.lastShownSleepFilename;
-  std::string pick;
-  for (int tries = 0; tries < 5; ++tries) {
-    const size_t idx = static_cast<size_t>(::random(static_cast<long>(count)));
-    pick = sfs->nthSleepBmp(idx);
-    if (count <= 1 || pick.empty() || pick != lastShown) break;
-  }
-  return pick;
+  return sfs->nextSleepBmpAfter(after);
 }
 
 SleepPick makePickFromBasename(const std::string& basename) {
@@ -222,10 +216,17 @@ SleepPick nextSleepFile(const RenderProbe& probe) {
   // entry at a time and never builds a list, so it is safe at any folder size.
   const bool useDirectPick = !sequentialPlaylistAffordable();
 
+  // Direct-pick walks the folder sequentially from the last-shown file. Track a
+  // local cursor so that if a candidate fails to render, the next retry advances
+  // PAST it (mirroring the buffer playlist's advanceCursor-on-reject) instead of
+  // re-picking the same broken file every attempt.
+  std::string directCursor = APP_STATE.lastShownSleepFilename;
+
   for (int attempt = 0; attempt < kNextSleepFileRetries; ++attempt) {
     std::string basename;
     if (useDirectPick) {
-      basename = pickDirectBasename();
+      basename = pickDirectBasename(directCursor);
+      directCursor = basename;
     } else {
       // Buffer-backed playlist advance via the facade entry point, so the
       // RFC #145 reconcile notice is drained + persisted here too (a direct
@@ -233,7 +234,8 @@ SleepPick nextSleepFile(const RenderProbe& probe) {
       // empty under its internal heap probes — fall through to the direct pick.
       basename = advance();
       if (basename.empty()) {
-        basename = pickDirectBasename();
+        basename = pickDirectBasename(directCursor);
+        directCursor = basename;
       }
     }
     if (basename.empty()) {

--- a/src/sleep/WallpaperPlaylistV2.cpp
+++ b/src/sleep/WallpaperPlaylistV2.cpp
@@ -336,8 +336,7 @@ void WallpaperPlaylistV2::reconcile() {
   // for a contiguous block first; if it won't fit, skip trim this cycle (the
   // over-cap files simply wait in /sleep) and still splice any new files the
   // cheap streaming walk already found. A later wake retries once heap allows.
-  if (diskCount > kSleepFolderCap &&
-      heapHasContiguous((kSleepFolderCap + 64) * sizeof(SleepBmpEntry))) {
+  if (diskCount > kSleepFolderCap && heapHasContiguous((kSleepFolderCap + 64) * sizeof(SleepBmpEntry))) {
     std::vector<SleepBmpEntry> all = deps_.fs->listSleepBmpsWithMtime(kSleepFolderCap + 64);
     // If the listing itself hit its cap, files beyond it were never seen —
     // stay dirty so a later reconcile finishes the job.

--- a/test/test_memory_policy/test_main.cpp
+++ b/test/test_memory_policy/test_main.cpp
@@ -150,8 +150,8 @@ struct LoopFake {
   int anchorCalls = 0;
   int maxCalls = 0;
   int restartCalls = 0;
-  size_t afterAnchor = 0;  // largest the heap "reveals" after releaseAnchor
-  size_t afterMax = 0;     // largest after releaseMaxResources
+  size_t afterAnchor = 0;        // largest the heap "reveals" after releaseAnchor
+  size_t afterMax = 0;           // largest after releaseMaxResources
   bool restartTriggers = false;  // trySilentRestart return (false = budget lost)
 };
 size_t loopFakeAnchor(void* p) {


### PR DESCRIPTION
## What

Adds a per-chapter page-length badge to the **Select Chapter** screen. Each visible row now shows, right-aligned, how many pages that chapter spans at the **current font size / settings** (e.g. `12p`) — the chapter-list analog of the reader status bar's "X left" counter.

| Before | After |
|--------|-------|
| Title only | Title + `12p` page-length badge on the right |

## How

- The reader passes the currently-read chapter's exact `section->pageCount` into `EpubReaderChapterSelectionActivity`.
- `onEnter` derives a **pages-per-byte** ratio from that chapter (its page count ÷ its byte size).
- `estimateChapterPages(tocIndex)`:
  - returns the **exact** count for the chapter currently being read;
  - **extrapolates** every other chapter from the pages-per-byte ratio × that chapter's spine byte size.
- This mirrors the existing status-bar **book-page-counter** estimation, so we get good estimates without laying out every chapter on open (which would be slow on-device).
- Title wrap width now reserves space for the badge so long titles don't overlap it; the badge matches the row's text styling (inverted when selected, bold for the current chapter).

## Notes / limitations

- Counts are **estimates** (the same approximation the book-page-counter already uses): chapters that are image- or code-heavy have a different density than prose, so the numbers can drift. The chapter you're reading is always exact.
- If the current chapter's page count isn't known yet (`0`), no badges are shown and titles use the full width — graceful fallback.
- Scope is the **EPUB** chapter selector (the screen in the request). The XTC reader has a separate selector that was left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nughoPpSnEaE4JfNXVWes

---
_Generated by [Claude Code](https://claude.ai/code/session_016nughoPpSnEaE4JfNXVWes)_